### PR TITLE
clients/js: fix envelope format

### DIFF
--- a/clients/js/test/cipher.spec.ts
+++ b/clients/js/test/cipher.spec.ts
@@ -27,7 +27,7 @@ describe('Plain', () => {
 
     const envelope = await cipher.encryptEnvelope(DATA);
     expect(envelope).toBeDefined();
-    expect({ format: 0, body: DATA }).toMatchObject(envelope!);
+    expect({ body: cbor.encode({ body: DATA }) }).toMatchObject(envelope!);
     expect(await cipher.encryptEnvelope()).not.toBeDefined();
 
     expect(await cipher.encryptEncode(DATA)).toEqual(
@@ -79,14 +79,13 @@ describe('X25519DeoxysII', () => {
     expect(envelope.format).toEqual(1);
     if (!('nonce' in envelope.body)) throw new Error('unenveloped body');
     expect(envelope.body.pk).toEqual(cipher.publicKey);
+    const resData = await cipher.encrypt(cbor.encode({ ok: DATA }));
     expect(
       await cipher.decryptCallResult({
-        unknown: hexlify(
-          cbor.encode({
-            nonce: envelope.body.nonce,
-            data: envelope.body.data,
-          }),
-        ),
+        unknown: {
+          nonce: resData.nonce,
+          data: resData.ciphertext,
+        },
       }),
     ).toEqual(DATA);
   });

--- a/clients/js/test/compat.spec.ts
+++ b/clients/js/test/compat.spec.ts
@@ -43,12 +43,10 @@ class MockProvider {
       if (method === 'eth_call') {
         return ethers.utils.hexlify(
           cbor.encode({
-            unknown: ethers.utils.hexlify(
-              cbor.encode({
-                nonce: MockCipher.NONCE,
-                data: new Uint8Array([0x11, 0x23, 0x58]),
-              }),
-            ),
+            unknown: {
+              nonce: MockCipher.NONCE,
+              data: cbor.encode({ ok: new Uint8Array([0x11, 0x23, 0x58]) }),
+            },
           }),
         );
       }
@@ -141,7 +139,7 @@ describe('ethers signer', () => {
     const txData = cbor.decode(ethers.utils.arrayify(tx.data));
     expect(txData.format).toEqual(cipher.kind);
     expect(ethers.utils.hexlify(txData.body.data)).toEqual(
-      ethers.utils.hexlify(data),
+      ethers.utils.hexlify(cbor.encode({ body: data })),
     );
   });
 

--- a/clients/js/test/utils.ts
+++ b/clients/js/test/utils.ts
@@ -17,9 +17,13 @@ export async function verifySignedCall(
   const { domain, types } = signedCallEIP712Params(CHAIN_ID);
   const dataPack = cbor.decode(ethers.utils.arrayify(call.data!));
   const body = dataPack?.data?.body;
-  const origData = cipher
-    ? await cipher.decrypt(body?.nonce, body?.data ?? body)
-    : body;
+  let origData: Uint8Array;
+  if (cipher) {
+    const envelopeBytes = await cipher.decrypt(body?.nonce, body?.data ?? body);
+    origData = cbor.decode(envelopeBytes).body;
+  } else {
+    origData = body;
+  }
   const recoveredSender = ethers.utils.verifyTypedData(
     domain,
     types,


### PR DESCRIPTION
This PR fixes some discrepancies between the client envelope format and the actual runtime format (mainly around cbor encoding).