### PR TITLE
clients/js: fix types

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oasisprotocol/sapphire-paratime",
   "license": "Apache-2.0",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The Sapphire ParaTime Web3 integration library.",
   "repository": "https://github.com/oasisprotocol/sapphire-paratime",
   "keywords": [

--- a/clients/js/src/cipher.ts
+++ b/clients/js/src/cipher.ts
@@ -283,13 +283,11 @@ export async function fetchRuntimePublicKey(
   const res = await (fetchImpl
     ? fetchRuntimePublicKeyBrowser(gatewayUrl, fetchImpl)
     : fetchRuntimePublicKeyNode(gatewayUrl));
-  return arrayify(res.key);
+  return arrayify(res.result.key);
 }
 
 type CallDataPublicKeyResponse = {
-  key: string;
-  checksum: string;
-  signature: string;
+  result: { key: string; checksum: string; signature: string };
 };
 
 async function fetchRuntimePublicKeyNode(

--- a/clients/js/src/compat.ts
+++ b/clients/js/src/compat.ts
@@ -406,6 +406,9 @@ class EnvelopeError extends Error {}
  *
  * If the upstream provider is Web3-like, then use that, as the user has chosen then gateway.
  * Otherwise, fetch the key from the default Web3 gateway for the particular chain ID.
+ *
+ * Note: MetaMask does not support Web3 methods it doesn't know about, so we have to
+ * fall back to manually querying the default gateway.
  */
 async function inferRuntimePublicKeySource(
   upstream: UpstreamProvider,
@@ -413,7 +416,7 @@ async function inferRuntimePublicKeySource(
   const isSigner = isEthersSigner(upstream);
   if (isSigner || isEthersProvider(upstream)) {
     const provider = isSigner ? upstream.provider : upstream;
-    if (isJsonRpcProvider(provider)) {
+    if (isJsonRpcProvider(provider) && !(upstream as any).isMetaMask) {
       return {
         send: (method, params) => provider.send(method, params),
       };

--- a/clients/js/src/compat.ts
+++ b/clients/js/src/compat.ts
@@ -62,8 +62,8 @@ export interface Web3ReqArgs {
 }
 
 const WRAPPED_MARKER = '_isSapphireWrapped';
-/** If a gas limit is not provided, the runtime will produce a very confusing error message, so we set a default limit (currently set to the one found in the Eth docs). */
-const DEFAULT_GAS = 90_000;
+/** If a gas limit is not provided, the runtime will produce a very confusing error message, so we set a default limit. This one is very high, but solves the problem. This should be lowered once error messages are better or gas estimation is enabled. */
+const DEFAULT_GAS = 1_000_000;
 
 /**
  * Wraps an upstream ethers/web3/EIP-1193 provider to speak the Sapphire format.

--- a/clients/js/src/signed_calls.ts
+++ b/clients/js/src/signed_calls.ts
@@ -1,6 +1,6 @@
-import { BlockTag } from '@ethersproject/abstract-provider';
+import { BlockTag, Provider } from '@ethersproject/abstract-provider';
 import {
-  Signer,
+  Signer as EthersSigner,
   TypedDataDomain,
   TypedDataField,
   TypedDataSigner,
@@ -21,6 +21,12 @@ const DEFAULT_GAS_LIMIT = 30_000_000;
 const DEFAULT_VALUE = 0;
 const DEFAULT_DATA = '0x';
 const zeroAddress = () => `0x${'0'.repeat(40)}`;
+
+export type Signer = Pick<EthersSigner, 'getTransactionCount' | 'getChainId'> &
+  TypedDataSigner & {
+    provider?: Pick<Provider, 'getBlock'>;
+    _checkProvider?: EthersSigner['_checkProvider'];
+  };
 
 export function signedCallEIP712Params(chainId: number): {
   domain: TypedDataDomain;
@@ -117,7 +123,7 @@ async function makeLeash(
   if (overrides?.block !== undefined) {
     blockP = overrides.block;
   } else {
-    signer._checkProvider('getBlock');
+    if (signer._checkProvider) signer._checkProvider('getBlock');
     const latestBlock = await signer.provider!.getBlock('latest');
     blockP = signer.provider!.getBlock(latestBlock.number - 1); // The latest block is not historical.
   }

--- a/clients/js/test/cipher.spec.ts
+++ b/clients/js/test/cipher.spec.ts
@@ -123,8 +123,10 @@ describe('fetchRuntimePublicKey', () => {
         return true;
       })
       .reply(200, {
-        key: `0x${Buffer.from(publicKey).toString('hex')}`,
-        // TODO: checksum and signature
+        result: {
+          key: `0x${Buffer.from(publicKey).toString('hex')}`,
+          // TODO: checksum and signature
+        },
       });
 
     expect(await fetchRuntimePublicKey(pointer, opts));

--- a/clients/js/test/cipher.spec.ts
+++ b/clients/js/test/cipher.spec.ts
@@ -27,7 +27,7 @@ describe('Plain', () => {
 
     const envelope = await cipher.encryptEnvelope(DATA);
     expect(envelope).toBeDefined();
-    expect({ body: cbor.encode({ body: DATA }) }).toMatchObject(envelope!);
+    expect({ body: DATA }).toMatchObject(envelope!);
     expect(await cipher.encryptEnvelope()).not.toBeDefined();
 
     expect(await cipher.encryptEncode(DATA)).toEqual(

--- a/clients/js/test/compat.spec.ts
+++ b/clients/js/test/compat.spec.ts
@@ -167,7 +167,7 @@ describe('ethers provider', () => {
     expect((wrapped as any)._isSapphireWrapped).toBe(true);
   });
 
-  it('call/estimateGas', async () => {
+  it('unsigned call/estimateGas', async () => {
     const callRequest = { to, data };
     const response = await wrapped.call(callRequest);
     expect(response).toEqual('0x112358');
@@ -305,7 +305,7 @@ function runTestBattery(
     expect(wrapped.provider!.sendTransaction(raw)).rejects.toThrow(/bogus/i);
   });
 
-  it('call/estimateGas', async () => {
+  it('signed call/estimateGas', async () => {
     const from = await wrapped.getAddress();
     const callRequest = {
       from,

--- a/clients/js/test/compat.spec.ts
+++ b/clients/js/test/compat.spec.ts
@@ -119,7 +119,7 @@ describe('ethers signer', () => {
       '0x11e244400Cf165ade687077984F09c3A037b868F',
     );
     expect(await wrapped.getAddress()).toEqual(wrapped.address);
-    expect((wrapped as any)._isSapphireWrapped).toBe(true);
+    expect((wrapped as any).sapphire).toMatchObject({ cipher });
   });
 
   it('sendRawTransaction un-enveloped', async () => {
@@ -164,7 +164,7 @@ describe('ethers provider', () => {
 
   it('proxy', async () => {
     expect(wrapped._isProvider).toBe(true);
-    expect((wrapped as any)._isSapphireWrapped).toBe(true);
+    expect((wrapped as any).sapphire).toMatchObject({ cipher });
   });
 
   it('unsigned call/estimateGas', async () => {
@@ -193,7 +193,7 @@ describe('window.ethereum', () => {
     const wrapped = wrap(new MockEIP1193Provider(), cipher);
     expect(wrapped.isMetaMask).toBe(false);
     expect(wrapped.isConnected()).toBe(false);
-    expect((wrapped as any)._isSapphireWrapped).toBe(true);
+    expect((wrapped as any).sapphire).toMatchObject({ cipher });
   });
 
   runTestBattery(() => {
@@ -216,7 +216,7 @@ describe('legacy MetaMask', () => {
     const wrapped = wrap(new MockLegacyProvider(), cipher);
     expect(wrapped.isMetaMask).toBe(false);
     expect(wrapped.isConnected()).toBe(false);
-    expect((wrapped as any)._isSapphireWrapped).toBe(true);
+    expect((wrapped as any).sapphire).toMatchObject({ cipher });
   });
 
   runTestBattery(() => {


### PR DESCRIPTION
This PR:
* increases compatibility of this library with versions of ethers by limiting the required props to just those used by this library
* changes `inferRuntimePublicKeySource` to always use `chainId`, as MetaMask does not call web3 methods it does not know about
* fixes the `Plain` cipher body encoding, which somehow escaped notice.