### PR TITLE
Fix repo link in package.json

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -3,7 +3,11 @@
   "license": "Apache-2.0",
   "version": "1.0.3",
   "description": "The Sapphire ParaTime Web3 integration library.",
-  "repository": "https://github.com/oasisprotocol/sapphire-paratime",
+  "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/clients/js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oasisprotocol/sapphire-paratime.git"
+  },
   "keywords": [
     "sapphire",
     "paratime",


### PR DESCRIPTION
https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime doesn't link back to repo. It probably wants different link format: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository