### PR TITLE
Use cross-fetch instead of node:https

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -52,7 +52,8 @@
     "deoxysii": "^0.0.2",
     "js-sha512": "^0.8.0",
     "tweetnacl": "^1.0.3",
-    "type-fest": "^2.19.0"
+    "type-fest": "^2.19.0",
+    "cross-fetch": "^3.1.5"
   },
   "devDependencies": {
     "@types/jest": "^28.1.8",


### PR DESCRIPTION
This simplifies bundler setup as it doesn't require to set aliases oasisprotocol/sapphire-paratime#56