### PR TITLE
clients/js: always infer rt pub key from chainId

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@oasisprotocol/sapphire-paratime",
   "license": "Apache-2.0",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "The Sapphire ParaTime Web3 integration library.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/clients/js",
   "repository": {

--- a/clients/js/src/compat.ts
+++ b/clients/js/src/compat.ts
@@ -492,10 +492,6 @@ class EnvelopeError extends Error {}
 /**
  * Picks the most user-trusted runtime calldata public key source based on what
  * connections are available.
- *
- * If the upstream provider is Web3-like, then use that, as the user has chosen then gateway.
- * Otherwise, fetch the key from the default Web3 gateway for the particular chain ID.
- *
  * Note: MetaMask does not support Web3 methods it doesn't know about, so we have to
  * fall back to manually querying the default gateway.
  */
@@ -504,12 +500,6 @@ async function inferRuntimePublicKeySource(
 ): Promise<Parameters<typeof fetchRuntimePublicKey>[0]> {
   const isSigner = isEthersSigner(upstream);
   if (isSigner || isEthersProvider(upstream)) {
-    const provider = isSigner ? upstream.provider : upstream;
-    if (isJsonRpcProvider(provider) && !(upstream as any).isMetaMask) {
-      return {
-        send: (method, params) => provider.send(method, params),
-      };
-    }
     return {
       chainId: isSigner
         ? await upstream.getChainId()


### PR DESCRIPTION
This PR works around an issue where wrapping an Ethers provider that in turn wraps Metamask prevents the library from detecting Metamask and falling back to fetching the runtime public key from the default gateway chosen by the `chainId` (Metamask does not like the custom `oasis_callDataPublicKey` RPC).