### PR TITLE
Fixing broken extension when working on mixed chains (e.g. localhost and sapphire)

### DIFF
--- a/integrations/hardhat/index.js
+++ b/integrations/hardhat/index.js
@@ -5,7 +5,9 @@ extendEnvironment((hre) => {
   const { chainId, url: rpcUrl } = hre.network.config;
   if (chainId) {
     if (!sapphire.NETWORKS[chainId]) return;
-  } else if (/sapphire/i.test(rpcUrl)) {
+  } else {
+    if (!/sapphire/i.test(rpcUrl)) return;
+
     console.warn(
       'The Hardhat config for the network with `url`',
       rpcUrl,

--- a/integrations/hardhat/package.json
+++ b/integrations/hardhat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oasisprotocol/sapphire-hardhat",
   "license": "Apache-2.0",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Hardhat plugin for developing on the Sapphire ParaTime.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/hardhat",
   "repository": {


### PR DESCRIPTION
When working with mixed environments (e.g. basic local hardhat node with `--network localhost` and sapphire) the extension breaks as it tries to wrap the local provider:

```bash
$ yarn hardhat run scripts/deploy.ts --network localhost
yarn run v1.22.19
warning package.json: No license field
$ /Users/***/Documents/Work/[***/hardhat/node_modules/.bin/hardhat](http://***/hardhat/node_modules/.bin/hardhat) run scripts/deploy.ts --network localhost
TypeError: Cannot destructure property 'defaultGateway' of 'index_js_1.NETWORKS[chainId]' as it is undefined.
    at /Users/***/Documents/Work/[***/hardhat/node_modules/@oasisprotocol/sapphire-paratime/src/cipher.ts:276:24](http://***/hardhat/node_modules/@oasisprotocol/sapphire-paratime/src/cipher.ts:276:24)
    at Generator.next (<anonymous>)
    at /Users/***/Documents/Work/[***/hardhat/node_modules/@oasisprotocol/sapphire-paratime/lib/cjs/cipher.cjs:31:71](http://***/hardhat/node_modules/@oasisprotocol/sapphire-paratime/lib/cjs/cipher.cjs:31:71)
    at new Promise (<anonymous>)
    at __awaiter (/Users/***/Documents/Work/[***/hardhat/node_modules/@oasisprotocol/sapphire-paratime/lib/cjs/cipher.cjs:27:12](http://***/hardhat/node_modules/@oasisprotocol/sapphire-paratime/lib/cjs/cipher.cjs:27:12))
    at fetchRuntimePublicKey (/Users/***/Documents/Work/[***/hardhat/node_modules/@oasisprotocol/sapphire-paratime/lib/cjs/cipher.cjs:241:12](http://***/hardhat/node_modules/@oasisprotocol/sapphire-paratime/lib/cjs/cipher.cjs:241:12))
    at /Users/***/Documents/Work/[***/hardhat/node_modules/@oasisprotocol/sapphire-paratime/src/compat.ts:231:49](http://***/hardhat/node_modules/@oasisprotocol/sapphire-paratime/src/compat.ts:231:49)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/***/Documents/Work/[***/hardhat/node_modules/@oasisprotocol/sapphire-paratime/lib/cjs/compat.cjs:28:58](http://***/hardhat/node_modules/@oasisprotocol/sapphire-paratime/lib/cjs/compat.cjs:28:58))
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

My suggestion is to early-return when the following conditions are met:
1. the chain id is `undefined`
2. the RPC url doesn't include `sapphire`