### PR TITLE
clients/js: only generate lazy cipher once

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@oasisprotocol/sapphire-paratime",
   "license": "Apache-2.0",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "The Sapphire ParaTime Web3 integration library.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/clients/js",
   "repository": {


### PR DESCRIPTION
Initializing the cipher wasn't sufficiently one-time. This PR fixes that and also #73. @pro-wh warned about this, but the fix wasn't good enough.