### PR TITLE
runtime: Add OASIS_UNSAFE_USE_LOCALNET_CHAINID env flag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,13 +26,13 @@ jobs:
           binaries: sapphire-paratime
           clean: no
           setup: |
-            export OASIS_UNSAFE_SKIP_AVR_VERIFY=1 OASIS_UNSAFE_SKIP_KM_POLICY=1 OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1
+            export OASIS_UNSAFE_SKIP_AVR_VERIFY=1 OASIS_UNSAFE_SKIP_KM_POLICY=1 OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1 OASIS_UNSAFE_USE_LOCALNET_CHAINID=1
 
       - name: Create the debug Oasis Runtime Container
         run: |
           go install github.com/oasisprotocol/oasis-sdk/tools/orc@latest
           pushd runtime
-          orc init ${RUNTIME_EXECUTABLE} --output ../insecure-debug-sapphire-paratime.orc
+          orc init ${RUNTIME_EXECUTABLE} --output ../localnet-sapphire-paratime.orc
           popd
         env:
           RUNTIME_EXECUTABLE: ${{ github.workspace }}/${{ steps.build-debug-elf.outputs.build-path }}/sapphire-paratime
@@ -71,5 +71,5 @@ jobs:
         with:
           # Create a draft since the release requires an offline signing process.
           draft: true
-          artifacts: sapphire-paratime.orc,insecure-debug-sapphire-paratime.orc
+          artifacts: sapphire-paratime.orc,localnet-sapphire-paratime.orc
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -22,11 +22,19 @@ const testnetParams = {
   runtimeId:
     '0x000000000000000000000000000000000000000000000000a6d1e3ebf60dff6c',
 };
+const localnetParams = {
+  chainId: 0x5afd,
+  defaultGateway: 'http://localhost:8545/',
+  runtimeId:
+    '0x8000000000000000000000000000000000000000000000000000000000000000',
+};
 export const NETWORKS = {
   mainnet: mainnetParams,
   testnet: testnetParams,
+  localnet: localnetParams,
   [mainnetParams.chainId]: mainnetParams,
   [testnetParams.chainId]: testnetParams,
+  [localnetParams.chainId]: localnetParams,
 };
 
 export const OASIS_CALL_DATA_PUBLIC_KEY = 'oasis_callDataPublicKey';

--- a/examples/hardhat-boilerplate/README.md
+++ b/examples/hardhat-boilerplate/README.md
@@ -20,7 +20,7 @@ https://faucet.testnet.oasis.dev/ and request some.
 Next, run this to deploy your contract on Sapphire Testnet:
 
 ```sh
-PRIVATE_KEY=your_sapphire_private_key_in_hex npx hardhat run scripts/deploy.js --network sapphire
+PRIVATE_KEY=your_sapphire_private_key_in_hex npx hardhat run scripts/deploy.js --network sapphire_testnet
 ```
 
 Finally, run the frontend with:

--- a/examples/hardhat-boilerplate/frontend/src/components/Dapp.js
+++ b/examples/hardhat-boilerplate/frontend/src/components/Dapp.js
@@ -23,7 +23,9 @@ import { NoTokensMessage } from "./NoTokensMessage";
 // This is the Hardhat Network id that we set in our hardhat.config.js.
 // Here's a list of network ids https://docs.metamask.io/guide/ethereum-provider.html#properties
 // to use when deploying to other networks.
-const HARDHAT_NETWORK_ID = '23295'; // Sapphire
+//const HARDHAT_NETWORK_ID = '23294'; // Sapphire Mainnet
+const HARDHAT_NETWORK_ID = '23295'; // Sapphire Testnet
+//const HARDHAT_NETWORK_ID = '23293'; // Sapphire Localnet
 
 // This is an error code that indicates that the user canceled a transaction
 const ERROR_CODE_TX_REJECTED_BY_USER = 4001;
@@ -368,7 +370,7 @@ export class Dapp extends React.Component {
     }
 
     this.setState({
-      networkError: 'Please connect to Sapphire ParaTime Testnet'
+      networkError: 'Please connect to Sapphire Testnet'
     });
 
     return false;

--- a/examples/hardhat-boilerplate/hardhat.config.js
+++ b/examples/hardhat-boilerplate/hardhat.config.js
@@ -13,12 +13,26 @@ module.exports = {
     hardhat: {
       chainId: 1337 // We set 1337 to make interacting with MetaMask simpler
     },
-    sapphire: {
+    sapphire_mainnet: {
+      url: "https://sapphire.oasis.io",
+      accounts: process.env.PRIVATE_KEY
+        ? [process.env.PRIVATE_KEY]
+        : [],
+      chainId: 0x5afe,
+    },
+    sapphire_testnet: {
       url: "https://testnet.sapphire.oasis.dev",
       accounts: process.env.PRIVATE_KEY
         ? [process.env.PRIVATE_KEY]
         : [],
       chainId: 0x5aff,
+    },
+    sapphire_localnet: {
+      url: "http://localhost:8545",
+      accounts: process.env.PRIVATE_KEY
+        ? [process.env.PRIVATE_KEY]
+        : [],
+      chainId: 0x5afd,
     },
   }
 };

--- a/examples/hardhat/hardhat.config.ts
+++ b/examples/hardhat/hardhat.config.ts
@@ -16,12 +16,26 @@ const config: HardhatUserConfig = {
     },
   },
   networks: {
-    'sapphire': {
+    'sapphire_mainnet': {
+      url: 'https://sapphire.oasis.io',
+      accounts: process.env.PRIVATE_KEY
+        ? [process.env.PRIVATE_KEY]
+        : [],
+      chainId: 0x5afe
+    },
+    'sapphire_testnet': {
       url: 'https://testnet.sapphire.oasis.dev',
       accounts: process.env.PRIVATE_KEY
         ? [process.env.PRIVATE_KEY]
         : [],
       chainId: 0x5aff
+    },
+    'sapphire_localnet': {
+      url: 'http://localhost:8545',
+      accounts: process.env.PRIVATE_KEY
+        ? [process.env.PRIVATE_KEY]
+        : [],
+      chainId: 0x5afd
     },
   },
   watcher: {

--- a/examples/truffle/truffle-config.js
+++ b/examples/truffle/truffle-config.js
@@ -54,7 +54,15 @@ module.exports = {
     //   network_id: 5,       // Goerli's id
     //   chain_id: 5
     // }
-    emerald: {
+    emerald_mainnet: {
+      provider: () =>
+        new HDWalletProvider(
+          [process.env.PRIVATE_KEY],
+          "https://emerald.oasis.dev"
+        ),
+      network_id: 0xa516,
+    },
+    emerald_testnet: {
       provider: () =>
         new HDWalletProvider(
           [process.env.PRIVATE_KEY],
@@ -62,7 +70,25 @@ module.exports = {
         ),
       network_id: 0xa515,
     },
-    sapphire: {
+    emerald_localnet: {
+      provider: () =>
+        new HDWalletProvider(
+          [process.env.PRIVATE_KEY],
+          "http://localhost:8545"
+        ),
+      network_id: 0xa514,
+    },
+    sapphire_mainnet: {
+      provider: () =>
+        sapphire.wrap(
+          new HDWalletProvider(
+            [process.env.PRIVATE_KEY],
+            "https://sapphire.oasis.io"
+          )
+        ),
+      network_id: 0x5afe,
+    },
+    sapphire_testnet: {
       provider: () =>
         sapphire.wrap(
           new HDWalletProvider(
@@ -71,6 +97,16 @@ module.exports = {
           )
         ),
       network_id: 0x5aff,
+    },
+    sapphire_localnet: {
+      provider: () =>
+        sapphire.wrap(
+          new HDWalletProvider(
+            [process.env.PRIVATE_KEY],
+            "http://localhost:8545"
+          )
+        ),
+      network_id: 0x5afd,
     },
   },
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -26,9 +26,12 @@ const fn is_testnet() -> bool {
     !env!("CARGO_PKG_VERSION_PRE").is_empty()
 }
 
-/// Determine EVM chain ID to use depending on whether the build is for Testnet or Mainnet.
+/// Determine EVM chain ID to use depending on whether the build is for Localnet, Testnet or Mainnet.
 const fn chain_id() -> u64 {
-    if is_testnet() {
+    if option_env!("OASIS_UNSAFE_USE_LOCALNET_CHAINID").is_some() {
+        // Localnet.
+        0x5afd
+    } else if is_testnet() {
         // Testnet.
         0x5aff
     } else {


### PR DESCRIPTION
Introduction of another *localnet* chain ID `0x5afd` if `OASIS_UNSAFE_USE_LOCALNET_CHAIN` env variable is set targeted at dApp devs for testing on the local stack. The PR sets this variable for debug-insecure builds on CI and renames the orc file to `localnet-sapphire-paratime.orc`.

Related: https://github.com/oasisprotocol/oasis-web3-gateway/pull/348, https://github.com/oasisprotocol/emerald-paratime/pull/27