### PR TITLE
runtime: Bump Oasis SDK to 45367837bc74540253c8a943cd982583f698be3f

### DIFF
--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
 dependencies = [
  "proc-macro2 1.0.50",
  "quote 1.0.23",
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
+checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
+checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -748,15 +748,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
+checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
+checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
 dependencies = [
  "proc-macro2 1.0.50",
  "quote 1.0.23",
@@ -1333,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
 
 [[package]]
 name = "glob"
@@ -1595,8 +1595,8 @@ dependencies = [
 
 [[package]]
 name = "keymanager"
-version = "0.3.2"
-source = "git+https://github.com/oasisprotocol/keymanager-paratime?tag=v0.3.2#261fb372cd29f4e5b996c1bd5ff734e162301cbe"
+version = "0.3.3-testnet"
+source = "git+https://github.com/oasisprotocol/keymanager-paratime?tag=v0.3.3-testnet#e87ee96f30f5695dbbebab986217f299e29bd686"
 dependencies = [
  "oasis-core-keymanager",
  "oasis-core-runtime",
@@ -1835,7 +1835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
  "num-bigint 0.4.3",
- "num-complex 0.4.2",
+ "num-complex 0.4.3",
  "num-integer",
  "num-iter",
  "num-rational 0.4.1",
@@ -1893,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
 ]
@@ -2022,7 +2022,7 @@ checksum = "5fe0d7f5a7c55eba7e8e845046c6c81332f4fa4997f0ed497b9f44db1d7f2050"
 [[package]]
 name = "oasis-core-keymanager"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v22.2.3#3d338936cd34e72a2662fa91d8e1aeb2ccf8d6d3"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v22.2.5#d0255ae47b429fc8809bf29d5202ba9af94bfc36"
 dependencies = [
  "anyhow",
  "base64",
@@ -2046,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "oasis-core-runtime"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v22.2.3#3d338936cd34e72a2662fa91d8e1aeb2ccf8d6d3"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v22.2.5#d0255ae47b429fc8809bf29d5202ba9af94bfc36"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2105,7 +2105,7 @@ dependencies = [
 [[package]]
 name = "oasis-runtime-sdk"
 version = "0.1.0"
-source = "git+https://github.com/oasisprotocol/oasis-sdk?rev=c43daf9d09c0d2c98c7bd6bf83294ced1db62a5c#c43daf9d09c0d2c98c7bd6bf83294ced1db62a5c"
+source = "git+https://github.com/oasisprotocol/oasis-sdk?rev=45367837bc74540253c8a943cd982583f698be3f#45367837bc74540253c8a943cd982583f698be3f"
 dependencies = [
  "anyhow",
  "base64",
@@ -2141,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "oasis-runtime-sdk-evm"
 version = "0.1.0"
-source = "git+https://github.com/oasisprotocol/oasis-sdk?rev=c43daf9d09c0d2c98c7bd6bf83294ced1db62a5c#c43daf9d09c0d2c98c7bd6bf83294ced1db62a5c"
+source = "git+https://github.com/oasisprotocol/oasis-sdk?rev=45367837bc74540253c8a943cd982583f698be3f#45367837bc74540253c8a943cd982583f698be3f"
 dependencies = [
  "anyhow",
  "base64",
@@ -2171,7 +2171,7 @@ dependencies = [
 [[package]]
 name = "oasis-runtime-sdk-macros"
 version = "0.1.0"
-source = "git+https://github.com/oasisprotocol/oasis-sdk?rev=c43daf9d09c0d2c98c7bd6bf83294ced1db62a5c#c43daf9d09c0d2c98c7bd6bf83294ced1db62a5c"
+source = "git+https://github.com/oasisprotocol/oasis-sdk?rev=45367837bc74540253c8a943cd982583f698be3f#45367837bc74540253c8a943cd982583f698be3f"
 dependencies = [
  "darling",
  "proc-macro2 1.0.50",
@@ -2181,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.2"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8c786513eb403643f2a88c244c2aaa270ef2153f55094587d0c48a3cf22a83"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
 ]
@@ -2221,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.2.1"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366e44391a8af4cfd6002ef6ba072bae071a96aafca98d7d448a34c5dca38b6a"
+checksum = "e7ab01d0f889e957861bc65888d5ccbe82c158d0270136ba46820d43837cdf72"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2235,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
+checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.50",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-paratime"
-version = "0.3.0"
+version = "0.3.1-testnet"
 dependencies = [
  "keymanager",
  "oasis-runtime-sdk",
@@ -3396,9 +3396,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3411,7 +3411,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3427,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -3464,9 +3464,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapphire-paratime"
-version = "0.3.0"
+version = "0.3.1-testnet"
 authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -12,15 +12,17 @@ runtime-id = "000000000000000000000000000000000000000000000000f80306c9858e7279"
 runtime-id = "000000000000000000000000000000000000000000000000a6d1e3ebf60dff6c"
 
 [package.metadata.fortanix-sgx]
-heap-size = 134217728
+heap-size = 268435456 # 256 MiB
 stack-size = 2097152
 threads = 6
 debug = false
 
 [dependencies]
-keymanager = { git = "https://github.com/oasisprotocol/keymanager-paratime", tag = "v0.3.2" }
-module-evm = { git = "https://github.com/oasisprotocol/oasis-sdk", rev = "c43daf9d09c0d2c98c7bd6bf83294ced1db62a5c", package = "oasis-runtime-sdk-evm" }
-oasis-runtime-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", rev = "c43daf9d09c0d2c98c7bd6bf83294ced1db62a5c" }
+keymanager = { git = "https://github.com/oasisprotocol/keymanager-paratime", tag = "v0.3.3-testnet" }
+
+# SDK.
+module-evm = { git = "https://github.com/oasisprotocol/oasis-sdk", rev = "45367837bc74540253c8a943cd982583f698be3f", package = "oasis-runtime-sdk-evm" }
+oasis-runtime-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", rev = "45367837bc74540253c8a943cd982583f698be3f" }
 
 # Third party.
 once_cell = "1.8.0"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -113,8 +113,8 @@ impl sdk::Runtime for Runtime {
         if is_testnet() {
             // Testnet.
             Some(TrustRoot {
-                height: 13033591,
-                hash: "fd99b786d9958ede6d37bdcd55c7cbc0f60f54cd8f84e27d06be3888674737aa".into(),
+                height: 13670553,
+                hash: "7e0e12dcdaa9e8a83e27799c03c873a0a2fc720bcef044992578a936ac7da2a2".into(),
                 runtime_id: "000000000000000000000000000000000000000000000000a6d1e3ebf60dff6c"
                     .into(),
                 chain_context: "50304f98ddb656620ea817cc1446c401752a05a249b36c9b90dba4616829977a"


### PR DESCRIPTION
This bumps Oasis Core to 22.2.5, increases the heap size to 256 MiB and updates the Testnet trust root.