### PR TITLE
Decode encrypted Ok and plain Fail

### DIFF
--- a/clients/go/cipher_test.go
+++ b/clients/go/cipher_test.go
@@ -150,7 +150,16 @@ func TestDeoxysIICipher(t *testing.T) {
 		t.Fatalf("decrypt failed: %v", err)
 	}
 
-	data, err := cipher.DecryptCallResult(decrypted)
+	data, err := cipher.DecryptCallResult(decrypted) // A plaintext `OK` gets returned.
+	if err != nil {
+		t.Fatalf("call result parsing failed: %v", err)
+	}
+
+	if string(data) != string(TestData) {
+		t.Fatalf("decrypt failed: %v", decrypted)
+	}
+
+	data, err = cipher.DecryptCallResult(encrypted) // An encrypted `OK` gets decrypted, decoded, then returned.
 	if err != nil {
 		t.Fatalf("call result parsing failed: %v", err)
 	}

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@oasisprotocol/sapphire-paratime",
   "license": "Apache-2.0",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "The Sapphire ParaTime Web3 integration library.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/clients/js",
   "repository": {

--- a/clients/js/test/cipher.spec.ts
+++ b/clients/js/test/cipher.spec.ts
@@ -100,8 +100,21 @@ describe('X25519DeoxysII', () => {
 
   it('encryptCallResult', async () => {
     const cipher = X25519DeoxysII.ephemeral(nacl.box.keyPair().publicKey);
-    const res = await cipher.encryptCallResult({ ok: DATA });
+    let res = await cipher.encryptCallResult({ ok: DATA });
     expect(await cipher.decryptCallResult(cbor.decode(res))).toEqual(DATA);
+
+    res = await cipher.encryptCallResult(
+      { ok: DATA },
+      true /* report unknown */,
+    );
+    expect(await cipher.decryptCallResult(cbor.decode(res))).toEqual(DATA);
+
+    res = await cipher.encryptCallResult({
+      fail: { module: 'test', code: -1, message: 'out of gas' },
+    });
+    await expect(cipher.decryptCallResult(cbor.decode(res))).rejects.toThrow(
+      'out of gas',
+    );
   });
 });
 


### PR DESCRIPTION
v0.5.0 introduced a change wherein the success or failure of the call is exposed: `Ok(Encrypt(Ok(result)))` and `Err(error)`. This PR adds decoding of encrypted `Ok`s to the client libraries.