### PR TITLE
runtime: Bump Oasis SDK to 0.6.0 and prepare 0.5.2-testnet

### DIFF
--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-paratime"
-version = "0.5.1-testnet"
+version = "0.5.2-testnet"
 dependencies = [
  "keymanager",
  "oasis-runtime-sdk",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -2106,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "oasis-runtime-sdk"
 version = "0.5.0"
-source = "git+https://github.com/oasisprotocol/oasis-sdk?tag=runtime-sdk/v0.5.0#cd7ea90268c754dd672f7c1b95a4e337be66ef86"
+source = "git+https://github.com/oasisprotocol/oasis-sdk?tag=runtime-sdk/v0.6.0#ca293cbb21480929ae6ab71808e2cdd9565ede2b"
 dependencies = [
  "anyhow",
  "base64",
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "oasis-runtime-sdk-evm"
 version = "0.4.0"
-source = "git+https://github.com/oasisprotocol/oasis-sdk?tag=runtime-sdk/v0.5.0#cd7ea90268c754dd672f7c1b95a4e337be66ef86"
+source = "git+https://github.com/oasisprotocol/oasis-sdk?tag=runtime-sdk/v0.6.0#ca293cbb21480929ae6ab71808e2cdd9565ede2b"
 dependencies = [
  "anyhow",
  "base64",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "oasis-runtime-sdk-macros"
 version = "0.3.0"
-source = "git+https://github.com/oasisprotocol/oasis-sdk?tag=runtime-sdk/v0.5.0#cd7ea90268c754dd672f7c1b95a4e337be66ef86"
+source = "git+https://github.com/oasisprotocol/oasis-sdk?tag=runtime-sdk/v0.6.0#ca293cbb21480929ae6ab71808e2cdd9565ede2b"
 dependencies = [
  "darling",
  "proc-macro2 1.0.56",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,8 +21,8 @@ debug = false
 keymanager = { git = "https://github.com/oasisprotocol/keymanager-paratime", tag = "v0.3.3-testnet" }
 
 # SDK.
-module-evm = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "runtime-sdk/v0.5.0", package = "oasis-runtime-sdk-evm" }
-oasis-runtime-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "runtime-sdk/v0.5.0" }
+module-evm = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "runtime-sdk/v0.6.0", package = "oasis-runtime-sdk-evm" }
+oasis-runtime-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "runtime-sdk/v0.6.0" }
 
 # Third party.
 once_cell = "1.8.0"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapphire-paratime"
-version = "0.5.1-testnet"
+version = "0.5.2-testnet"
 authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -50,8 +50,9 @@ impl modules::core::Config for Config {
     const MIN_GAS_PRICE_EXEMPT_METHODS: Lazy<BTreeSet<&'static str>> =
         Lazy::new(|| ["consensus.Deposit"].into());
 
-    /// Default local estimate gas amount to be added to failed transaction simulations.
-    const DEFAULT_LOCAL_ESTIMATE_GAS_EXTRA_FAIL: u64 = 5_000_000;
+    /// Estimated gas amount to be added to failed transaction simulations for selected methods.
+    const ESTIMATE_GAS_EXTRA_FAIL: Lazy<BTreeMap<&'static str, u64>> =
+        Lazy::new(|| [("evm.Create", 5_000_000), ("evm.Call", 5_000_000)].into());
 }
 
 impl module_evm::Config for Config {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -122,8 +122,8 @@ impl sdk::Runtime for Runtime {
         if is_testnet() {
             // Testnet.
             Some(TrustRoot {
-                height: 14975369,
-                hash: "3c6dd897249e9c84b210e6b81071bd9da89610eebf403bb047aa69aa9a657a95".into(),
+                height: 15413160,
+                hash: "766a9e90c395e8b0355a5a5364d6d444a8c7288d6685d83287b61b9d0fb33308".into(),
                 runtime_id: "000000000000000000000000000000000000000000000000a6d1e3ebf60dff6c"
                     .into(),
                 chain_context: "50304f98ddb656620ea817cc1446c401752a05a249b36c9b90dba4616829977a"


### PR DESCRIPTION
This release contains a fix for a gas overestimation issue introduced in 0.5.1-testnet.