### PR TITLE
randomBytes: Revert with error if precompile not found

### DIFF
--- a/contracts/contracts/Sapphire.sol
+++ b/contracts/contracts/Sapphire.sol
@@ -23,6 +23,8 @@ library Sapphire {
     address private constant CURVE25519_PUBLIC_KEY =
         0x0100000000000000000000000000000000000008;
 
+    error Precompile_Not_Present();
+
     type Curve25519PublicKey is bytes32;
     type Curve25519SecretKey is bytes32;
 
@@ -61,6 +63,7 @@ library Sapphire {
             abi.encode(numBytes, pers)
         );
         require(success, "randomBytes: failed");
+        if(entropy.length != numBytes) revert Precompile_Not_Present();
         return entropy;
     }
 


### PR DESCRIPTION
Fixes #133

There is bigger problem with `success=true` even if precompile doesn't exist. So most of the `require()` checks are ineffective and could lead to weirdness when debugging contracts in Hardhat, instead of failures.

For `Sapphire.randomBytes()` the answer is simpler - ensure `returndatasize()` (EPI-211) is equal to the number of requested bytes.

However, for other functions with argument dependent lengths would require different checks.

Suggested checks:

 * `generateCurve25519KeyPair`, `require(pkBytes.length == 32)`
 * `deriveSymmetricKey`, `require(secretKey.length == 32)`
 * `encrypt`, `require(ciphertext.length == padded plaintext length + nonce overhead)`
 * `verifyDigestSignature`, `require(v.length == 32)` ... `abi.encode(true).length == 32`?

Less easier to handle:

 * `decrypt` 
 * `generateSigningKeyPair` 
 * `signDigest`
 * 