### PR TITLE
Use SigningAlg instead of uint256 in Sapphire.signDigest

### DIFF
--- a/contracts/contracts/Sapphire.sol
+++ b/contracts/contracts/Sapphire.sol
@@ -175,7 +175,7 @@ library Sapphire {
      * @return signature The resulting signature.
      */
     function signDigest(
-        uint256 alg,
+        SigningAlg alg,
         bytes memory secretKey,
         bytes memory digest
     ) internal view returns (bytes memory signature) {


### PR DESCRIPTION
 to be consistent with `generateSigningKeyPair` and `verifyDigestSignature`.