### PR TITLE
contracts: Added EIP-155 signer and extended EthereumUtils

### DIFF
--- a/contracts/contracts/EIP155Signer.sol
+++ b/contracts/contracts/EIP155Signer.sol
@@ -53,15 +53,14 @@ library EIP155Signer {
         address pubkeyAddr,
         bytes32 secretKey
     ) internal view returns (SignatureRSV memory ret) {
-        bytes memory encoded = encodeSignedTx(rawTx, SignatureRSV({v: rawTx.chainId, r: 0, s: 0}));
+        bytes memory encoded = encodeSignedTx(
+            rawTx,
+            SignatureRSV({v: rawTx.chainId, r: 0, s: 0})
+        );
 
         bytes32 digest = keccak256(abi.encodePacked(encoded));
 
-        ret = EthereumUtils.sign(
-            pubkeyAddr,
-            secretKey,
-            digest
-        );
+        ret = EthereumUtils.sign(pubkeyAddr, secretKey, digest);
     }
 
     /**
@@ -75,7 +74,11 @@ library EIP155Signer {
         bytes32 secretKey,
         EthTx memory transaction
     ) internal view returns (bytes memory) {
-        SignatureRSV memory rsv = signRawTx(transaction, publicAddress, secretKey);
+        SignatureRSV memory rsv = signRawTx(
+            transaction,
+            publicAddress,
+            secretKey
+        );
         rsv.v = (rsv.v - 27) + (transaction.chainId * 2) + 35;
         return encodeSignedTx(transaction, rsv);
     }

--- a/contracts/contracts/EIP155Signer.sol
+++ b/contracts/contracts/EIP155Signer.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {Sapphire} from "./Sapphire.sol";
+import {EthereumUtils} from "./EthereumUtils.sol";
+import {RLPWriter} from "./RLPWriter.sol";
+
+/**
+ * @title Ethereum EIP-155 compatible transaction signer & encoder
+ */
+library EIP155Signer {
+    struct EthTx {
+        uint64 nonce;
+        uint256 gasPrice;
+        uint64 gasLimit;
+        address to;
+        uint256 value;
+        bytes data;
+        uint256 chainId;
+    }
+
+    struct SignatureRSV {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+    }
+
+    /**
+     * Encode a signed EIP-155 transaction
+     * @param rawTx Transaction which was signed
+     * @param rsv R, S & V parameters of signature
+     */
+    function encodeSignedTx(EthTx memory rawTx, SignatureRSV memory rsv)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes[] memory b = new bytes[](9);
+        b[0] = RLPWriter.writeUint(rawTx.nonce);
+        b[1] = RLPWriter.writeUint(rawTx.gasPrice);
+        b[2] = RLPWriter.writeUint(rawTx.gasLimit);
+        b[3] = RLPWriter.writeAddress(rawTx.to);
+        b[4] = RLPWriter.writeUint(rawTx.value);
+        b[5] = RLPWriter.writeBytes(rawTx.data);
+        b[6] = RLPWriter.writeUint((rsv.v - 27) + (block.chainid * 2) + 35);
+        b[7] = RLPWriter.writeUint(uint256(rsv.r));
+        b[8] = RLPWriter.writeUint(uint256(rsv.s));
+        return RLPWriter.writeList(b);
+    }
+
+    /**
+     * Sign a raw transaction, which will then need to be encoded to include the signature
+     * @param rawTx Transaction to sign
+     * @param pubkeyAddr Ethereum address of secret key
+     * @param secretKey Secret key used to sign
+     */
+    function signRawTx(
+        EthTx memory rawTx,
+        address pubkeyAddr,
+        bytes32 secretKey
+    ) internal view returns (SignatureRSV memory ret) {
+        bytes[] memory a = new bytes[](9);
+        a[0] = RLPWriter.writeUint(rawTx.nonce);
+        a[1] = RLPWriter.writeUint(rawTx.gasPrice);
+        a[2] = RLPWriter.writeUint(rawTx.gasLimit);
+        a[3] = RLPWriter.writeAddress(rawTx.to);
+        a[4] = RLPWriter.writeUint(rawTx.value);
+        a[5] = RLPWriter.writeBytes(rawTx.data);
+        a[6] = RLPWriter.writeUint(rawTx.chainId);
+        a[7] = RLPWriter.writeUint(0);
+        a[8] = RLPWriter.writeUint(0);
+
+        bytes32 digest = keccak256(RLPWriter.writeList(a));
+
+        (ret.r, ret.s, ret.v) = EthereumUtils.sign(
+            pubkeyAddr,
+            secretKey,
+            digest
+        );
+    }
+
+    /**
+     * Sign a transaction, returning it in EIP-155 encoded form
+     * @param publicAddress Ethereum address of secret key
+     * @param secretKey Secret key used to sign
+     * @param transaction Transaction to sign
+     */
+    function sign(
+        address publicAddress,
+        bytes32 secretKey,
+        EthTx memory transaction
+    ) internal view returns (bytes memory) {
+        return
+            encodeSignedTx(
+                transaction,
+                signRawTx(transaction, publicAddress, secretKey)
+            );
+    }
+}

--- a/contracts/contracts/EthereumUtils.sol
+++ b/contracts/contracts/EthereumUtils.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.0;
 
+import {Sapphire} from "./Sapphire.sol";
+
 library EthereumUtils {
     uint256 internal constant K256_P =
         0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f;

--- a/contracts/contracts/EthereumUtils.sol
+++ b/contracts/contracts/EthereumUtils.sol
@@ -226,14 +226,7 @@ library EthereumUtils {
         bytes memory pubkey,
         bytes32 digest,
         bytes memory signature
-    )
-        internal
-        view
-        returns (
-            address pubkeyAddr,
-            SignatureRSV memory rsv
-        )
-    {
+    ) internal view returns (address pubkeyAddr, SignatureRSV memory rsv) {
         pubkeyAddr = k256PubkeyToEthereumAddress(pubkey);
 
         rsv = splitDERSignature(signature);
@@ -245,11 +238,7 @@ library EthereumUtils {
         address pubkeyAddr,
         bytes32 secretKey,
         bytes32 digest
-    )
-        internal
-        view
-        returns (SignatureRSV memory rsv)
-    {
+    ) internal view returns (SignatureRSV memory rsv) {
         bytes memory signature = Sapphire.sign(
             Sapphire.SigningAlg.Secp256k1PrehashedKeccak256,
             abi.encodePacked(secretKey),

--- a/contracts/contracts/RLPWriter.sol
+++ b/contracts/contracts/RLPWriter.sol
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @custom:attribution https://github.com/bakaoh/solidity-rlp-encode
+ * @custom:attribution https://raw.githubusercontent.com/Maia-DAO/solidity-rlp-encoder/main/src/rlp/RLPWriter.sol
+ * @title RLPWriter
+ * @author RLPWriter is a library for encoding Solidity types to RLP bytes. Adapted from Bakaoh's
+ *         RLPEncode library (https://github.com/bakaoh/solidity-rlp-encode) with minor
+ *         modifications to improve legibility.
+ */
+library RLPWriter {
+    /**
+     * @notice RLP encodes a byte string.
+     *
+     * @param _in The byte string to encode.
+     *
+     * @return The RLP encoded string in bytes.
+     */
+    function writeBytes(bytes memory _in) internal pure returns (bytes memory) {
+        bytes memory encoded;
+
+        if (_in.length == 1 && uint8(_in[0]) < 128) {
+            encoded = _in;
+        } else {
+            encoded = abi.encodePacked(_writeLength(_in.length, 128), _in);
+        }
+
+        return encoded;
+    }
+
+    /**
+     * @notice RLP encodes a list of RLP encoded byte byte strings.
+     *
+     * @param _in The RLP encoded byte strings.
+     *
+     * @return The RLP encoded list of items in bytes.
+     */
+    function writeList(bytes memory _in) internal pure returns (bytes memory) {
+        return abi.encodePacked(_writeLength(_in.length, 192), _in);
+    }
+
+    /**
+     * @notice RLP encodes a list of RLP encoded byte byte strings.
+     *
+     * @param _in The list of RLP encoded byte strings.
+     *
+     * @return The RLP encoded list of items in bytes.
+     */
+    function writeList(bytes[] memory _in)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        bytes memory list = _flatten(_in);
+        return abi.encodePacked(_writeLength(list.length, 192), list);
+    }
+
+    /**
+     * @notice RLP encodes a string.
+     *
+     * @param _in The string to encode.
+     *
+     * @return The RLP encoded string in bytes.
+     */
+    function writeString(string memory _in)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return writeBytes(bytes(_in));
+    }
+
+    /**
+     * @notice RLP encodes an address.
+     *
+     * @param _in The address to encode.
+     *
+     * @return The RLP encoded address in bytes.
+     */
+    function writeAddress(address _in) internal pure returns (bytes memory) {
+        return writeBytes(abi.encodePacked(_in));
+    }
+
+    /**
+     * @notice RLP encodes a uint.
+     *
+     * @param _in The uint256 to encode.
+     *
+     * @return The RLP encoded uint256 in bytes.
+     */
+    function writeUint(uint256 _in) internal pure returns (bytes memory) {
+        return writeBytes(_toBinary(_in));
+    }
+
+    /**
+     * @notice RLP encodes a bool.
+     *
+     * @param _in The bool to encode.
+     *
+     * @return The RLP encoded bool in bytes.
+     */
+    function writeBool(bool _in) internal pure returns (bytes memory) {
+        bytes memory encoded = new bytes(1);
+        encoded[0] = (_in ? bytes1(0x01) : bytes1(0x80));
+        return encoded;
+    }
+
+    /**
+     * @notice Encode the first byte and then the `len` in binary form if `length` is more than 55.
+     *
+     * @param _len    The length of the string or the payload.
+     * @param _offset 128 if item is string, 192 if item is list.
+     *
+     * @return RLP encoded bytes.
+     */
+    function _writeLength(uint256 _len, uint256 _offset)
+        private
+        pure
+        returns (bytes memory)
+    {
+        bytes memory encoded;
+
+        if (_len < 56) {
+            encoded = new bytes(1);
+            encoded[0] = bytes1(uint8(_len) + uint8(_offset));
+        } else {
+            uint256 lenLen;
+            uint256 i = 1;
+            while (_len / i != 0) {
+                lenLen++;
+                i *= 256;
+            }
+
+            encoded = new bytes(lenLen + 1);
+            encoded[0] = bytes1(uint8(lenLen) + uint8(_offset) + 55);
+            for (i = 1; i <= lenLen; i++) {
+                encoded[i] = bytes1(uint8((_len / (256**(lenLen - i))) % 256));
+            }
+        }
+
+        return encoded;
+    }
+
+    /**
+     * @notice Encode integer in big endian binary form with no leading zeroes.
+     *
+     * @param _x The integer to encode.
+     *
+     * @return RLP encoded bytes.
+     */
+    function _toBinary(uint256 _x) private pure returns (bytes memory) {
+        bytes memory b = abi.encodePacked(_x);
+
+        uint256 i = 0;
+        for (; i < 32; i++) {
+            if (b[i] != 0) {
+                break;
+            }
+        }
+
+        bytes memory res = new bytes(32 - i);
+        for (uint256 j = 0; j < res.length; j++) {
+            res[j] = b[i++];
+        }
+
+        return res;
+    }
+
+    /**
+     * @custom:attribution https://github.com/Arachnid/solidity-stringutils
+     * @notice Copies a piece of memory to another location.
+     *
+     * @param _dest Destination location.
+     * @param _src  Source location.
+     * @param _len  Length of memory to copy.
+     */
+    function _memcpy(
+        uint256 _dest,
+        uint256 _src,
+        uint256 _len
+    ) private pure {
+        uint256 dest = _dest;
+        uint256 src = _src;
+        uint256 len = _len;
+
+        for (; len >= 32; len -= 32) {
+            assembly {
+                mstore(dest, mload(src))
+            }
+            dest += 32;
+            src += 32;
+        }
+
+        uint256 mask;
+        unchecked {
+            mask = 256**(32 - len) - 1;
+        }
+        assembly {
+            let srcpart := and(mload(src), not(mask))
+            let destpart := and(mload(dest), mask)
+            mstore(dest, or(destpart, srcpart))
+        }
+    }
+
+    /**
+     * @custom:attribution https://github.com/sammayo/solidity-rlp-encoder
+     * @notice Flattens a list of byte strings into one byte string.
+     *
+     * @param _list List of byte strings to flatten.
+     *
+     * @return The flattened byte string.
+     */
+    function _flatten(bytes[] memory _list)
+        private
+        pure
+        returns (bytes memory)
+    {
+        if (_list.length == 0) {
+            return new bytes(0);
+        }
+
+        uint256 len;
+        uint256 i = 0;
+        for (; i < _list.length; i++) {
+            len += _list[i].length;
+        }
+
+        bytes memory flattened = new bytes(len);
+        uint256 flattenedPtr;
+        assembly {
+            flattenedPtr := add(flattened, 0x20)
+        }
+
+        for (i = 0; i < _list.length; i++) {
+            bytes memory item = _list[i];
+
+            uint256 listPtr;
+            assembly {
+                listPtr := add(item, 0x20)
+            }
+
+            _memcpy(flattenedPtr, listPtr, item.length);
+            flattenedPtr += _list[i].length;
+        }
+
+        return flattened;
+    }
+}

--- a/contracts/contracts/tests/EIP155Tests.sol
+++ b/contracts/contracts/tests/EIP155Tests.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.0;
+
+import {EthereumUtils} from "../EthereumUtils.sol";
+import {EIP155Signer} from "../EIP155Signer.sol";
+
+contract EIP155Tests {
+    address public immutable publicAddr;
+    bytes32 public immutable secretKey;
+    constructor ()
+        payable
+    {
+        (publicAddr, secretKey) = EthereumUtils.generateKeypair();
+        payable(publicAddr).transfer(msg.value);
+    }
+    function sign(EIP155Signer.EthTx memory transaction)
+        external view
+        returns (bytes memory)
+    {
+        transaction.data = abi.encodeWithSelector(this.example.selector);
+        transaction.chainId = block.chainid;
+        return EIP155Signer.sign(publicAddr, secretKey, transaction);
+    }
+
+    event ExampleEvent(bytes32 x);
+
+    function example()
+        external
+    {
+        emit ExampleEvent(0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210);
+    }
+}

--- a/contracts/contracts/tests/EIP155Tests.sol
+++ b/contracts/contracts/tests/EIP155Tests.sol
@@ -8,14 +8,15 @@ import {EIP155Signer} from "../EIP155Signer.sol";
 contract EIP155Tests {
     address public immutable publicAddr;
     bytes32 public immutable secretKey;
-    constructor ()
-        payable
-    {
+
+    constructor() payable {
         (publicAddr, secretKey) = EthereumUtils.generateKeypair();
         payable(publicAddr).transfer(msg.value);
     }
+
     function sign(EIP155Signer.EthTx memory transaction)
-        external view
+        external
+        view
         returns (bytes memory)
     {
         transaction.data = abi.encodeWithSelector(this.example.selector);
@@ -25,9 +26,9 @@ contract EIP155Tests {
 
     event ExampleEvent(bytes32 x);
 
-    function example()
-        external
-    {
-        emit ExampleEvent(0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210);
+    function example() external {
+        emit ExampleEvent(
+            0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
+        );
     }
 }

--- a/contracts/contracts/tests/SigningTests.sol
+++ b/contracts/contracts/tests/SigningTests.sol
@@ -37,10 +37,7 @@ contract SigningTests {
     function testEthereum(bytes memory seed, bytes32 digest)
         external
         view
-        returns (
-            address addr,
-            SignatureRSV memory rsv
-        )
+        returns (address addr, SignatureRSV memory rsv)
     {
         Sapphire.SigningAlg alg = Sapphire
             .SigningAlg

--- a/contracts/contracts/tests/SigningTests.sol
+++ b/contracts/contracts/tests/SigningTests.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import "../Sapphire.sol";
-import "../EthereumUtils.sol";
+import {Sapphire} from "../Sapphire.sol";
+import {EthereumUtils} from "../EthereumUtils.sol";
 
 contract SigningTests {
     function testKeygen(Sapphire.SigningAlg alg, bytes memory seed)

--- a/contracts/contracts/tests/SigningTests.sol
+++ b/contracts/contracts/tests/SigningTests.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 import {Sapphire} from "../Sapphire.sol";
-import {EthereumUtils} from "../EthereumUtils.sol";
+import {EthereumUtils, SignatureRSV} from "../EthereumUtils.sol";
 
 contract SigningTests {
     function testKeygen(Sapphire.SigningAlg alg, bytes memory seed)
@@ -39,9 +39,7 @@ contract SigningTests {
         view
         returns (
             address addr,
-            bytes32 r,
-            bytes32 s,
-            uint8 v
+            SignatureRSV memory rsv
         )
     {
         Sapphire.SigningAlg alg = Sapphire
@@ -55,6 +53,6 @@ contract SigningTests {
 
         bytes memory sig = Sapphire.sign(alg, sk, abi.encodePacked(digest), "");
 
-        (addr, r, s, v) = EthereumUtils.toEthereumSignature(pk, digest, sig);
+        (addr, rsv) = EthereumUtils.toEthereumSignature(pk, digest, sig);
     }
 }

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.5",
     "@nomiclabs/hardhat-ethers": "^2.1.1",
-    "@ethersproject/providers": "^5.7.2",
     "@oasisprotocol/sapphire-hardhat": "workspace:^",
     "@openzeppelin/contracts": "^4.7.3",
     "@typechain/ethers-v5": "^10.1.0",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.5",
     "@nomiclabs/hardhat-ethers": "^2.1.1",
+    "@ethersproject/providers": "^5.7.2",
     "@oasisprotocol/sapphire-hardhat": "workspace:^",
     "@openzeppelin/contracts": "^4.7.3",
     "@typechain/ethers-v5": "^10.1.0",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisprotocol/sapphire-contracts",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "description": "Solidity smart contract library for confidential contract development",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/contracts",

--- a/contracts/test/eip155.ts
+++ b/contracts/test/eip155.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { EIP155Tests__factory } from '../typechain-types/factories/contracts/tests';
+import { StaticJsonRpcProvider } from "@ethersproject/providers";
+
+describe('EIP-155', function () {
+    async function deploy() {
+      const factory = (await ethers.getContractFactory(
+        'EIP155Tests',
+      )) as EIP155Tests__factory;
+      const x = await factory.deploy({value: ethers.utils.parseEther('1')});
+      return { x };
+    }
+
+    it('Signed transactions can be submitted', async function () {
+        const {x} = await deploy();
+        const txobj = {
+            nonce: 0,
+            gasPrice: await x.provider.getGasPrice(),
+            gasLimit: 250000,
+            to: x.address,
+            value: 0,
+            data: "0x",
+            chainId: 0
+        };
+        const signedTx = await x.sign(txobj);
+
+        // Submit signed transaction via plain JSON-RPC provider (avoiding saphire.wrap)
+        const plain_provider = new StaticJsonRpcProvider(ethers.provider.connection);
+        let plain_resp = await plain_provider.sendTransaction(signedTx);
+        let receipt = await x.provider.waitForTransaction(plain_resp.hash);
+        expect(receipt.logs[0].data).equal('0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210');
+    });
+});

--- a/contracts/test/eip155.ts
+++ b/contracts/test/eip155.ts
@@ -1,36 +1,40 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect } from "chai";
+import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { EIP155Tests__factory } from '../typechain-types/factories/contracts/tests';
-import { StaticJsonRpcProvider } from "@ethersproject/providers";
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
 
 describe('EIP-155', function () {
-    async function deploy() {
-      const factory = (await ethers.getContractFactory(
-        'EIP155Tests',
-      )) as EIP155Tests__factory;
-      const x = await factory.deploy({value: ethers.utils.parseEther('1')});
-      return { x };
-    }
+  async function deploy() {
+    const factory = (await ethers.getContractFactory(
+      'EIP155Tests',
+    )) as EIP155Tests__factory;
+    const x = await factory.deploy({ value: ethers.utils.parseEther('1') });
+    return { x };
+  }
 
-    it('Signed transactions can be submitted', async function () {
-        const {x} = await deploy();
-        const txobj = {
-            nonce: 0,
-            gasPrice: await x.provider.getGasPrice(),
-            gasLimit: 250000,
-            to: x.address,
-            value: 0,
-            data: "0x",
-            chainId: 0
-        };
-        const signedTx = await x.sign(txobj);
+  it('Signed transactions can be submitted', async function () {
+    const { x } = await deploy();
+    const txobj = {
+      nonce: 0,
+      gasPrice: await x.provider.getGasPrice(),
+      gasLimit: 250000,
+      to: x.address,
+      value: 0,
+      data: '0x',
+      chainId: 0,
+    };
+    const signedTx = await x.sign(txobj);
 
-        // Submit signed transaction via plain JSON-RPC provider (avoiding saphire.wrap)
-        const plain_provider = new StaticJsonRpcProvider(ethers.provider.connection);
-        let plain_resp = await plain_provider.sendTransaction(signedTx);
-        let receipt = await x.provider.waitForTransaction(plain_resp.hash);
-        expect(receipt.logs[0].data).equal('0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210');
-    });
+    // Submit signed transaction via plain JSON-RPC provider (avoiding saphire.wrap)
+    const plain_provider = new StaticJsonRpcProvider(
+      ethers.provider.connection,
+    );
+    let plain_resp = await plain_provider.sendTransaction(signedTx);
+    let receipt = await x.provider.waitForTransaction(plain_resp.hash);
+    expect(receipt.logs[0].data).equal(
+      '0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
+    );
+  });
 });

--- a/contracts/test/eip155.ts
+++ b/contracts/test/eip155.ts
@@ -9,7 +9,9 @@ describe('EIP-155', function () {
     const factory = (await ethers.getContractFactory(
       'EIP155Tests',
     )) as EIP155Tests__factory;
-    const testContract = await factory.deploy({ value: ethers.utils.parseEther('1') });
+    const testContract = await factory.deploy({
+      value: ethers.utils.parseEther('1'),
+    });
     return { testContract };
   }
 
@@ -31,7 +33,9 @@ describe('EIP-155', function () {
       ethers.provider.connection,
     );
     let plainResp = await plainProvider.sendTransaction(signedTx);
-    let receipt = await testContract.provider.waitForTransaction(plainResp.hash);
+    let receipt = await testContract.provider.waitForTransaction(
+      plainResp.hash,
+    );
     expect(receipt.logs[0].data).equal(
       '0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
     );

--- a/contracts/test/eip155.ts
+++ b/contracts/test/eip155.ts
@@ -3,36 +3,35 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { EIP155Tests__factory } from '../typechain-types/factories/contracts/tests';
-import { StaticJsonRpcProvider } from '@ethersproject/providers';
 
 describe('EIP-155', function () {
   async function deploy() {
     const factory = (await ethers.getContractFactory(
       'EIP155Tests',
     )) as EIP155Tests__factory;
-    const x = await factory.deploy({ value: ethers.utils.parseEther('1') });
-    return { x };
+    const testContract = await factory.deploy({ value: ethers.utils.parseEther('1') });
+    return { testContract };
   }
 
   it('Signed transactions can be submitted', async function () {
-    const { x } = await deploy();
+    const { testContract } = await deploy();
     const txobj = {
       nonce: 0,
-      gasPrice: await x.provider.getGasPrice(),
+      gasPrice: await testContract.provider.getGasPrice(),
       gasLimit: 250000,
-      to: x.address,
+      to: testContract.address,
       value: 0,
       data: '0x',
       chainId: 0,
     };
-    const signedTx = await x.sign(txobj);
+    const signedTx = await testContract.sign(txobj);
 
     // Submit signed transaction via plain JSON-RPC provider (avoiding saphire.wrap)
-    const plain_provider = new StaticJsonRpcProvider(
+    const plainProvider = new ethers.providers.StaticJsonRpcProvider(
       ethers.provider.connection,
     );
-    let plain_resp = await plain_provider.sendTransaction(signedTx);
-    let receipt = await x.provider.waitForTransaction(plain_resp.hash);
+    let plainResp = await plainProvider.sendTransaction(signedTx);
+    let receipt = await testContract.provider.waitForTransaction(plainResp.hash);
     expect(receipt.logs[0].data).equal(
       '0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
     );

--- a/contracts/test/precompiles.ts
+++ b/contracts/test/precompiles.ts
@@ -114,9 +114,9 @@ describe('Precompiles', function () {
       expect(expected_addr).equal(resp.addr);
 
       const addr_v = ethers.utils.recoverAddress(digest, {
-        r: resp.r,
-        s: resp.s,
-        v: resp.v,
+        r: resp.rsv.r,
+        s: resp.rsv.s,
+        v: Number(resp.rsv.v),
       });
       expect(addr_v).to.equal(expected_addr);
     }

--- a/contracts/test/precompiles.ts
+++ b/contracts/test/precompiles.ts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2
+// SPDX-License-Identifier: Apache-2.0
 
 import { randomBytes } from 'crypto';
 import { expect } from 'chai';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,7 @@ importers:
 
   contracts:
     specifiers:
+      '@ethersproject/providers': ^5.7.2
       '@nomicfoundation/hardhat-chai-matchers': ^1.0.5
       '@nomiclabs/hardhat-ethers': ^2.1.1
       '@oasisprotocol/sapphire-hardhat': workspace:^
@@ -107,12 +108,13 @@ importers:
       typechain: ^8.1.0
       typescript: ^4.8.3
     devDependencies:
+      '@ethersproject/providers': 5.7.2
       '@nomicfoundation/hardhat-chai-matchers': 1.0.6_b5aapq7yti7itqx6wcz3o7bx6q
       '@nomiclabs/hardhat-ethers': 2.2.3_drbn5rr2wg6skrabufgggpzpcu
       '@oasisprotocol/sapphire-hardhat': link:../integrations/hardhat
       '@openzeppelin/contracts': 4.9.2
-      '@typechain/ethers-v5': 10.2.1_kd2jok6auccgi7myntldx3ze7u
-      '@typechain/hardhat': 6.1.6_5baw6cnhn6tns6ldeygt5ylv2i
+      '@typechain/ethers-v5': 10.2.1_behyd5ue2kbktb7mrkw7mlslyu
+      '@typechain/hardhat': 6.1.6_mmhutvpepocg57xpbx6cbqj2xi
       '@types/chai': 4.3.5
       '@types/mocha': 9.1.1
       '@types/node': 18.16.18
@@ -4500,7 +4502,7 @@ packages:
   /@tsconfig/node16/1.0.4:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  /@typechain/ethers-v5/10.2.1_kd2jok6auccgi7myntldx3ze7u:
+  /@typechain/ethers-v5/10.2.1_behyd5ue2kbktb7mrkw7mlslyu:
     resolution: {integrity: sha512-n3tQmCZjRE6IU4h6lqUGiQ1j866n5MTCBJreNEHHVWXa2u9GJTaeYyU1/k+1qLutkyw+sS6VAN+AbeiTqsxd/A==}
     peerDependencies:
       '@ethersproject/abi': ^5.0.0
@@ -4509,6 +4511,7 @@ packages:
       typechain: ^8.1.1
       typescript: '>=4.3.0'
     dependencies:
+      '@ethersproject/providers': 5.7.2
       ethers: 5.7.2
       lodash: 4.17.21
       ts-essentials: 7.0.3_typescript@4.9.5
@@ -4554,23 +4557,6 @@ packages:
       typescript: 4.7.4
     dev: true
 
-  /@typechain/hardhat/6.1.6_5baw6cnhn6tns6ldeygt5ylv2i:
-    resolution: {integrity: sha512-BiVnegSs+ZHVymyidtK472syodx1sXYlYJJixZfRstHVGYTi8V1O7QG4nsjyb0PC/LORcq7sfBUcHto1y6UgJA==}
-    peerDependencies:
-      '@ethersproject/abi': ^5.4.7
-      '@ethersproject/providers': ^5.4.7
-      '@typechain/ethers-v5': ^10.2.1
-      ethers: ^5.4.7
-      hardhat: ^2.9.9
-      typechain: ^8.1.1
-    dependencies:
-      '@typechain/ethers-v5': 10.2.1_kd2jok6auccgi7myntldx3ze7u
-      ethers: 5.7.2
-      fs-extra: 9.1.0
-      hardhat: 2.16.1_6qtx7vkbdhwvdm4crzlegk4mvi
-      typechain: 8.2.0_typescript@4.9.5
-    dev: true
-
   /@typechain/hardhat/6.1.6_dh4iu7h5wvmdp3xxt5l2yfasdy:
     resolution: {integrity: sha512-BiVnegSs+ZHVymyidtK472syodx1sXYlYJJixZfRstHVGYTi8V1O7QG4nsjyb0PC/LORcq7sfBUcHto1y6UgJA==}
     peerDependencies:
@@ -4603,6 +4589,24 @@ packages:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/providers': 5.7.2
       '@typechain/ethers-v5': 10.2.1_yivnc5nurfvwqckylwurpk6z34
+      ethers: 5.7.2
+      fs-extra: 9.1.0
+      hardhat: 2.16.1_6qtx7vkbdhwvdm4crzlegk4mvi
+      typechain: 8.2.0_typescript@4.9.5
+    dev: true
+
+  /@typechain/hardhat/6.1.6_mmhutvpepocg57xpbx6cbqj2xi:
+    resolution: {integrity: sha512-BiVnegSs+ZHVymyidtK472syodx1sXYlYJJixZfRstHVGYTi8V1O7QG4nsjyb0PC/LORcq7sfBUcHto1y6UgJA==}
+    peerDependencies:
+      '@ethersproject/abi': ^5.4.7
+      '@ethersproject/providers': ^5.4.7
+      '@typechain/ethers-v5': ^10.2.1
+      ethers: ^5.4.7
+      hardhat: ^2.9.9
+      typechain: ^8.1.1
+    dependencies:
+      '@ethersproject/providers': 5.7.2
+      '@typechain/ethers-v5': 10.2.1_behyd5ue2kbktb7mrkw7mlslyu
       ethers: 5.7.2
       fs-extra: 9.1.0
       hardhat: 2.16.1_6qtx7vkbdhwvdm4crzlegk4mvi

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,6 @@ importers:
 
   contracts:
     specifiers:
-      '@ethersproject/providers': ^5.7.2
       '@nomicfoundation/hardhat-chai-matchers': ^1.0.5
       '@nomiclabs/hardhat-ethers': ^2.1.1
       '@oasisprotocol/sapphire-hardhat': workspace:^
@@ -108,13 +107,12 @@ importers:
       typechain: ^8.1.0
       typescript: ^4.8.3
     devDependencies:
-      '@ethersproject/providers': 5.7.2
       '@nomicfoundation/hardhat-chai-matchers': 1.0.6_b5aapq7yti7itqx6wcz3o7bx6q
       '@nomiclabs/hardhat-ethers': 2.2.3_drbn5rr2wg6skrabufgggpzpcu
       '@oasisprotocol/sapphire-hardhat': link:../integrations/hardhat
       '@openzeppelin/contracts': 4.9.2
-      '@typechain/ethers-v5': 10.2.1_behyd5ue2kbktb7mrkw7mlslyu
-      '@typechain/hardhat': 6.1.6_mmhutvpepocg57xpbx6cbqj2xi
+      '@typechain/ethers-v5': 10.2.1_kd2jok6auccgi7myntldx3ze7u
+      '@typechain/hardhat': 6.1.6_5baw6cnhn6tns6ldeygt5ylv2i
       '@types/chai': 4.3.5
       '@types/mocha': 9.1.1
       '@types/node': 18.16.18
@@ -4502,7 +4500,7 @@ packages:
   /@tsconfig/node16/1.0.4:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  /@typechain/ethers-v5/10.2.1_behyd5ue2kbktb7mrkw7mlslyu:
+  /@typechain/ethers-v5/10.2.1_kd2jok6auccgi7myntldx3ze7u:
     resolution: {integrity: sha512-n3tQmCZjRE6IU4h6lqUGiQ1j866n5MTCBJreNEHHVWXa2u9GJTaeYyU1/k+1qLutkyw+sS6VAN+AbeiTqsxd/A==}
     peerDependencies:
       '@ethersproject/abi': ^5.0.0
@@ -4511,7 +4509,6 @@ packages:
       typechain: ^8.1.1
       typescript: '>=4.3.0'
     dependencies:
-      '@ethersproject/providers': 5.7.2
       ethers: 5.7.2
       lodash: 4.17.21
       ts-essentials: 7.0.3_typescript@4.9.5
@@ -4557,6 +4554,23 @@ packages:
       typescript: 4.7.4
     dev: true
 
+  /@typechain/hardhat/6.1.6_5baw6cnhn6tns6ldeygt5ylv2i:
+    resolution: {integrity: sha512-BiVnegSs+ZHVymyidtK472syodx1sXYlYJJixZfRstHVGYTi8V1O7QG4nsjyb0PC/LORcq7sfBUcHto1y6UgJA==}
+    peerDependencies:
+      '@ethersproject/abi': ^5.4.7
+      '@ethersproject/providers': ^5.4.7
+      '@typechain/ethers-v5': ^10.2.1
+      ethers: ^5.4.7
+      hardhat: ^2.9.9
+      typechain: ^8.1.1
+    dependencies:
+      '@typechain/ethers-v5': 10.2.1_kd2jok6auccgi7myntldx3ze7u
+      ethers: 5.7.2
+      fs-extra: 9.1.0
+      hardhat: 2.16.1_6qtx7vkbdhwvdm4crzlegk4mvi
+      typechain: 8.2.0_typescript@4.9.5
+    dev: true
+
   /@typechain/hardhat/6.1.6_dh4iu7h5wvmdp3xxt5l2yfasdy:
     resolution: {integrity: sha512-BiVnegSs+ZHVymyidtK472syodx1sXYlYJJixZfRstHVGYTi8V1O7QG4nsjyb0PC/LORcq7sfBUcHto1y6UgJA==}
     peerDependencies:
@@ -4589,24 +4603,6 @@ packages:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/providers': 5.7.2
       '@typechain/ethers-v5': 10.2.1_yivnc5nurfvwqckylwurpk6z34
-      ethers: 5.7.2
-      fs-extra: 9.1.0
-      hardhat: 2.16.1_6qtx7vkbdhwvdm4crzlegk4mvi
-      typechain: 8.2.0_typescript@4.9.5
-    dev: true
-
-  /@typechain/hardhat/6.1.6_mmhutvpepocg57xpbx6cbqj2xi:
-    resolution: {integrity: sha512-BiVnegSs+ZHVymyidtK472syodx1sXYlYJJixZfRstHVGYTi8V1O7QG4nsjyb0PC/LORcq7sfBUcHto1y6UgJA==}
-    peerDependencies:
-      '@ethersproject/abi': ^5.4.7
-      '@ethersproject/providers': ^5.4.7
-      '@typechain/ethers-v5': ^10.2.1
-      ethers: ^5.4.7
-      hardhat: ^2.9.9
-      typechain: ^8.1.1
-    dependencies:
-      '@ethersproject/providers': 5.7.2
-      '@typechain/ethers-v5': 10.2.1_behyd5ue2kbktb7mrkw7mlslyu
       ethers: 5.7.2
       fs-extra: 9.1.0
       hardhat: 2.16.1_6qtx7vkbdhwvdm4crzlegk4mvi


### PR DESCRIPTION
This allows contracts to sign and encode Ethereum compatible EIP-155 transactions.

As a follow-up to https://github.com/oasisprotocol/demo-voting/pull/9 where we should make this code commonly available in sapphire-contracts library.

Truffle tests are still intermittent with `callback` related errors (weeiird).

This will require publishing an updated sapphire-contracts NPM repo.

RLPWriter contract is MIT licensed from elsewhere, with (multiple) attributions in the file.

TODO:

 - [x] Commit v0.2.3 sapphire-contracts version
 - [x] Add tests for EIP-155 oroborus