### PR TITLE
contracts: Update Celer MessageBus address for Sapphire Mainnet

### DIFF
--- a/contracts/contracts/EthereumUtils.sol
+++ b/contracts/contracts/EthereumUtils.sol
@@ -265,7 +265,7 @@ library EthereumUtils {
 
         secretKey = bytes32(randSeed);
 
-        (bytes memory pk,) = Sapphire.generateSigningKeyPair(
+        (bytes memory pk, ) = Sapphire.generateSigningKeyPair(
             Sapphire.SigningAlg.Secp256k1PrehashedKeccak256,
             randSeed
         );

--- a/contracts/contracts/EthereumUtils.sol
+++ b/contracts/contracts/EthereumUtils.sol
@@ -265,7 +265,7 @@ library EthereumUtils {
 
         secretKey = bytes32(randSeed);
 
-        (bytes memory pk, bytes memory tmp) = Sapphire.generateSigningKeyPair(
+        (bytes memory pk,) = Sapphire.generateSigningKeyPair(
             Sapphire.SigningAlg.Secp256k1PrehashedKeccak256,
             randSeed
         );

--- a/contracts/contracts/opl/Endpoint.sol
+++ b/contracts/contracts/opl/Endpoint.sol
@@ -269,7 +269,7 @@ function _getChainConfig(uint256 _chainId)
         return (0x940dAAbA3F713abFabD79CdD991466fe698CBe54, false);
     if (_chainId == 0x5afe)
         // sapphire
-        return (0x9Bb46D5100d2Db4608112026951c9C965b233f4D, false);
+        return (0x9B36f165baB9ebe611d491180418d8De4b8f3a1f, false);
     if (_chainId == 0x5aff)
         // sapphire testnet
         return (0x9Bb46D5100d2Db4608112026951c9C965b233f4D, true);

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisprotocol/sapphire-contracts",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "Apache-2.0",
   "description": "Solidity smart contract library for confidential contract development",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/contracts",


### PR DESCRIPTION
Fixes #155 

Also, fixed minor warning when compiling EthereumUtils.sol, it will no-longer warn about an unused return parameter.

Celer-IM documentation for MessageBus addresses are:
 - https://im-docs.celer.network/developer/contract-addresses-and-rpc-info

Unrelated:
 - There is still an intermittent failure in the Truffle CI tests using sapphire-dev. These will be addressed in another ticket/pr.