### PR TITLE
Utilize gas estimation in client libraries

### DIFF
--- a/.github/workflows/contracts-test.yaml
+++ b/.github/workflows/contracts-test.yaml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 jobs:
-  hardhat-test:
+  contracts-test:
     runs-on: ubuntu-latest
     services:
       sapphire-dev-ci:
@@ -59,7 +59,7 @@ jobs:
       - name: Build hardhat integration
         working-directory: integrations/hardhat
         run: pnpm build
-      - name: hardhat test contracts
+      - name: Test contracts with Hardhat
         working-directory: contracts
         run: pnpm hardhat test --network sapphire-dev-ci
       - name: Build docs

--- a/clients/js/src/signed_calls.ts
+++ b/clients/js/src/signed_calls.ts
@@ -202,7 +202,7 @@ async function makeLeash(
   const [nonce, block] = await Promise.all([nonceP, blockP]);
   const blockRange = overrides?.blockRange ?? DEFAULT_BLOCK_RANGE;
 
-  // check wether we should use cached leashes
+  // check whether we should use cached leashes
   if (overrides?.nonce === undefined && overrides?.block === undefined) {
     if (!signer.provider)
       throw new Error(


### PR DESCRIPTION
## Why
Relates to #39 

## Development

### Go
This appears fairly straight forward. I can test with a base Go script against our Vigil [contract](https://github.com/oasisprotocol/sapphire-paratime/blob/4e0434db8677862f9f1ca78735760b283148114e/examples/hardhat/contracts/Vigil.sol).

```Golang
package main

import (
	"context"
	"crypto/ecdsa"
	"fmt"
	"log"
	"math/big"

	"github.com/aefhm/vigil" // or however you do local modules
	"github.com/ethereum/go-ethereum/accounts/abi/bind"
	"github.com/ethereum/go-ethereum/crypto"
	"github.com/ethereum/go-ethereum/ethclient"
	sapphire "github.com/oasisprotocol/sapphire-paratime/clients/go"
)

var SapphireChainID = big.NewInt(0x5aff)

func main() {
	c, err := ethclient.Dial("https://testnet.sapphire.oasis.dev")
	if err != nil {
		log.Fatal(err)
	}

	privateKey, err := crypto.HexToECDSA("")
	if err != nil {
		log.Fatal(err)
	}

	publicKey := privateKey.Public()
	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
	if !ok {
		log.Fatal("error casting public key to ECDSA")
	}

	var client *sapphire.WrappedBackend
	client, err = sapphire.WrapClient(*c, func(digest [32]byte) ([]byte, error) { return crypto.Sign(digest[:], privateKey) })

	if err != nil {
		log.Fatal(err)
	}

	fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)
	nonce, err := client.PendingNonceAt(context.Background(), fromAddress)

	gasPrice, err := client.SuggestGasPrice(context.Background())
	if err != nil {
		log.Fatal(err)
	}

	auth, _ := bind.NewKeyedTransactorWithChainID(privateKey, SapphireChainID)
	auth.Nonce = big.NewInt(int64(nonce))
	auth.Value = big.NewInt(0) // in wei
	auth.GasLimit = uint64(0)  // in units
	auth.GasPrice = gasPrice

	if err != nil {
		log.Fatal(err)
	}

	address, tx, _, err := vigil.DeployVigil(auth, client)
	if err != nil {
		log.Fatal(err)
	}

	fmt.Println(address.Hex())
	fmt.Println(tx.Hash().Hex())


        // create secret
        // reuse address or wait
	vigil, err := vigil.NewVigil(address, client)

	if err != nil {
		log.Fatalf("Failed to instantiate Vigil contract: %v", err)
	}

	val := []byte("123")
	transactOpts := client.Transactor(fromAddress)
	transaction, err := vigil.CreateSecret(transactOpts, "age", big.NewInt(5), val)

	if err != nil {
		log.Fatalf("Failed to create secret: %v", err)
	}

	fmt.Println(transaction.Data())
}
```

### JS
I'm testing with [Vigil.sol](https://github.com/oasisprotocol/sapphire-paratime/blob/4e0434db8677862f9f1ca78735760b283148114e/examples/hardhat/contracts/Vigil.sol) and [run-vigil.ts](https://github.com/oasisprotocol/sapphire-paratime/blob/4e0434db8677862f9f1ca78735760b283148114e/examples/hardhat/scripts/run-vigil.ts)

## TODO
- [x] Inform community
- [x] Test locally again