### PR TITLE
ci: Bump Node.js to v18

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - uses: pnpm/action-setup@v2.4.0
         name: Install pnpm
@@ -116,7 +116,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - uses: pnpm/action-setup@v2.4.0
         name: Install pnpm

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -111,6 +111,8 @@ jobs:
             clients/js/lib
 
       - name: Test JS client
+        env:
+          NODE_OPTIONS: "--no-experimental-fetch" # https://github.com/nock/nock/issues/2397
         run: pnpm test
 
   test-integration-hardhat:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - uses: pnpm/action-setup@v2.4.0
         name: Install pnpm
@@ -127,7 +127,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - uses: pnpm/action-setup@v2.4.0
         name: Install pnpm
@@ -222,7 +222,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - uses: pnpm/action-setup@v2.4.0
         name: Install pnpm

--- a/.github/workflows/contracts-test.yaml
+++ b/.github/workflows/contracts-test.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - uses: pnpm/action-setup@v2.4.0
         name: Install pnpm
         id: pnpm-install

--- a/clients/js/test/cipher.spec.ts
+++ b/clients/js/test/cipher.spec.ts
@@ -155,7 +155,9 @@ describe('fetchPublicKeyByChainId', () => {
         },
       });
 
-    expect(await fetchRuntimePublicKeyByChainId(chainId, opts));
+    expect(
+      await fetchRuntimePublicKeyByChainId(chainId, opts),
+    ).not.toHaveLength(0);
 
     scope.done();
   }


### PR DESCRIPTION
This PR bumps Node.js to v18.x. Since `nock` used for unit tests of `sapphire-paratime` js client does not support Node.js v18.x yet (https://github.com/nock/nock/issues/2397), the `--no-experimental-fetch` flag is added in the CI tests.