### PR TITLE
ci-test: Do not run all truffle combinations for onchain-signer

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -201,19 +201,13 @@ jobs:
     needs: [test-client-js, test-integration-hardhat]
     strategy:
       matrix:
-        example: [hardhat, hardhat-boilerplate, truffle, onchain-signer]
-        truffle_version: [none, 5.8.2, 5.10.1]
-        exclude:
-          - example: hardhat
-            truffle_version: 5.8.2
-          - example: hardhat
-            truffle_version: 5.10.1
-          - example: hardhat-boilerplate
-            truffle_version: 5.8.2
-          - example: hardhat-boilerplate
-            truffle_version: 5.10.1
+        example: [hardhat, hardhat-boilerplate, onchain-signer]
+        include:
           - example: truffle
-            truffle_version: none
+          - example: truffle
+            truffle_version: 5.8.2
+          - example: truffle
+            truffle_version: 5.10.1
     defaults:
       run:
         working-directory: examples/${{ matrix.example }}
@@ -264,7 +258,7 @@ jobs:
           pnpm install
 
       - name: Update Truffle version
-        if: ${{ matrix.example == 'truffle' && matrix.truffle_version != 'none' }}
+        if: ${{ matrix.example == 'truffle' && matrix.truffle_version }}
         run: |
           pnpm up truffle@${{matrix.truffle_version}}
 


### PR DESCRIPTION
This PR removes running onchain-signer for each truffle version combination, because it doesn't rely on truffle.

Followup to https://github.com/oasisprotocol/sapphire-paratime/pull/177.