### PR TITLE
clients/js: Add typedoc deployment

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -1,0 +1,69 @@
+name: ci-docs
+
+on:
+  push:
+    paths:
+      - clients/js/**
+    branches:
+      - main
+
+# Cancel in-progress jobs on same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  js-docs:
+    name: js-docs
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./clients/js
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - uses: pnpm/action-setup@v2.4.0
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 8
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm --filter @oasisprotocol/sapphire-paratime install
+
+      - name: Build docs
+        run: |
+          pnpm typedoc
+
+      - name: Deploy to api-reference branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: clients/js/docs/api
+          publish_branch: api-reference
+          destination_dir: js/sapphire-paratime
+          commit_message: Deploy js API reference ${{ github.event.head_commit.message }}
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -101,6 +101,9 @@ jobs:
       - name: Build JS client
         run: pnpm build
 
+      - name: Build typedoc
+        run: pnpm typedoc
+
       - name: Upload client-js build
         uses: actions/upload-artifact@v3
         with:

--- a/clients/js/README.md
+++ b/clients/js/README.md
@@ -5,7 +5,7 @@ by wrapping your existing `ethers.Provider`/`window.ethereum`/`web3.providers.*`
 Once you wrap your provider, you can use Sapphire just like you would use Ethereum.
 
 [@oasisprotocol/sapphire-paratime]: https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime
-[sapphire paratime]: https://docs.oasis.dev/general/developer-resources/sapphire-paratime/
+[sapphire paratime]: https://docs.oasis.io/dapp/sapphire/
 
 _If your dapp doesn't port in under 10 minutes, it's a bug!_  
 If you have more than a little trouble, please file an issue.  

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -38,7 +38,6 @@
     "build:cjs": "tsc -p ./tsconfig.cjs.json && node scripts/rename-cjs",
     "test": "jest",
     "coverage": "jest --coverage",
-    "doc": "typedoc --excludeInternal --excludePrivate src/index.ts",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
@@ -70,7 +69,7 @@
     "node-fetch": "^2.6.7",
     "prettier": "^2.7.1",
     "ts-jest": "^28.0.8",
-    "typedoc": "^0.23.15",
+    "typedoc": "^0.25.1",
     "typescript": "^4.8.3"
   }
 }

--- a/clients/js/tsconfig.json
+++ b/clients/js/tsconfig.json
@@ -16,5 +16,11 @@
     "sourceMap": true,
     "strict": true,
     "target": "es6"
+  },
+  "typedocOptions": {
+    "entryPoints": ["src/index.ts"],
+    "out": "docs/api",
+    "excludeInternal": true,
+    "excludePrivate": true
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: ^28.0.8
         version: 28.0.8(@babel/core@7.22.5)(jest@28.1.3)(typescript@4.9.5)
       typedoc:
-        specifier: ^0.23.15
-        version: 0.23.28(typescript@4.9.5)
+        specifier: ^0.25.1
+        version: 0.25.1(typescript@4.9.5)
       typescript:
         specifier: ^4.8.3
         version: 4.9.5
@@ -5717,8 +5717,8 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /ansi-sequence-parser@1.1.0:
-    resolution: {integrity: sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==}
+  /ansi-sequence-parser@1.1.1:
+    resolution: {integrity: sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==}
     dev: true
 
   /ansi-styles@3.2.1:
@@ -12939,9 +12939,9 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
-  /minimatch@7.4.6:
-    resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
-    engines: {node: '>=10'}
+  /minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
     dev: true
@@ -16237,10 +16237,10 @@ packages:
       rechoir: 0.6.2
     dev: true
 
-  /shiki@0.14.3:
-    resolution: {integrity: sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==}
+  /shiki@0.14.4:
+    resolution: {integrity: sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==}
     dependencies:
-      ansi-sequence-parser: 1.1.0
+      ansi-sequence-parser: 1.1.1
       jsonc-parser: 3.2.0
       vscode-oniguruma: 1.7.0
       vscode-textmate: 8.0.0
@@ -17595,17 +17595,17 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typedoc@0.23.28(typescript@4.9.5):
-    resolution: {integrity: sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==}
-    engines: {node: '>= 14.14'}
+  /typedoc@0.25.1(typescript@4.9.5):
+    resolution: {integrity: sha512-c2ye3YUtGIadxN2O6YwPEXgrZcvhlZ6HlhWZ8jQRNzwLPn2ylhdGqdR8HbyDRyALP8J6lmSANILCkkIdNPFxqA==}
+    engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:
-      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0
-      minimatch: 7.4.6
-      shiki: 0.14.3
+      minimatch: 9.0.3
+      shiki: 0.14.4
       typescript: 4.9.5
     dev: true
 


### PR DESCRIPTION
Generate typedoc for @oasisprotocol/sapphire-paratime package and deploy it to api-reference branch.

Related oasis-sdk isssue https://github.com/oasisprotocol/oasis-sdk/pull/1504.

[Preview](https://api.docs.oasis.io/js/sapphire-paratime/)