### PR TITLE
Add Hardhat example script `run-vigil.ts` to CI

### DIFF
--- a/.github/workflows/contracts-test.yaml
+++ b/.github/workflows/contracts-test.yaml
@@ -71,6 +71,11 @@ jobs:
         run: pnpm run test --network sapphire_localnet
         env:
           PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+      - name: hardhat test examples/hardhat
+        working-directory: examples/hardhat
+        run: pnpm hardhat run --network sapphire_localnet scripts/run-vigil.ts
+        env:
+          PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
       - name: hardhat test examples/onchain-signer
         working-directory: examples/onchain-signer
         run: pnpm run test --network sapphire-localnet

--- a/examples/hardhat/scripts/run-vigil.ts
+++ b/examples/hardhat/scripts/run-vigil.ts
@@ -23,11 +23,30 @@ async function main() {
     console.log('failed to fetch secret:', e.message);
   }
   console.log('Waiting...');
+
+  // Manually generate some transactions to increment local Docker
+  // container block
+  if ((await ethers.provider.getNetwork()).name == 'sapphire_localnet') {
+    await generateTraffic(10);
+  }
+
+  await generateTraffic(10);
   await new Promise((resolve) => setTimeout(resolve, 30_000));
   console.log('Checking the secret again');
   await (await vigil.revealSecret(0)).wait(); // Reveal the secret.
   const secret = await vigil.callStatic.revealSecret(0); // Get the value.
   console.log('The secret ingredient is', Buffer.from(secret.slice(2), 'hex').toString());
+}
+
+async function generateTraffic(n: number) {
+  const signer = await ethers.provider.getSigner();
+  for (let i = 0; i < n; i++) {
+    await signer.sendTransaction({
+      to: "0x000000000000000000000000000000000000dEaD",
+      value: ethers.utils.parseEther("1.0"),
+      data: "0x"
+    });
+  };
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Description
Improve the robustness of our example script `run-vigil.ts`. Add this workflow to CI.

Supplant #198 due to GitHub weirdness with closing/reopening PR.

## TODO
- [x] Add test assertion that should fail
- [x] Fix test
- [ ] Close #188 after merging