### PR TITLE
contracts: add gaspad and gasused precompiles

### DIFF
--- a/contracts/contracts/Sapphire.sol
+++ b/contracts/contracts/Sapphire.sol
@@ -23,6 +23,10 @@ library Sapphire {
         0x0100000000000000000000000000000000000007;
     address internal constant CURVE25519_PUBLIC_KEY =
         0x0100000000000000000000000000000000000008;
+    address internal constant GAS_USED =
+        0x0100000000000000000000000000000000000009;
+    address internal constant GAS_PAD =
+        0x010000000000000000000000000000000000000a;
 
     // Oasis-specific, general precompiles
     address internal constant SHA512_256 =
@@ -224,6 +228,32 @@ library Sapphire {
         );
         require(success, "verify: failed");
         return abi.decode(v, (bool));
+    }
+
+    /**
+     * @dev Set the current transactions gas usage to a specific amount
+     * @param toAmount Gas usage will be set to this amount
+     * @custom:see @oasisprotocol/oasis-sdk :: precompile/gas.rs :: call_pad_gas
+     *
+     * Will cause a reversion if the current usage is more than the amount
+     */
+    function gaspad(uint128 toAmount) internal view
+    {
+        (bool success,) = GAS_PAD.staticcall(
+            abi.encode(toAmount)
+        );
+        require(success, "verify: failed");
+    }
+
+    /**
+     * @dev Returns the amount of gas currently used by the transaction
+     * @custom:see @oasisprotocol/oasis-sdk :: precompile/gas.rs :: call_gas_used
+     */
+    function gasused() internal view returns (uint64)
+    {
+        (bool success, bytes memory v) = GAS_USED.staticcall("");
+        require(success, "gasused: failed");
+        return abi.decode(v, (uint64));
     }
 }
 

--- a/contracts/contracts/Sapphire.sol
+++ b/contracts/contracts/Sapphire.sol
@@ -237,11 +237,8 @@ library Sapphire {
      *
      * Will cause a reversion if the current usage is more than the amount
      */
-    function gaspad(uint128 toAmount) internal view
-    {
-        (bool success,) = GAS_PAD.staticcall(
-            abi.encode(toAmount)
-        );
+    function gaspad(uint128 toAmount) internal view {
+        (bool success, ) = GAS_PAD.staticcall(abi.encode(toAmount));
         require(success, "verify: failed");
     }
 
@@ -249,8 +246,7 @@ library Sapphire {
      * @dev Returns the amount of gas currently used by the transaction
      * @custom:see @oasisprotocol/oasis-sdk :: precompile/gas.rs :: call_gas_used
      */
-    function gasused() internal view returns (uint64)
-    {
+    function gasused() internal view returns (uint64) {
         (bool success, bytes memory v) = GAS_USED.staticcall("");
         require(success, "gasused: failed");
         return abi.decode(v, (uint64));

--- a/contracts/contracts/Sapphire.sol
+++ b/contracts/contracts/Sapphire.sol
@@ -25,7 +25,7 @@ library Sapphire {
         0x0100000000000000000000000000000000000008;
     address internal constant GAS_USED =
         0x0100000000000000000000000000000000000009;
-    address internal constant GAS_PAD =
+    address internal constant PAD_GAS =
         0x010000000000000000000000000000000000000a;
 
     // Oasis-specific, general precompiles
@@ -237,8 +237,8 @@ library Sapphire {
      *
      * Will cause a reversion if the current usage is more than the amount
      */
-    function gaspad(uint128 toAmount) internal view {
-        (bool success, ) = GAS_PAD.staticcall(abi.encode(toAmount));
+    function padGas(uint128 toAmount) internal view {
+        (bool success, ) = PAD_GAS.staticcall(abi.encode(toAmount));
         require(success, "verify: failed");
     }
 
@@ -246,7 +246,7 @@ library Sapphire {
      * @dev Returns the amount of gas currently used by the transaction
      * @custom:see @oasisprotocol/oasis-sdk :: precompile/gas.rs :: call_gas_used
      */
-    function gasused() internal view returns (uint64) {
+    function gasUsed() internal view returns (uint64) {
         (bool success, bytes memory v) = GAS_USED.staticcall("");
         require(success, "gasused: failed");
         return abi.decode(v, (uint64));

--- a/contracts/contracts/tests/Gas.sol
+++ b/contracts/contracts/tests/Gas.sol
@@ -7,15 +7,11 @@ import {Sapphire} from "../Sapphire.sol";
 contract GasTests {
     bytes32 tmp;
 
-    function testConstantTime(uint useGas, uint128 padGasAmount)
-        external
-    {
-        if( useGas == 1 )
-        {
+    function testConstantTime(uint256 useGas, uint128 padGasAmount) external {
+        if (useGas == 1) {
             bytes32 x;
 
-            for( uint i = 0; i < 100; i++ )
-            {
+            for (uint256 i = 0; i < 100; i++) {
                 x = keccak256(abi.encodePacked(x, tmp));
             }
 

--- a/contracts/contracts/tests/Gas.sol
+++ b/contracts/contracts/tests/Gas.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.0;
+
+import {Sapphire} from "../Sapphire.sol";
+
+contract GasTests {
+    bytes32 tmp;
+
+    function testConstantTime(uint useGas, uint128 padGasAmount)
+        external
+    {
+        if( useGas == 1 )
+        {
+            bytes32 x;
+
+            for( uint i = 0; i < 100; i++ )
+            {
+                x = keccak256(abi.encodePacked(x, tmp));
+            }
+
+            tmp = x;
+        }
+
+        Sapphire.gaspad(padGasAmount);
+    }
+}

--- a/contracts/contracts/tests/Gas.sol
+++ b/contracts/contracts/tests/Gas.sol
@@ -18,6 +18,6 @@ contract GasTests {
             tmp = x;
         }
 
-        Sapphire.gaspad(padGasAmount);
+        Sapphire.padGas(padGasAmount);
     }
 }

--- a/contracts/test/gas.ts
+++ b/contracts/test/gas.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { GasTests__factory } from '../typechain-types/factories/contracts/tests/Gas.sol';
+import { GasTests } from '../typechain-types/contracts/tests/Gas.sol/GasTests';
+
+describe('Gas Padding', function () {
+    let contract: GasTests;
+
+    before(async () => {
+        const factory = (await ethers.getContractFactory(
+            'GasTests',
+        )) as GasTests__factory;
+        contract = await factory.deploy();
+    });
+
+    it('Gas Padding works as Expected', async () => {
+        const expectedGas = 122735;
+
+        let tx = await contract.testConstantTime(1, 100000);
+        let receipt = await tx.wait();
+        expect(receipt.cumulativeGasUsed).eq(expectedGas);
+
+        tx = await contract.testConstantTime(2, 100000);
+        receipt = await tx.wait();
+        expect(receipt.cumulativeGasUsed).eq(expectedGas);
+
+        tx = await contract.testConstantTime(1, 100000);
+        receipt = await tx.wait();
+        expect(receipt.cumulativeGasUsed).eq(expectedGas);
+
+        // Note: calldata isn't included in gas padding
+        // Thus when the value is 0 it will use 4 gas instead of 16 gas
+        tx = await contract.testConstantTime(0, 100000);
+        receipt = await tx.wait();
+        expect(receipt.cumulativeGasUsed).eq(expectedGas - 12);
+    });
+});

--- a/contracts/test/gas.ts
+++ b/contracts/test/gas.ts
@@ -6,34 +6,34 @@ import { GasTests__factory } from '../typechain-types/factories/contracts/tests/
 import { GasTests } from '../typechain-types/contracts/tests/Gas.sol/GasTests';
 
 describe('Gas Padding', function () {
-    let contract: GasTests;
+  let contract: GasTests;
 
-    before(async () => {
-        const factory = (await ethers.getContractFactory(
-            'GasTests',
-        )) as GasTests__factory;
-        contract = await factory.deploy();
-    });
+  before(async () => {
+    const factory = (await ethers.getContractFactory(
+      'GasTests',
+    )) as GasTests__factory;
+    contract = await factory.deploy();
+  });
 
-    it('Gas Padding works as Expected', async () => {
-        const expectedGas = 122735;
+  it('Gas Padding works as Expected', async () => {
+    const expectedGas = 122735;
 
-        let tx = await contract.testConstantTime(1, 100000);
-        let receipt = await tx.wait();
-        expect(receipt.cumulativeGasUsed).eq(expectedGas);
+    let tx = await contract.testConstantTime(1, 100000);
+    let receipt = await tx.wait();
+    expect(receipt.cumulativeGasUsed).eq(expectedGas);
 
-        tx = await contract.testConstantTime(2, 100000);
-        receipt = await tx.wait();
-        expect(receipt.cumulativeGasUsed).eq(expectedGas);
+    tx = await contract.testConstantTime(2, 100000);
+    receipt = await tx.wait();
+    expect(receipt.cumulativeGasUsed).eq(expectedGas);
 
-        tx = await contract.testConstantTime(1, 100000);
-        receipt = await tx.wait();
-        expect(receipt.cumulativeGasUsed).eq(expectedGas);
+    tx = await contract.testConstantTime(1, 100000);
+    receipt = await tx.wait();
+    expect(receipt.cumulativeGasUsed).eq(expectedGas);
 
-        // Note: calldata isn't included in gas padding
-        // Thus when the value is 0 it will use 4 gas instead of 16 gas
-        tx = await contract.testConstantTime(0, 100000);
-        receipt = await tx.wait();
-        expect(receipt.cumulativeGasUsed).eq(expectedGas - 12);
-    });
+    // Note: calldata isn't included in gas padding
+    // Thus when the value is 0 it will use 4 gas instead of 16 gas
+    tx = await contract.testConstantTime(0, 100000);
+    receipt = await tx.wait();
+    expect(receipt.cumulativeGasUsed).eq(expectedGas - 12);
+  });
 });


### PR DESCRIPTION
Unfortunately this has different semantics than was initially intended as the initial gas cost for the calldata is added after the transaction is executed.

This means that there will be a 12 gas difference, even after padding, between every NULL and non-NULL byte of the calldata. While this has a very small impact and won't reveal too much sensitive information, it will still reveal *some* information about the encrypted calldata.

A suggested workaround is to add `bytes calldata fuz` argument and filling it with one non-zero byte for every zero byte in the other arguments.