### PR TITLE
examples/onchain-signer/test: Add support for Sapphire Testnet/Mainnet

### DIFF
--- a/examples/onchain-signer/hardhat.config.ts
+++ b/examples/onchain-signer/hardhat.config.ts
@@ -38,6 +38,9 @@ const config: HardhatUserConfig = {
     },
   },
   solidity: '0.8.19',
+  mocha: {
+    timeout: 120_000_000, // Sapphire Mainnet/Testnet require more time.
+  },
 };
 
 export default config;

--- a/examples/onchain-signer/test/CommentBox.ts
+++ b/examples/onchain-signer/test/CommentBox.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import hre, { config, ethers } from 'hardhat';
+import { ethers } from 'hardhat';
 import { CommentBox, Gasless } from '../typechain-types';
-import { HDAccountsUserConfig } from 'hardhat/types';
+import { parseEther } from 'ethers/lib/utils';
 
 describe('CommentBox', function () {
   let commentBox: CommentBox;
@@ -13,27 +13,8 @@ describe('CommentBox', function () {
     await commentBox.deployed();
 
     const GaslessFactory = await ethers.getContractFactory('Gasless');
-    gasless = await GaslessFactory.deploy();
+    gasless = await GaslessFactory.deploy({value: parseEther('0.1')});
     await gasless.deployed();
-
-    // Derive the private key of the 1st (counting from 0) builtin hardhat test account.
-    const accounts = config.networks.hardhat
-      .accounts as unknown as HDAccountsUserConfig;
-    const wallet1 = ethers.Wallet.fromMnemonic(
-      accounts.mnemonic,
-      accounts.path + `/1`,
-    );
-
-    // Use it as the relayer private key.
-    await expect(
-      await gasless.setKeypair({
-        addr: wallet1.address,
-        secret: Uint8Array.from(
-          Buffer.from(wallet1.privateKey.substring(2), 'hex'),
-        ),
-        nonce: ethers.provider.getTransactionCount(wallet1.address),
-      }),
-    ).not.to.be.reverted;
   });
 
   it('Should comment', async function () {
@@ -41,6 +22,15 @@ describe('CommentBox', function () {
 
     const tx = await commentBox.comment('Hello, world!');
     await tx.wait();
+
+    // Sapphire Mainnet/Testnet: Wait a few moments for nodes to catch up.
+    if (
+      (await gasless.provider.getNetwork()).chainId == 23294 ||
+      (await gasless.provider.getNetwork()).chainId == 23295
+    ) {
+      await new Promise((r) => setTimeout(r, 6_000));
+    }
+
     expect(await commentBox.commentCount()).eq(prevCommentCount.add(1));
   });
 
@@ -48,16 +38,27 @@ describe('CommentBox', function () {
     // You can set up sapphire-dev image and run the test like this:
     // docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-dev -to 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
     // npx hardhat test --grep proxy --network sapphire-localnet
-    if ((await ethers.provider.getNetwork()).chainId == 1337) {
+    if ((await gasless.provider.getNetwork()).chainId == 1337) {
       this.skip();
     }
+
     const innercall = commentBox.interface.encodeFunctionData('comment', [
       'Hello, free world!',
     ]);
+
+    // Sapphire Mainnet/Testnet: Wait a few moments for nodes to catch up.
+    if (
+      (await gasless.provider.getNetwork()).chainId == 23294 ||
+      (await gasless.provider.getNetwork()).chainId == 23295
+    ) {
+      await new Promise((r) => setTimeout(r, 6_000));
+    }
+
     const tx = await gasless.makeProxyTx(commentBox.address, innercall);
 
-    const plainResp = await gasless.provider.sendTransaction(tx);
-    const receipt = await ethers.provider.waitForTransaction(plainResp.hash);
+    // TODO: https://github.com/oasisprotocol/sapphire-paratime/issues/179
+    const response = await gasless.provider.sendTransaction(tx);
+    const receipt = await gasless.provider.waitForTransaction(response.hash);
     if (!receipt || receipt.status != 1) throw new Error('tx failed');
   });
 });


### PR DESCRIPTION
This PR makes examples/onchain-signer tests actually pass on sapphire-testnet.

Merge after #175 since we use the wrapped provider for gasless tx.