### PR TITLE
Fix missing build on publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,5 +22,7 @@ jobs:
       - name: Publish ${{ github.ref_name }} to NPM
         uses: JS-DevTools/npm-publish@v3
         with:
+          # Build runs as a prepublish script
+          ignore-scripts: false
           token: ${{ secrets.NPM_TOKEN }}
           package: ${{ steps.extract-tag.outputs.NPM_PACKAGE }}


### PR DESCRIPTION
#### Description
#203 had a bug where the build step was skipped when publishing.

Specifically, we need to explicitly set `ignore-scripts` to `false` for this [action](https://github.com/JS-DevTools/npm-publish#action-usage). We can see that the only `prepublish` step is to `build`.

https://github.com/oasisprotocol/sapphire-paratime/blob/bcecd07d135adaa85897973087cbe6d380baa07d/clients/js/package.json#L41

I believe that using a separate workflow build step is unnecessary.