### PR TITLE
Hardhat: Use sapphire and sapphire-testnet for network names

### DIFF
--- a/.github/workflows/contracts-test.yaml
+++ b/.github/workflows/contracts-test.yaml
@@ -68,7 +68,7 @@ jobs:
           forge doc --build
       - name: hardhat test examples/hardhat
         working-directory: examples/hardhat
-        run: pnpm hardhat run --network sapphire_localnet scripts/run-vigil.ts
+        run: pnpm hardhat run --network sapphire-localnet scripts/run-vigil.ts
         env:
           PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
       - name: hardhat test examples/onchain-signer

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -66,7 +66,7 @@ const config: HardhatUserConfig = {
         ? [process.env.SAPPHIRE_TESTNET_PRIVATE_KEY]
         : [],
     },
-    'sapphire-mainnet': {
+    sapphire: {
       url: 'https://sapphire.oasis.io',
       chainId: 0x5afe,
       accounts: process.env.SAPPHIRE_MAINNET_PRIVATE_KEY

--- a/examples/hardhat-boilerplate/README.md
+++ b/examples/hardhat-boilerplate/README.md
@@ -20,7 +20,7 @@ https://faucet.testnet.oasis.dev/ and request some.
 Next, run this to deploy your contract on Sapphire Testnet:
 
 ```sh
-PRIVATE_KEY=your_sapphire_private_key_in_hex npx hardhat run scripts/deploy.js --network sapphire_testnet
+PRIVATE_KEY=your_sapphire_private_key_in_hex npx hardhat run scripts/deploy.js --network sapphire-testnet
 ```
 
 Finally, run the frontend with:

--- a/examples/hardhat-boilerplate/hardhat.config.js
+++ b/examples/hardhat-boilerplate/hardhat.config.js
@@ -13,21 +13,21 @@ module.exports = {
     hardhat: {
       chainId: 1337 // We set 1337 to make interacting with MetaMask simpler
     },
-    sapphire_mainnet: {
+    sapphire: {
       url: "https://sapphire.oasis.io",
       accounts: process.env.PRIVATE_KEY
         ? [process.env.PRIVATE_KEY]
         : [],
       chainId: 0x5afe,
     },
-    sapphire_testnet: {
+    'sapphire-testnet': {
       url: "https://testnet.sapphire.oasis.dev",
       accounts: process.env.PRIVATE_KEY
         ? [process.env.PRIVATE_KEY]
         : [],
       chainId: 0x5aff,
     },
-    sapphire_localnet: {
+    'sapphire-localnet': {
       url: "http://localhost:8545",
       accounts: process.env.PRIVATE_KEY
         ? [process.env.PRIVATE_KEY]

--- a/examples/hardhat/hardhat.config.ts
+++ b/examples/hardhat/hardhat.config.ts
@@ -16,21 +16,21 @@ const config: HardhatUserConfig = {
     },
   },
   networks: {
-    'sapphire_mainnet': {
+    sapphire: {
       url: 'https://sapphire.oasis.io',
       accounts: process.env.PRIVATE_KEY
         ? [process.env.PRIVATE_KEY]
         : [],
       chainId: 0x5afe
     },
-    'sapphire_testnet': {
+    'sapphire-testnet': {
       url: 'https://testnet.sapphire.oasis.dev',
       accounts: process.env.PRIVATE_KEY
         ? [process.env.PRIVATE_KEY]
         : [],
       chainId: 0x5aff
     },
-    'sapphire_localnet': {
+    'sapphire-localnet': {
       url: 'http://localhost:8545',
       accounts: process.env.PRIVATE_KEY
         ? [process.env.PRIVATE_KEY]


### PR DESCRIPTION
Make Hardhat network names consistent with the ones that are registered in the [Ethereum chain list](https://github.com/ethereum-lists/chains/tree/master/_data/chains). This is currently:
- sapphire
- sapphire-testnet
- emerald
- emerald-testnet

In the future, we may want to register `sapphire-localnet` and `emerald-localnet` as well, rename the docker image from `sapphire-dev` -> `sapphire-localnet` and update the contracts CI scripts accordingly.