### PR TITLE
contracts: hashing tests weren't running, which meant sha384 error wasn't caught

### DIFF
--- a/contracts/contracts/Sapphire.sol
+++ b/contracts/contracts/Sapphire.sol
@@ -34,7 +34,7 @@ library Sapphire {
     address internal constant SHA512 =
         0x0100000000000000000000000000000000000102;
     address internal constant SHA384 =
-        0x0100000000000000000000000000000000000103;
+        0x0100000000000000000000000000000000000104;
 
     type Curve25519PublicKey is bytes32;
     type Curve25519SecretKey is bytes32;

--- a/contracts/test/hashes.ts
+++ b/contracts/test/hashes.ts
@@ -32,14 +32,14 @@ describe('Hashes', () => {
   }
 
   it('SHA512-256', async () => {
-    testHashes('SHA512-256', contract.testSHA512_256.bind(contract));
+    await testHashes('SHA512-256', contract.testSHA512_256.bind(contract));
   });
 
   it('SHA512', async () => {
-    testHashes('SHA512', contract.testSHA512.bind(contract));
+    await testHashes('SHA512', contract.testSHA512.bind(contract));
   });
 
   it('SHA384', async () => {
-    testHashes('SHA384', contract.testSHA384.bind(contract));
+    await testHashes('SHA384', contract.testSHA384.bind(contract));
   });
 });


### PR DESCRIPTION
Closes #228