### PR TITLE
Update addresses.md with wrose.oasis.io link

### DIFF
--- a/docs/addresses.md
+++ b/docs/addresses.md
@@ -7,7 +7,7 @@ description: List of Standard Contract Addresses
 | Name         | Mainnet Address                            | Testnet Address                            | Verify                                                           | Source                          |
 |--------------|--------------------------------------------|--------------------------------------------|------------------------------------------------------------------|---------------------------------|
 | [Multicall V3][multicall] | `0xcA11bde05977b3631167028862bE2a173976CA11` | - | [Mainnet][multicall-verify-mainnet] | [Multicall3.sol][multicall-source] |
-| Wrapped ROSE | `0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3` | `0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94` | [Mainnet][wrose-verify-mainnet], [Testnet][wrose-verify-testnet] | [WrappedROSE.sol][wrose-source] |
+| [Wrapped ROSE](https://wrose.oasis.io/) | `0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3` | `0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94` | [Mainnet][wrose-verify-mainnet], [Testnet][wrose-verify-testnet] | [WrappedROSE.sol][wrose-source] |
 
 [multicall-source]: https://github.com/mds1/multicall/blob/main/src/Multicall3.sol
 [multicall-verify-mainnet]: https://sourcify.dev/#/lookup/0xcA11bde05977b3631167028862bE2a173976CA11

--- a/docs/addresses.md
+++ b/docs/addresses.md
@@ -7,12 +7,13 @@ description: List of Standard Contract Addresses
 | Name         | Mainnet Address                            | Testnet Address                            | Verify                                                           | Source                          |
 |--------------|--------------------------------------------|--------------------------------------------|------------------------------------------------------------------|---------------------------------|
 | [Multicall V3][multicall] | `0xcA11bde05977b3631167028862bE2a173976CA11` | - | [Mainnet][multicall-verify-mainnet] | [Multicall3.sol][multicall-source] |
-| [Wrapped ROSE](https://wrose.oasis.io/) | `0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3` | `0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94` | [Mainnet][wrose-verify-mainnet], [Testnet][wrose-verify-testnet] | [WrappedROSE.sol][wrose-source] |
+| [Wrapped ROSE][wrose-dapp] | `0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3` | `0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94` | [Mainnet][wrose-verify-mainnet], [Testnet][wrose-verify-testnet] | [WrappedROSE.sol][wrose-source] |
 
 [multicall-source]: https://github.com/mds1/multicall/blob/main/src/Multicall3.sol
 [multicall-verify-mainnet]: https://sourcify.dev/#/lookup/0xcA11bde05977b3631167028862bE2a173976CA11
 [multicall]: https://multicall3.com/
 
+[wrose-dapp]: https://wrose.oasis.io/
 [wrose-source]: https://github.com/oasisprotocol/sapphire-paratime/blob/main/contracts/contracts/WrappedROSE.sol
 [wrose-verify-mainnet]: https://sourcify.dev/#/lookup/0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3
 [wrose-verify-testnet]: https://sourcify.dev/#/lookup/0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94


### PR DESCRIPTION
This adds the wROSE wrapper dApp link to the documentation in the standard addresses section.