### PR TITLE
contracts: remove custom reverts and ERC2771Context

### DIFF
--- a/contracts/contracts/opl/Enclave.sol
+++ b/contracts/contracts/opl/Enclave.sol
@@ -1,37 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import {ERC2771Context} from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
-import {Context} from "@openzeppelin/contracts/utils/Context.sol";
-
 import {Endpoint} from "./Endpoint.sol";
 
 /**
  * @title OPL Enclave
  * @dev The Sapphire-side of an OPL dapp.
  */
-contract Enclave is Endpoint, ERC2771Context {
+contract Enclave is Endpoint {
     constructor(address _host, bytes32 _hostChain)
         Endpoint(_host, _hostChain)
-        ERC2771Context(block.chainid == 0x5aff ? address(0) : address(0)) // TODO: insert gsn deployment
     {} // solhint-disable-line no-empty-blocks
-
-    // The following functions are overrides required by Solidity.
-    function _msgData()
-        internal
-        view
-        override(Context, ERC2771Context)
-        returns (bytes calldata)
-    {
-        return ERC2771Context._msgData();
-    }
-
-    function _msgSender()
-        internal
-        view
-        override(Context, ERC2771Context)
-        returns (address)
-    {
-        return ERC2771Context._msgSender();
-    }
 }

--- a/contracts/contracts/opl/Endpoint.sol
+++ b/contracts/contracts/opl/Endpoint.sol
@@ -119,7 +119,7 @@ contract BaseEndpoint is Context {
         address // executor
     ) external payable returns (uint256) {
         // The method can only be called by the message bus;
-        require(msg.sender == messageBus, "NotMessageBus");
+        require(_msgSender() == messageBus, "NotMessageBus");
         // Messages may only be sent by the remote endpoint (Enclave or Host).
         require(
             _sender == remote && _senderChainId == remoteChainId,

--- a/contracts/contracts/opl/Endpoint.sol
+++ b/contracts/contracts/opl/Endpoint.sol
@@ -98,7 +98,7 @@ contract BaseEndpoint is Context {
                 address(this) // executor
             );
             // Receiving endpoint did not return successfully.
-            require( celerStatus == 1, "ReceiverError" );
+            require(celerStatus == 1, "ReceiverError");
             if (fee > 0) payable(0).transfer(fee); // burn the fee, for fidelity
         } else {
             ICelerMessageBus(messageBus).sendMessage{value: fee}(
@@ -121,13 +121,16 @@ contract BaseEndpoint is Context {
         // The method can only be called by the message bus;
         require(msg.sender == messageBus, "NotMessageBus");
         // Messages may only be sent by the remote endpoint (Enclave or Host).
-        require( _sender == remote && _senderChainId == remoteChainId, "NotRemoteEndpoint" );
+        require(
+            _sender == remote && _senderChainId == remoteChainId,
+            "NotRemoteEndpoint"
+        );
         bytes4 epSel = bytes4(_message[:4]);
         uint256 seq = uint256(bytes32(_message[4:36]));
         bytes calldata message = _message[36:];
         if (inOrder) {
             // This message arrived too early or late.
-            require( seq == rxSeq, "WrongSeqNum" );
+            require(seq == rxSeq, "WrongSeqNum");
             ++rxSeq;
         }
         function(bytes calldata) returns (Result) ep = endpoints[epSel];


### PR DESCRIPTION
The Celer IM message bus doesn't support custom errors in Solidity, this means that any reverts thrown in the critical path from the OPL code when receiving a message will be ignored and replaced with 'reverted silently' by the Message Bus.
 - See: https://github.com/celer-network/sgn-v2-contracts/blob/main/contracts/libraries/Utils.sol#L8

This also removes the unused ERC2771Context from the Enclave contract. (Contracts can still suport ERC2771Context, or other meta-tx standard).

I've updated `BaseEndpoint` to use `_msgSender()` from `Context` so inheriting contracts can override it with their meta-tx scheme of choice.