### PR TITLE
ci: JS-DevTools/npm-publish requires pnpm to publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "18"
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 8
+          run_install: false
       - name: Extract package from tag
         id: extract-tag
         run: |


### PR DESCRIPTION
This should fix the following error:

```
Run JS-DevTools/npm-publish@v3
  with:
    ignore-scripts: false
    token: ***
    package: clients/js
Error: NpmCallError: Call to "npm publish" exited with non-zero exit code 127
sh: 1: pnpm: not found
```