### PR TITLE
docs: updated README.md with extra badges & links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![ci-lint](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/ci-lint.yaml/badge.svg)](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/ci-lint.yaml)
 [![ci-test](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/ci-test.yaml/badge.svg)](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/ci-test.yaml)
+[![ci-test](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/contracts-test.yaml/badge.svg)](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/contracts-test.yaml)
 
 The Sapphire ParaTime is the official confidential EVM Compatible ParaTime
 providing a smart contract development environment with EVM compatibility
@@ -9,19 +10,19 @@ on the Oasis Network.
 
 This monorepo includes the source code for the following Sapphire packages:
 
-- TypeScript [client](https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime) ![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-paratime)
-- Golang [client](https://pkg.go.dev/github.com/oasisprotocol/sapphire-paratime)
-![GitHub go.mod Go version (branch & subdirectory of monorepo)](https://img.shields.io/github/go-mod/go-version/oasisprotocol/sapphire-paratime?filename=clients%2Fgo%2Fgo.mod)
-
-- Solidity [smart contracts](https://www.npmjs.com/package/@oasisprotocol/sapphire-contracts) ![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-contracts)
-- Hardhat [plugin](https://www.npmjs.com/package/@oasisprotocol/sapphire-hardhat) ![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-hardhat)
+| Language | Version | Size | Downloads |
+| -------- | ------- | ---- | --------- |
+| [TypeScript client](https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime) | [![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-paratime)](https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime) | [![size](https://img.shields.io/bundlephobia/minzip/@oasisprotocol/sapphire-paratime)](https://bundlephobia.com/package/@oasisprotocol/sapphire-paratime) | ![downloads](https://img.shields.io/npm/dm/@oasisprotocol/sapphire-paratime.svg?style=flat-square) |
+| [Golang client](https://pkg.go.dev/github.com/oasisprotocol/sapphire-paratime) | [![GitHub go.mod Go version (branch & subdirectory of monorepo)](https://img.shields.io/github/go-mod/go-version/oasisprotocol/sapphire-paratime?filename=clients%2Fgo%2Fgo.mod)](https://pkg.go.dev/github.com/oasisprotocol/sapphire-paratime) | |
+| [Solidity smart contracts](https://www.npmjs.com/package/@oasisprotocol/sapphire-contracts) | [![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-contracts)](https://www.npmjs.com/package/@oasisprotocol/sapphire-contracts) |  | ![downloads](https://img.shields.io/npm/dm/@oasisprotocol/sapphire-contracts.svg?style=flat-square) |
+| [Hardhat plugin](https://www.npmjs.com/package/@oasisprotocol/sapphire-hardhat) | [![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-hardhat)](https://www.npmjs.com/package/@oasisprotocol/sapphire-hardhat) | [![size](https://img.shields.io/bundlephobia/minzip/@oasisprotocol/sapphire-hardhat)](https://bundlephobia.com/package/@oasisprotocol/sapphire-hardhat) | ![downloads](https://img.shields.io/npm/dm/@oasisprotocol/sapphire-hardhat.svg?style=flat-square) |
 
 ## Layout
 
 This repository includes all relevant Sapphire and dependencies organized into
 the following directories:
 
-- [`clients`](./clients): the Go and TypeScript clients
+- [`clients`](./clients): the Go, Python and TypeScript clients
 - [`contracts`](./contracts): Sapphire and [OPL](https://docs.oasis.io/dapp/opl/) smart contracts
 - [`docs`](./docs): topic-oriented Sapphire documentation
 - [`examples`](./examples/): sample code snippets in popular Ethereum

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sapphire Paratime
 
-![license](https://img.shields.io/github/license/oasisprotocol/sapphire-paratime.svg)
+[![license](https://img.shields.io/github/license/oasisprotocol/sapphire-paratime.svg)](https://github.com/oasisprotocol/sapphire-paratime/blob/main/LICENSE)
 [![ci-lint](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/ci-lint.yaml/badge.svg)](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/ci-lint.yaml)
 [![ci-test](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/ci-test.yaml/badge.svg)](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/ci-test.yaml)
 [![ci-test](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/contracts-test.yaml/badge.svg)](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/contracts-test.yaml)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Sapphire Paratime
 
+![license](https://img.shields.io/github/license/oasisprotocol/sapphire-paratime.svg)
 [![ci-lint](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/ci-lint.yaml/badge.svg)](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/ci-lint.yaml)
 [![ci-test](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/ci-test.yaml/badge.svg)](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/ci-test.yaml)
 [![ci-test](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/contracts-test.yaml/badge.svg)](https://github.com/oasisprotocol/sapphire-paratime/actions/workflows/contracts-test.yaml)
@@ -12,10 +13,10 @@ This monorepo includes the source code for the following Sapphire packages:
 
 | Language | Version | Size | Downloads |
 | -------- | ------- | ---- | --------- |
-| [TypeScript client](https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime) | [![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-paratime)](https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime) | [![size](https://img.shields.io/bundlephobia/minzip/@oasisprotocol/sapphire-paratime)](https://bundlephobia.com/package/@oasisprotocol/sapphire-paratime) | ![downloads](https://img.shields.io/npm/dm/@oasisprotocol/sapphire-paratime.svg?style=flat-square) |
+| [TypeScript client](https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime) | [![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-paratime)](https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime) | [![size](https://img.shields.io/bundlephobia/minzip/@oasisprotocol/sapphire-paratime)](https://bundlephobia.com/package/@oasisprotocol/sapphire-paratime) | ![downloads](https://img.shields.io/npm/dm/@oasisprotocol/sapphire-paratime.svg) |
 | [Golang client](https://pkg.go.dev/github.com/oasisprotocol/sapphire-paratime) | [![GitHub go.mod Go version (branch & subdirectory of monorepo)](https://img.shields.io/github/go-mod/go-version/oasisprotocol/sapphire-paratime?filename=clients%2Fgo%2Fgo.mod)](https://pkg.go.dev/github.com/oasisprotocol/sapphire-paratime) | |
-| [Solidity smart contracts](https://www.npmjs.com/package/@oasisprotocol/sapphire-contracts) | [![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-contracts)](https://www.npmjs.com/package/@oasisprotocol/sapphire-contracts) |  | ![downloads](https://img.shields.io/npm/dm/@oasisprotocol/sapphire-contracts.svg?style=flat-square) |
-| [Hardhat plugin](https://www.npmjs.com/package/@oasisprotocol/sapphire-hardhat) | [![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-hardhat)](https://www.npmjs.com/package/@oasisprotocol/sapphire-hardhat) | [![size](https://img.shields.io/bundlephobia/minzip/@oasisprotocol/sapphire-hardhat)](https://bundlephobia.com/package/@oasisprotocol/sapphire-hardhat) | ![downloads](https://img.shields.io/npm/dm/@oasisprotocol/sapphire-hardhat.svg?style=flat-square) |
+| [Solidity smart contracts](https://www.npmjs.com/package/@oasisprotocol/sapphire-contracts) | [![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-contracts)](https://www.npmjs.com/package/@oasisprotocol/sapphire-contracts) |  | ![downloads](https://img.shields.io/npm/dm/@oasisprotocol/sapphire-contracts.svg) |
+| [Hardhat plugin](https://www.npmjs.com/package/@oasisprotocol/sapphire-hardhat) | [![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-hardhat)](https://www.npmjs.com/package/@oasisprotocol/sapphire-hardhat) | [![size](https://img.shields.io/bundlephobia/minzip/@oasisprotocol/sapphire-hardhat)](https://bundlephobia.com/package/@oasisprotocol/sapphire-hardhat) | ![downloads](https://img.shields.io/npm/dm/@oasisprotocol/sapphire-hardhat.svg) |
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,34 @@ on the Oasis Network.
 
 This monorepo includes the source code for the following Sapphire packages:
 
-| Sub-Project | Version | Size | Downloads |
-| -------- | ------- | ---- | --------- |
-| [TypeScript client](https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime) | [![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-paratime)](https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime) | [![size](https://img.shields.io/bundlephobia/minzip/@oasisprotocol/sapphire-paratime)](https://bundlephobia.com/package/@oasisprotocol/sapphire-paratime) | ![downloads](https://img.shields.io/npm/dm/@oasisprotocol/sapphire-paratime.svg) |
-| [Golang client](https://pkg.go.dev/github.com/oasisprotocol/sapphire-paratime) | [![GitHub go.mod Go version (branch & subdirectory of monorepo)](https://img.shields.io/github/go-mod/go-version/oasisprotocol/sapphire-paratime?filename=clients%2Fgo%2Fgo.mod)](https://pkg.go.dev/github.com/oasisprotocol/sapphire-paratime) | |
-| [Solidity smart contracts](https://www.npmjs.com/package/@oasisprotocol/sapphire-contracts) | [![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-contracts)](https://www.npmjs.com/package/@oasisprotocol/sapphire-contracts) |  | ![downloads](https://img.shields.io/npm/dm/@oasisprotocol/sapphire-contracts.svg) |
-| [Hardhat plugin](https://www.npmjs.com/package/@oasisprotocol/sapphire-hardhat) | [![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-hardhat)](https://www.npmjs.com/package/@oasisprotocol/sapphire-hardhat) | [![size](https://img.shields.io/bundlephobia/minzip/@oasisprotocol/sapphire-hardhat)](https://bundlephobia.com/package/@oasisprotocol/sapphire-hardhat) | ![downloads](https://img.shields.io/npm/dm/@oasisprotocol/sapphire-hardhat.svg) |
+| Sub-Project                               | Version                                        | Size                                          | Downloads                         |
+| ----------------------------------------- | ---------------------------------------------- | --------------------------------------------- | --------------------------------- |
+| [TypeScript client][client-npm]           | [![version][client-version]][client-npm]       | [![size][client-size]][client-bundlephobia]   | ![downloads][client-downloads]    |
+| [Go client][go-pkg]                       | [![version][go-version]][go-pkg]               |                                               |                                   |
+| [Solidity smart contracts][contracts-npm] | [![version][contracts-version]][contracts-npm] |                                               | ![downloads][contracts-downloads] |
+| [Hardhat plugin][hardhat-npm]             | [![version][hardhat-version]][hardhat-npm]     | [![size][hardhat-size]][hardhat-bundlephobia] | ![downloads][hardhat-downloads]   |
+
+
+[go-pkg]: https://pkg.go.dev/github.com/oasisprotocol/sapphire-paratime
+
+[hardhat-npm]: https://www.npmjs.com/package/@oasisprotocol/sapphire-hardhat
+[contracts-npm]: https://www.npmjs.com/package/@oasisprotocol/sapphire-contracts
+[client-npm]: https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime
+
+[go-version]: https://img.shields.io/github/go-mod/go-version/oasisprotocol/sapphire-paratime?filename=clients%2Fgo%2Fgo.mod
+[hardhat-version]: https://img.shields.io/npm/v/@oasisprotocol/sapphire-hardhat
+[contracts-version]: https://img.shields.io/npm/v/@oasisprotocol/sapphire-contracts
+[client-version]: https://img.shields.io/npm/v/@oasisprotocol/sapphire-paratime
+
+[hardhat-size]: https://img.shields.io/bundlephobia/minzip/@oasisprotocol/sapphire-hardhat
+[client-size]: https://img.shields.io/bundlephobia/minzip/@oasisprotocol/sapphire-paratime
+
+[hardhat-bundlephobia]: https://bundlephobia.com/package/@oasisprotocol/sapphire-hardhat
+[client-bundlephobia]: https://bundlephobia.com/package/@oasisprotocol/sapphire-paratime
+
+[hardhat-downloads]: https://img.shields.io/npm/dm/@oasisprotocol/sapphire-hardhat.svg
+[contracts-downloads]: https://img.shields.io/npm/dm/@oasisprotocol/sapphire-contracts.svg
+[client-downloads]: https://img.shields.io/npm/dm/@oasisprotocol/sapphire-paratime.svg
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ on the Oasis Network.
 
 This monorepo includes the source code for the following Sapphire packages:
 
-| Language | Version | Size | Downloads |
+| Sub-Project | Version | Size | Downloads |
 | -------- | ------- | ---- | --------- |
 | [TypeScript client](https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime) | [![npm](https://img.shields.io/npm/v/@oasisprotocol/sapphire-paratime)](https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime) | [![size](https://img.shields.io/bundlephobia/minzip/@oasisprotocol/sapphire-paratime)](https://bundlephobia.com/package/@oasisprotocol/sapphire-paratime) | ![downloads](https://img.shields.io/npm/dm/@oasisprotocol/sapphire-paratime.svg) |
 | [Golang client](https://pkg.go.dev/github.com/oasisprotocol/sapphire-paratime) | [![GitHub go.mod Go version (branch & subdirectory of monorepo)](https://img.shields.io/github/go-mod/go-version/oasisprotocol/sapphire-paratime?filename=clients%2Fgo%2Fgo.mod)](https://pkg.go.dev/github.com/oasisprotocol/sapphire-paratime) | |


### PR DESCRIPTION
[Preview](https://github.com/oasisprotocol/sapphire-paratime/tree/CedarMist/bundlephobia)

This adds:

 * Monthly downloads (for NPM packages)
 * Bundle size (for JS packages)
 * Table instead of list for badges
 * Badge for contracts-test CI step
 * License icon

Inspiration: 

 * https://github.com/privacy-scaling-explorations/zk-kit