### PR TITLE
fix: Invalid messageBus address for Sapphire Mainnet

### DIFF
--- a/contracts/contracts/opl/Endpoint.sol
+++ b/contracts/contracts/opl/Endpoint.sol
@@ -267,7 +267,7 @@ function _getChainConfig(uint256 _chainId)
         return (0x940dAAbA3F713abFabD79CdD991466fe698CBe54, false);
     if (_chainId == 0x5afe)
         // sapphire
-        return (0x9B36f165baB9ebe611d491180418d8De4b8f3a1f, false);
+        return (0x9Bb46D5100d2Db4608112026951c9C965b233f4D, false);
     if (_chainId == 0x5aff)
         // sapphire testnet
         return (0x9Bb46D5100d2Db4608112026951c9C965b233f4D, true);


### PR DESCRIPTION
The Celer MessageBus address seems to be set to cBridge address for the Sapphire Mainnet in the OPL code.

The correct one: https://im-docs.celer.network/developer/contract-addresses-and-rpc-info#oasis-sapphire-23294

The currently used one: https://github.com/oasisprotocol/sapphire-paratime/blob/3cd6a601b7fd5e27c3830483cebfe65497b51785/contracts/contracts/opl/Endpoint.sol#L270C17-L270C59