### PR TITLE
fix: Rename sapphire-dev to sapphire-localnet

### DIFF
--- a/.github/workflows/contracts-test.yaml
+++ b/.github/workflows/contracts-test.yaml
@@ -10,8 +10,8 @@ jobs:
   contracts-test:
     runs-on: ubuntu-latest
     services:
-      sapphire-dev-ci:
-        image: ghcr.io/oasisprotocol/sapphire-dev:latest
+      sapphire-localnet-ci:
+        image: ghcr.io/oasisprotocol/sapphire-localnet:latest
         ports:
           - 8545:8545
           - 8546:8546
@@ -66,7 +66,7 @@ jobs:
         run: pnpm build
       - name: Test contracts with Hardhat
         working-directory: contracts
-        run: pnpm hardhat test --network sapphire-dev-ci
+        run: pnpm hardhat test --network sapphire-localnet-ci
       - name: Build docs
         working-directory: contracts
         run: |

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -73,12 +73,12 @@ const config: HardhatUserConfig = {
         ? [process.env.SAPPHIRE_MAINNET_PRIVATE_KEY]
         : [],
     },
-    'sapphire-dev-ci': {
+    'sapphire-localnet-ci': {
       url: `http://127.0.0.1:8545`,
       chainId: 0x5afd,
       accounts: TEST_HDWALLET,
     },
-    'sapphire-dev': {
+    'sapphire-localnet': {
       url: 'http://localhost:8545',
       chainId: 0x5afd,
       accounts: TEST_HDWALLET,

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -294,7 +294,7 @@ You can also explore other verification methods on Sourcify by reading the
 ## Running a Private Oasis Network Locally
 
 For convenient development and testing of your dApps the Oasis team prepared
-the [ghcr.io/oasisprotocol/sapphire-dev][sapphire-dev] Docker image which brings you a
+the [ghcr.io/oasisprotocol/sapphire-localnet][sapphire-localnet] Docker image which brings you a
 complete Oasis stack to your desktop. The Localnet Sapphire instance **mimics
 confidential transactions**, but it does not run in a trusted execution
 environment nor does it require Intel's SGX on your computer. The network is
@@ -311,13 +311,13 @@ isolated from Mainnet or Testnet and consists of:
 To run the image, execute:
 
 ```sh
-docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-dev
+docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-localnet
 ```
 
 After a while, the tool will show you something like this:
 
 ```
-sapphire-dev 2023-02-28-git84730b2 (oasis-core: 22.2.6, sapphire-paratime: 0.4.0, oasis-web3-gateway: 3.2.0-git84730b2)
+sapphire-localnet 2023-02-28-git84730b2 (oasis-core: 22.2.6, sapphire-paratime: 0.4.0, oasis-web3-gateway: 3.2.0-git84730b2)
 
 Starting oasis-net-runner with sapphire...
 Starting postgresql...
@@ -352,9 +352,9 @@ Listening on http://localhost:8545 and ws://localhost:8546
 
 Those familiar with local dApp environments will find the output above similar
 to `geth --dev` or `ganache-cli` commands or the `geth-dev-assistant` npm
-package. [sapphire-dev] will spin up a private Oasis Network locally, generate
-and populate test accounts and make the following Web3 endpoints available for
-you to use:
+package. [sapphire-localnet] will spin up a private Oasis Network locally,
+generate and populate test accounts and make the following Web3 endpoints
+available for you to use:
 - `http://localhost:8545`
 - `ws://localhost:8546`
 
@@ -365,20 +365,20 @@ or to populate just a single wallet, use `-to` flag and pass the mnemonics or
 the wallet addresses. For example
 
 ```sh
-docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-dev -to "bench remain brave curve frozen verify dream margin alarm world repair innocent"
-docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-dev -to "0x75eCF0d4496C2f10e4e9aF3D4d174576Ee9010E2,0xbDA5747bFD65F08deb54cb465eB87D40e51B197E"
+docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-localnet -to "bench remain brave curve frozen verify dream margin alarm world repair innocent"
+docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-localnet -to "0x75eCF0d4496C2f10e4e9aF3D4d174576Ee9010E2,0xbDA5747bFD65F08deb54cb465eB87D40e51B197E"
 ```
 
 :::
 
 :::danger
 
-[sapphire-dev] runs in ephemeral mode. Any smart contract and wallet balance
+[sapphire-localnet] runs in ephemeral mode. Any smart contract and wallet balance
 will be lost after you quit the Docker container!
 
 :::
 
-[sapphire-dev]: https://github.com/oasisprotocol/oasis-web3-gateway/pkgs/container/sapphire-dev
+[sapphire-localnet]: https://github.com/oasisprotocol/oasis-web3-gateway/pkgs/container/sapphire-localnet
 
 ## See also
 

--- a/examples/onchain-signer/README.md
+++ b/examples/onchain-signer/README.md
@@ -30,7 +30,7 @@ To also run confidential tests, you need to spin up a Localnet Sapphire node.
 For example in the Docker:
 
 ```shell
-docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-dev -test-mnemonic -n 5
+docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-localnet -test-mnemonic -n 5
 ```
 
 Then, let tests use the Localnet network:

--- a/examples/onchain-signer/test/CommentBox.ts
+++ b/examples/onchain-signer/test/CommentBox.ts
@@ -53,8 +53,8 @@ describe('CommentBox', function () {
   });
 
   it('Should comment gasless', async function () {
-    // You can set up sapphire-dev image and run the test like this:
-    // docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-dev -to 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+    // You can set up sapphire-localnet image and run the test like this:
+    // docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-localnet -to 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
     // npx hardhat test --grep proxy --network sapphire-localnet
     if ((await gasless.provider.getNetwork()).chainId == 1337) {
       this.skip();


### PR DESCRIPTION
This PR renames sapphire-dev to sapphire-localnet in the docs and CI.

Merge after https://github.com/oasisprotocol/oasis-web3-gateway/pull/507.