### PR TITLE
Update hardhat with peer dependency

### DIFF
--- a/integrations/hardhat/package.json
+++ b/integrations/hardhat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oasisprotocol/sapphire-hardhat",
   "license": "Apache-2.0",
-  "version": "2.17.3",
+  "version": "2.19.4",
   "description": "A Hardhat plugin for developing on the Sapphire ParaTime.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/hardhat",
   "repository": {
@@ -22,19 +22,20 @@
   "scripts": {
     "lint": "prettier --cache --ignore-path .gitignore --check .",
     "format": "prettier --cache --ignore-path .gitignore --write .",
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@oasisprotocol/sapphire-paratime": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "^18.7.18",
-    "hardhat": "^2.19.2",
+    "hardhat": "^2.19.4",
     "prettier": "^2.8.3",
     "ts-node": "^8.10.2",
     "typescript": "^4.9.4"
   },
   "peerDependencies": {
-    "hardhat": "^2.19.2"
+    "hardhat": "2.x"
   }
 }


### PR DESCRIPTION
This will also fix the build problem not including `dist` in the directory.