### PR TITLE
Refactor callDataPublicKey handling

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@oasisprotocol/sapphire-paratime",
   "license": "Apache-2.0",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "The Sapphire ParaTime Web3 integration library.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/clients/js",
   "repository": {

--- a/clients/js/scripts/proxy.ts
+++ b/clients/js/scripts/proxy.ts
@@ -91,9 +91,9 @@ async function onRequest(req: IncomingMessage, response: ServerResponse) {
             epoch = y.body.epoch;
           }
           console.log(
-            'ENCRYPTED'
-            + (isSignedQuery ? ' SIGNED QUERY' : '')
-            + (epoch ? ` +EPOCH(${epoch})` : ''),
+            'ENCRYPTED' +
+              (isSignedQuery ? ' SIGNED QUERY' : '') +
+              (epoch ? ` +EPOCH(${epoch})` : ''),
             req.method,
             req.url,
             body.method,
@@ -123,7 +123,10 @@ async function onRequest(req: IncomingMessage, response: ServerResponse) {
           const epoch = z.body.epoch;
           console.log(
             'ENCRYPTED' + (epoch ? ` +EPOCH(${epoch})` : ''),
-            req.method, req.url, body.method);
+            req.method,
+            req.url,
+            body.method,
+          );
           showResult = true;
         } catch (e: any) {
           if (DIE_ON_UNENCRYPTED) {

--- a/clients/js/src/calldatapublickey.ts
+++ b/clients/js/src/calldatapublickey.ts
@@ -237,7 +237,7 @@ export class KeyFetcher extends AbstractKeyFetcher {
 
   public async cipher(upstream: UpstreamProvider): Promise<Cipher> {
     const kp = await this.fetch(upstream);
-    return X25519DeoxysII.ephemeral(kp.key);
+    return X25519DeoxysII.ephemeral(kp.key, kp.epoch);
   }
 }
 

--- a/clients/js/src/calldatapublickey.ts
+++ b/clients/js/src/calldatapublickey.ts
@@ -1,0 +1,260 @@
+import { getBytes } from 'ethers';
+
+import { UpstreamProvider, EIP1193Provider } from './interfaces.js';
+import { CallError, OASIS_CALL_DATA_PUBLIC_KEY } from './index.js';
+import { NETWORKS } from './networks.js';
+import { Cipher, Mock as MockCipher, X25519DeoxysII } from './cipher.js';
+
+const DEFAULT_PUBKEY_CACHE_EXPIRATION_MS = 60 * 5 * 1000; // 5 minutes in milliseconds
+
+// -----------------------------------------------------------------------------
+// Fetch calldata public key
+// Well use provider when possible, and fallback to HTTP(S)? requests
+// e.g. MetaMask doesn't allow the oasis_callDataPublicKey JSON-RPC method
+
+type RawCallDataPublicKeyResponseResult = {
+  key: string;
+  checksum: string;
+  signature: string;
+  epoch: number;
+};
+
+type RawCallDataPublicKeyResponse = {
+  result: RawCallDataPublicKeyResponseResult;
+};
+
+export interface CallDataPublicKey {
+    // PublicKey is the requested public key.
+    key: Uint8Array;
+
+    // Checksum is the checksum of the key manager state.
+    checksum: Uint8Array;
+
+    // Signature is the Sign(sk, (key || checksum)) from the key manager.
+    signature: Uint8Array;
+
+    // Epoch is the epoch of the ephemeral runtime key.
+    epoch: number | undefined;
+
+    chainId: number;
+
+    fetched: Date;
+
+    cipher: Cipher;
+}
+
+function toCallDataPublicKey(
+  result: RawCallDataPublicKeyResponseResult,
+  chainId: number,
+) {
+    const key = getBytes(result.key);
+    return {
+        key,
+        checksum: getBytes(result.checksum),
+        signature: getBytes(result.signature),
+        epoch: result.epoch,
+        chainId,
+        fetched: new Date(),
+        cipher: X25519DeoxysII.ephemeral(key),
+    } as CallDataPublicKey;
+}
+
+// TODO: remove, this is unecessary, node has `fetch` now?
+async function fetchRuntimePublicKeyNode(
+  gwUrl: string,
+): Promise<RawCallDataPublicKeyResponse> {
+  // Import http or https, depending on the URI scheme.
+  const https = await import(/* webpackIgnore: true */ gwUrl.split(':')[0]);
+
+  const body = makeCallDataPublicKeyBody();
+  return new Promise((resolve, reject) => {
+    const opts = {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-length': body.length,
+      },
+    };
+    const req = https.request(gwUrl, opts, (res: any) => {
+      const chunks: Buffer[] = [];
+      res.on('error', (err: any) => reject(err));
+      res.on('data', (chunk: any) => chunks.push(chunk));
+      res.on('end', () => {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()));
+      });
+    });
+    req.on('error', (err: Error) => reject(err));
+    req.write(body);
+    req.end();
+  });
+}
+
+async function fetchRuntimePublicKeyBrowser(
+  gwUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<RawCallDataPublicKeyResponse> {
+  const res = await fetchImpl(gwUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: makeCallDataPublicKeyBody(),
+  });
+  if (!res.ok) {
+    throw new CallError('Failed to fetch runtime public key.', res);
+  }
+  return await res.json();
+}
+
+function makeCallDataPublicKeyBody(): string {
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id: Math.floor(Math.random() * 1e9),
+    method: OASIS_CALL_DATA_PUBLIC_KEY,
+    params: [],
+  });
+}
+
+export async function fetchRuntimePublicKeyByChainId(
+  chainId: number,
+  opts?: { fetch?: typeof fetch },
+): Promise<CallDataPublicKey> {
+  const { defaultGateway } = NETWORKS[chainId];
+  if (!defaultGateway)
+    throw new Error(
+      `Unable to fetch runtime public key for network with unknown ID: ${chainId}.`,
+    );
+  const fetchImpl = opts?.fetch ?? globalThis?.fetch;
+  const res = await (fetchImpl
+    ? fetchRuntimePublicKeyBrowser(defaultGateway, fetchImpl)
+    : fetchRuntimePublicKeyNode(defaultGateway));
+  return toCallDataPublicKey(res.result, chainId);
+}
+
+function fromQuantity(x: number | string): number {
+  if (typeof x === 'string') {
+    if (x.startsWith('0x')) {
+      return parseInt(x, 16);
+    }
+    return parseInt(x); // Assumed to be base 10
+  }
+  return x;
+}
+
+/**
+ * Picks the most user-trusted runtime calldata public key source based on what
+ * connections are available.
+ *
+ * NOTE: MetaMask does not support Web3 methods it doesn't know about, so we have to
+ *       fall-back to manually querying the default gateway.
+ */
+export async function fetchRuntimePublicKey(
+  upstream: UpstreamProvider,
+): Promise<CallDataPublicKey> {
+  const provider = 'provider' in upstream ? upstream['provider'] : upstream;
+  let chainId: number | undefined;
+  if (provider) {
+    let resp;
+    // It's probably an EIP-1193 provider
+    if ('request' in provider) {
+      const source = provider as EIP1193Provider;
+      chainId = fromQuantity(
+        (await source.request({ method: 'eth_chainId' })) as string | number,
+      );
+      try {
+        resp = await source.request({
+          method: OASIS_CALL_DATA_PUBLIC_KEY,
+          params: [],
+        });
+      } catch (ex) {
+        // don't do anything, move on to try next
+      }
+    }
+    // If it's a `send` provider
+    else if ('send' in provider) {
+      const source = provider as {
+        send: (method: string, params: any[]) => Promise<any>;
+      };
+      chainId = fromQuantity(await source.send('eth_chainId', []));
+      try {
+        resp = await source.send(OASIS_CALL_DATA_PUBLIC_KEY, []);
+      } catch (ex) {
+        // don't do anything, move on to try chainId fetch
+      }
+    }
+    // Otherwise, we have no idea what to do with this provider!
+    else {
+      throw new Error(
+        'fetchRuntimePublicKey does not support non-request non-send provier!',
+      );
+    }
+    if (resp && 'key' in resp) {
+      return toCallDataPublicKey(resp, chainId);
+    }
+  }
+
+  if (!chainId) {
+    throw new Error(
+      'fetchRuntimePublicKey failed to retrieve chainId from provider',
+    );
+  }
+  return fetchRuntimePublicKeyByChainId(chainId);
+}
+
+export abstract class AbstractKeyFetcher {
+    public abstract fetch(upstream: UpstreamProvider): Promise<CallDataPublicKey>;
+    public abstract cipher(upstream: UpstreamProvider): Promise<Cipher>;
+    constructor() {}
+}
+
+export class KeyFetcher extends AbstractKeyFetcher {
+  readonly timeoutMilliseconds: number;
+  public pubkey?: CallDataPublicKey;
+
+  constructor(in_timeoutMilliseconds?: number) {
+    super();
+    if (!in_timeoutMilliseconds) {
+      in_timeoutMilliseconds = DEFAULT_PUBKEY_CACHE_EXPIRATION_MS;
+    }
+    this.timeoutMilliseconds = in_timeoutMilliseconds;
+  }
+
+  /**
+   * Retrieve cached key if possible, otherwise fetch a fresh one
+   *
+   * @param upstream Upstream ETH JSON-RPC provider
+   * @returns calldata public key
+   */
+  public async fetch(upstream: UpstreamProvider): Promise<CallDataPublicKey> {
+    if (this.pubkey) {
+      const pk = this.pubkey;
+      const expiry = Date.now() - this.timeoutMilliseconds;
+      if (pk.fetched && pk.fetched.valueOf() > expiry) {
+        // XXX: if provider switch chain, may return cached key for wrong chain
+        return pk;
+      }
+    }
+    return (this.pubkey = await fetchRuntimePublicKey(upstream));
+  }
+
+  public async cipher(upstream: UpstreamProvider): Promise<Cipher> {
+    return (await this.fetch(upstream)).cipher;
+  }
+}
+
+export class MockKeyFetcher extends AbstractKeyFetcher {
+    #_cipher: MockCipher;
+
+    constructor(in_cipher: MockCipher) {
+        super();
+        this.#_cipher = in_cipher;
+    }
+
+    public async fetch(upstream: UpstreamProvider): Promise<CallDataPublicKey> {
+        throw new Error("MockKeyFetcher doesn't support fetch(), only cipher()");
+    }
+
+    public async cipher(upstream: UpstreamProvider): Promise<Cipher> {
+        return this.#_cipher
+    }
+}

--- a/clients/js/src/compat.ts
+++ b/clients/js/src/compat.ts
@@ -156,11 +156,7 @@ function hookEIP1193Request(
   return async (args: Web3ReqArgs) => {
     const signer = await provider.getSigner();
     const cipher = await options.fetcher.cipher(provider);
-    const { method, params } = await prepareRequest(
-      args,
-      signer,
-      cipher,
-    );
+    const { method, params } = await prepareRequest(args, signer, cipher);
     const res = await signer.provider.send(method, params ?? []);
     if (method === 'eth_call') {
       return await cipher.decryptEncoded(res);

--- a/clients/js/src/compat.ts
+++ b/clients/js/src/compat.ts
@@ -159,7 +159,6 @@ function hookEIP1193Request(
     const { method, params } = await prepareRequest(
       args,
       signer,
-      options,
       cipher,
     );
     const res = await signer.provider.send(method, params ?? []);
@@ -410,7 +409,6 @@ async function callNeedsSigning(
 async function prepareRequest(
   { method, params }: Web3ReqArgs,
   signer: JsonRpcSigner,
-  options: SapphireWrapOptions,
   cipher: Cipher,
 ): Promise<{ method: string; params?: Array<any> }> {
   if (!Array.isArray(params)) return { method, params };
@@ -427,7 +425,6 @@ async function prepareRequest(
     (await callNeedsSigning(params[0]))
   ) {
     const dataPack = await SignedCallDataPack.make(params[0], signer);
-    const cipher = await options.fetcher.cipher(signer);
     const signedCall = {
       ...params[0],
       data: await dataPack.encryptEncode(cipher),
@@ -442,7 +439,6 @@ async function prepareRequest(
     /^eth_((send|sign)Transaction|call|estimateGas)$/.test(method) &&
     params[0].data // Ignore balance transfers without calldata
   ) {
-    const cipher = await options.fetcher.cipher(signer);
     params[0].data = await cipher.encryptEncode(params[0].data);
     return { method, params };
   }

--- a/clients/js/src/compat.ts
+++ b/clients/js/src/compat.ts
@@ -264,7 +264,6 @@ export function wrapEthersProvider<P extends Provider | Ethers5Provider>(
         const cipher = await filled_options.fetcher.cipher(provider);;
         const repacked = await repackRawTx(
           raw,
-          filled_options,
           cipher,
           signer,
         );
@@ -278,7 +277,6 @@ export function wrapEthersProvider<P extends Provider | Ethers5Provider>(
           const cipher = await filled_options.fetcher.cipher(provider);;
           const repacked = await repackRawTx(
             raw,
-            filled_options,
             cipher,
             signer,
           );
@@ -423,7 +421,7 @@ async function prepareRequest(
   if (method === 'eth_sendRawTransaction') {
     return {
       method,
-      params: [await repackRawTx(params[0], options, cipher, signer)],
+      params: [await repackRawTx(params[0], cipher, signer)],
     };
   }
 
@@ -463,7 +461,6 @@ const REPACK_ERROR =
 /** Repacks and signs a sendRawTransaction if needed and possible. */
 async function repackRawTx(
   raw: string,
-  options: SapphireWrapOptions,
   cipher: Cipher,
   signer?: Ethers5Signer | Signer,
 ): Promise<string> {

--- a/clients/js/src/compat.ts
+++ b/clients/js/src/compat.ts
@@ -17,16 +17,11 @@ import {
   hexlify,
 } from 'ethers';
 
-import {
-  Cipher,
-  Kind as CipherKind,
-  Envelope,
-  X25519DeoxysII,
-  lazy as lazyCipher,
-} from './cipher.js';
-import { CallError, OASIS_CALL_DATA_PUBLIC_KEY } from './index.js';
+import { Kind as CipherKind, Envelope } from './cipher.js';
+
+import { CallError } from './index.js';
+
 import { EthCall, Leash, SignedCallDataPack } from './signed_calls.js';
-import { NETWORKS } from './networks.js';
 
 import {
   Deferrable,
@@ -34,15 +29,13 @@ import {
   Ethers5Provider,
   EIP1193Provider,
   Web3ReqArgs,
+  UpstreamProvider,
 } from './interfaces.js';
 
-export type UpstreamProvider =
-  | EIP1193Provider
-  | Ethers5Signer
-  | Ethers5Provider;
+import { AbstractKeyFetcher, KeyFetcher } from './calldatapublickey.js';
 
 interface SapphireWrapOptions {
-  cipher: Cipher;
+  fetcher: AbstractKeyFetcher;
 }
 
 const SAPPHIRE_PROP = 'sapphire';
@@ -52,13 +45,12 @@ export type SapphireAnnex = {
 
 function fillOptions(
   options: SapphireWrapOptions | undefined,
-  provider: UpstreamProvider,
 ): SapphireWrapOptions {
   if (!options) {
     options = {} as SapphireWrapOptions;
   }
-  if (!options.cipher) {
-    options.cipher = getCipher(provider);
+  if (!options.fetcher) {
+    options.fetcher = new KeyFetcher();
   }
   return options;
 }
@@ -106,7 +98,7 @@ export function wrap<U extends UpstreamProvider>(
     upstream = new JsonRpcProvider(upstream) as any;
   }
 
-  const filled_options = fillOptions(options, upstream);
+  const filled_options = fillOptions(options);
 
   if (isEthersSigner(upstream)) {
     return wrapEthersSigner(upstream as Ethers5Signer, filled_options) as any;
@@ -136,7 +128,7 @@ function wrapEIP1193Provider<P extends EIP1193Provider>(
   upstream: P,
   options?: SapphireWrapOptions,
 ): P & SapphireAnnex {
-  const filled_options = fillOptions(options, upstream);
+  const filled_options = fillOptions(options);
   const browserProvider = new BrowserProvider(upstream);
   const request = hookEIP1193Request(browserProvider, filled_options);
   const hooks: Record<string, any> = {
@@ -163,23 +155,22 @@ function hookEIP1193Request(
 ): EIP1193Provider['request'] {
   return async (args: Web3ReqArgs) => {
     const signer = await provider.getSigner();
-    const { method, params } = await prepareRequest(args, signer, options);
+    const { method, params } = await prepareRequest(
+      args,
+      signer,
+      options,
+      provider,
+    );
     const res = await signer.provider.send(method, params ?? []);
     if (method === 'eth_call') {
-      return options.cipher.decryptEncoded(res);
+      const cipher = await options.fetcher.cipher(provider);
+      return await cipher.decryptEncoded(res);
     }
     return res;
   };
 }
 
 // -----------------------------------------------------------------------------
-
-function getCipher(provider: UpstreamProvider): Cipher {
-  return lazyCipher(async () => {
-    const rtPubKey = await fetchRuntimePublicKey(provider);
-    return X25519DeoxysII.ephemeral(rtPubKey);
-  });
-}
 
 function makeProxy<U extends UpstreamProvider>(
   upstream: U,
@@ -202,7 +193,7 @@ export function wrapEthersSigner<P extends Ethers5Signer>(
   upstream: P,
   options?: SapphireWrapOptions,
 ): P & SapphireAnnex {
-  const filled_options = fillOptions(options, upstream);
+  const filled_options = fillOptions(options);
 
   let signer: Ethers5Signer;
   if (upstream.provider) {
@@ -220,10 +211,12 @@ export function wrapEthersSigner<P extends Ethers5Signer>(
     sendTransaction: hookEthersSend(
       signer.sendTransaction.bind(signer),
       filled_options,
+      signer,
     ),
     signTransaction: hookEthersSend(
       signer.signTransaction.bind(signer),
       filled_options,
+      signer,
     ),
     call: hookEthersCall(signer, 'call', filled_options),
     estimateGas: hookEthersCall(signer, 'estimateGas', filled_options),
@@ -246,7 +239,7 @@ export function wrapEthersProvider<P extends Provider | Ethers5Provider>(
   options?: SapphireWrapOptions,
   signer?: Ethers5Signer | Signer,
 ): P & SapphireAnnex {
-  const filled_options = fillOptions(options, provider);
+  const filled_options = fillOptions(options);
 
   // Already wrapped, so don't wrap it again.
   if (Reflect.get(provider, SAPPHIRE_PROP) !== undefined) {
@@ -268,7 +261,12 @@ export function wrapEthersProvider<P extends Provider | Ethers5Provider>(
       hooks['broadcastTransaction'] = <Provider['broadcastTransaction']>(async (
         raw: string,
       ) => {
-        const repacked = await repackRawTx(raw, filled_options, signer);
+        const repacked = await repackRawTx(
+          raw,
+          filled_options,
+          provider,
+          signer,
+        );
         return (provider as Provider).broadcastTransaction(repacked);
       });
     } else {
@@ -276,7 +274,12 @@ export function wrapEthersProvider<P extends Provider | Ethers5Provider>(
       // Ethers v5 `sendTransaction` takes hex encoded byte string
       hooks['sendTransaction'] = <Ethers5ProviderWithSend['sendTransaction']>(
         (async (raw: string) => {
-          const repacked = await repackRawTx(raw, filled_options, signer);
+          const repacked = await repackRawTx(
+            raw,
+            filled_options,
+            provider,
+            signer,
+          );
           return (
             provider as unknown as Ethers5ProviderWithSend
           ).sendTransaction(repacked);
@@ -335,9 +338,8 @@ function hookEthersCall(
   ) => {
     let call_data = call.data;
     if (!is_already_enveloped) {
-      call_data = await options.cipher.encryptEncode(
-        call.data ?? new Uint8Array(),
-      );
+      const cipher = await options.fetcher.cipher(runner as any);
+      call_data = await cipher.encryptEncode(call.data ?? new Uint8Array());
     }
     const result = await runner[method]!({
       ...call,
@@ -361,10 +363,11 @@ function hookEthersCall(
         throw new Error('signer not connected to a provider');
       const provider = signer.provider;
       if (await callNeedsSigning(call)) {
+        const cipher = await options.fetcher.cipher(runner as any);
         const dataPack = await SignedCallDataPack.make(call, signer);
         res = await provider[method]({
           ...call,
-          data: await dataPack.encryptEncode(options.cipher),
+          data: await dataPack.encryptEncode(cipher),
         });
       } else {
         res = await sendUnsignedCall(provider, call, is_already_enveloped);
@@ -374,7 +377,8 @@ function hookEthersCall(
     }
     // NOTE: if it's already enveloped, caller will decrypt it (not us)
     if (!is_already_enveloped && typeof res === 'string') {
-      return await options.cipher.decryptEncoded(res);
+      const cipher = await options.fetcher.cipher(runner as any);
+      return await cipher.decryptEncoded(res);
     }
     return res;
   };
@@ -382,10 +386,15 @@ function hookEthersCall(
 
 type EthersCall = (tx: EthCall | TransactionRequest) => Promise<unknown>;
 
-function hookEthersSend<C>(send: C, options: SapphireWrapOptions): C {
+function hookEthersSend<C>(
+  send: C,
+  options: SapphireWrapOptions,
+  signer: Ethers5Signer,
+): C {
   return (async (tx: EthCall | TransactionRequest, ...rest: any[]) => {
     if (tx.data) {
-      tx.data = await options.cipher.encryptEncode(tx.data);
+      const cipher = await options.fetcher.cipher(signer);
+      tx.data = await cipher.encryptEncode(tx.data);
     }
     return (send as any)(tx, ...rest);
   }) as C;
@@ -406,13 +415,14 @@ async function prepareRequest(
   { method, params }: Web3ReqArgs,
   signer: JsonRpcSigner,
   options: SapphireWrapOptions,
+  provider: BrowserProvider,
 ): Promise<{ method: string; params?: Array<any> }> {
   if (!Array.isArray(params)) return { method, params };
 
   if (method === 'eth_sendRawTransaction') {
     return {
       method,
-      params: [await repackRawTx(params[0], options, signer)],
+      params: [await repackRawTx(params[0], options, provider, signer)],
     };
   }
 
@@ -421,9 +431,10 @@ async function prepareRequest(
     (await callNeedsSigning(params[0]))
   ) {
     const dataPack = await SignedCallDataPack.make(params[0], signer);
+    const cipher = await options.fetcher.cipher(signer);
     const signedCall = {
       ...params[0],
-      data: await dataPack.encryptEncode(options.cipher),
+      data: await dataPack.encryptEncode(cipher),
     };
     return {
       method,
@@ -435,7 +446,8 @@ async function prepareRequest(
     /^eth_((send|sign)Transaction|call|estimateGas)$/.test(method) &&
     params[0].data // Ignore balance transfers without calldata
   ) {
-    params[0].data = await options.cipher.encryptEncode(params[0].data);
+    const cipher = await options.fetcher.cipher(signer);
+    params[0].data = await cipher.encryptEncode(params[0].data);
     return { method, params };
   }
 
@@ -451,6 +463,7 @@ const REPACK_ERROR =
 async function repackRawTx(
   raw: string,
   options: SapphireWrapOptions,
+  provider: UpstreamProvider,
   signer?: Ethers5Signer | Signer,
 ): Promise<string> {
   const tx = Transaction.from(raw);
@@ -466,7 +479,8 @@ async function repackRawTx(
     return raw;
   }
 
-  tx.data = await options.cipher.encryptEncode(tx.data);
+  const cipher = await options.fetcher.cipher(provider);
+  tx.data = await cipher.encryptEncode(tx.data);
 
   try {
     return signer!.signTransaction(tx);
@@ -533,160 +547,4 @@ function envelopeFormatOk(envelope: Envelope): boolean {
   }
 
   return true;
-}
-
-// -----------------------------------------------------------------------------
-// Fetch calldata public key
-// Well use provider when possible, and fallback to HTTP(S)? requests
-// e.g. MetaMask doesn't allow the oasis_callDataPublicKey JSON-RPC method
-
-type CallDataPublicKeyResponse = {
-  result: {
-    key: string;
-    checksum: string;
-    signature: string;
-    epoch: number;
-  };
-};
-
-async function fetchRuntimePublicKeyNode(
-  gwUrl: string,
-): Promise<CallDataPublicKeyResponse> {
-  // Import http or https, depending on the URI scheme.
-  const https = await import(/* webpackIgnore: true */ gwUrl.split(':')[0]);
-
-  const body = makeCallDataPublicKeyBody();
-  return new Promise((resolve, reject) => {
-    const opts = {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        'content-length': body.length,
-      },
-    };
-    const req = https.request(gwUrl, opts, (res: any) => {
-      const chunks: Buffer[] = [];
-      res.on('error', (err: any) => reject(err));
-      res.on('data', (chunk: any) => chunks.push(chunk));
-      res.on('end', () => {
-        resolve(JSON.parse(Buffer.concat(chunks).toString()));
-      });
-    });
-    req.on('error', (err: Error) => reject(err));
-    req.write(body);
-    req.end();
-  });
-}
-
-async function fetchRuntimePublicKeyBrowser(
-  gwUrl: string,
-  fetchImpl: typeof fetch,
-): Promise<CallDataPublicKeyResponse> {
-  const res = await fetchImpl(gwUrl, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-    },
-    body: makeCallDataPublicKeyBody(),
-  });
-  if (!res.ok) {
-    throw new CallError('Failed to fetch runtime public key.', res);
-  }
-  return await res.json();
-}
-
-function makeCallDataPublicKeyBody(): string {
-  return JSON.stringify({
-    jsonrpc: '2.0',
-    id: Math.floor(Math.random() * 1e9),
-    method: OASIS_CALL_DATA_PUBLIC_KEY,
-    params: [],
-  });
-}
-
-export async function fetchRuntimePublicKeyByChainId(
-  chainId: number,
-  opts?: { fetch?: typeof fetch },
-): Promise<Uint8Array> {
-  const { defaultGateway } = NETWORKS[chainId];
-  if (!defaultGateway)
-    throw new Error(
-      `Unable to fetch runtime public key for network with unknown ID: ${chainId}.`,
-    );
-  const fetchImpl = opts?.fetch ?? globalThis?.fetch;
-  const res = await (fetchImpl
-    ? fetchRuntimePublicKeyBrowser(defaultGateway, fetchImpl)
-    : fetchRuntimePublicKeyNode(defaultGateway));
-  return getBytes(res.result.key);
-}
-
-function fromQuantity(x: number | string): number {
-  if (typeof x === 'string') {
-    if (x.startsWith('0x')) {
-      return parseInt(x, 16);
-    }
-    return parseInt(x); // Assumed to be base 10
-  }
-  return x;
-}
-
-/**
- * Picks the most user-trusted runtime calldata public key source based on what
- * connections are available.
- *
- * NOTE: MetaMask does not support Web3 methods it doesn't know about, so we have to
- *       fall-back to manually querying the default gateway.
- */
-export async function fetchRuntimePublicKey(
-  upstream: UpstreamProvider,
-): Promise<Uint8Array> {
-  const provider = 'provider' in upstream ? upstream['provider'] : upstream;
-  let chainId: number | undefined;
-  if (provider) {
-    let resp: any;
-    // It's probably an EIP-1193 provider
-    if ('request' in provider) {
-      const source = provider as EIP1193Provider;
-      try {
-        resp = await source.request({
-          method: OASIS_CALL_DATA_PUBLIC_KEY,
-          params: [],
-        });
-      } catch (ex) {
-        // don't do anything, move on to try next
-        chainId = fromQuantity(
-          (await source.request({ method: 'eth_chainId' })) as string | number,
-        );
-      }
-    }
-    // If it's a `send` provider
-    else if ('send' in provider) {
-      const source = provider as {
-        send: (method: string, params: any[]) => Promise<any>;
-      };
-      try {
-        resp = await source.send(OASIS_CALL_DATA_PUBLIC_KEY, []);
-      } catch (ex) {
-        // don't do anything, move on to try chainId fetch
-        chainId = fromQuantity(await source.send('eth_chainId', []));
-      }
-    }
-    // Otherwise, we have no idea what to do with this provider!
-    else {
-      throw new Error(
-        'fetchRuntimePublicKey does not support non-request non-send provier!',
-      );
-    }
-    if (resp && 'key' in resp) {
-      const key = resp.key;
-      return getBytes(key);
-    }
-  }
-
-  if (!chainId) {
-    throw new Error(
-      'fetchRuntimePublicKey failed to retrieve chainId from provider',
-    );
-  }
-  return fetchRuntimePublicKeyByChainId(chainId);
 }

--- a/clients/js/src/compat.ts
+++ b/clients/js/src/compat.ts
@@ -261,12 +261,8 @@ export function wrapEthersProvider<P extends Provider | Ethers5Provider>(
       hooks['broadcastTransaction'] = <Provider['broadcastTransaction']>(async (
         raw: string,
       ) => {
-        const cipher = await filled_options.fetcher.cipher(provider);;
-        const repacked = await repackRawTx(
-          raw,
-          cipher,
-          signer,
-        );
+        const cipher = await filled_options.fetcher.cipher(provider);
+        const repacked = await repackRawTx(raw, cipher, signer);
         return (provider as Provider).broadcastTransaction(repacked);
       });
     } else {
@@ -274,12 +270,8 @@ export function wrapEthersProvider<P extends Provider | Ethers5Provider>(
       // Ethers v5 `sendTransaction` takes hex encoded byte string
       hooks['sendTransaction'] = <Ethers5ProviderWithSend['sendTransaction']>(
         (async (raw: string) => {
-          const cipher = await filled_options.fetcher.cipher(provider);;
-          const repacked = await repackRawTx(
-            raw,
-            cipher,
-            signer,
-          );
+          const cipher = await filled_options.fetcher.cipher(provider);
+          const repacked = await repackRawTx(raw, cipher, signer);
           return (
             provider as unknown as Ethers5ProviderWithSend
           ).sendTransaction(repacked);
@@ -335,7 +327,7 @@ function hookEthersCall(
     runner: Ethers5Provider | Ethers5Signer | ContractRunner,
     call: EthCall | TransactionRequest,
     is_already_enveloped: boolean,
-    cipher: Cipher
+    cipher: Cipher,
   ) => {
     let call_data = call.data;
     if (!is_already_enveloped) {
@@ -370,7 +362,12 @@ function hookEthersCall(
           data: await dataPack.encryptEncode(cipher),
         });
       } else {
-        res = await sendUnsignedCall(provider, call, is_already_enveloped, cipher);
+        res = await sendUnsignedCall(
+          provider,
+          call,
+          is_already_enveloped,
+          cipher,
+        );
       }
     } else {
       res = await sendUnsignedCall(runner, call, is_already_enveloped, cipher);

--- a/clients/js/src/interfaces.ts
+++ b/clients/js/src/interfaces.ts
@@ -77,3 +77,8 @@ export async function undefer<T>(obj: Deferrable<T>): Promise<T> {
     await Promise.all(Object.entries(obj).map(async ([k, v]) => [k, await v])),
   );
 }
+
+export type UpstreamProvider =
+  | EIP1193Provider
+  | Ethers5Signer
+  | Ethers5Provider;

--- a/clients/js/test/cipher.spec.ts
+++ b/clients/js/test/cipher.spec.ts
@@ -6,7 +6,6 @@ import nacl from 'tweetnacl';
 import {
   Plain,
   X25519DeoxysII,
-  lazy,
 } from '@oasisprotocol/sapphire-paratime/cipher.js';
 
 const DATA = new Uint8Array([1, 2, 3, 4, 5]);
@@ -110,17 +109,6 @@ describe('X25519DeoxysII', () => {
     });
     await expect(cipher.decryptCallResult(cbor.decode(res))).rejects.toThrow(
       'out of gas',
-    );
-  });
-});
-
-describe('lazy', () => {
-  it('forwards', async () => {
-    const inner = X25519DeoxysII.ephemeral(nacl.box.keyPair().publicKey);
-    const cipher = lazy(() => inner);
-    expect(await cipher.publicKey).toEqual(inner.publicKey);
-    expect((await cipher.encrypt(DATA)).ciphertext).toHaveLength(
-      DATA.length + TagSize,
     );
   });
 });

--- a/clients/js/test/compat.spec.ts
+++ b/clients/js/test/compat.spec.ts
@@ -6,21 +6,25 @@ import nacl from 'tweetnacl';
 
 import {
   wrap,
+} from '@oasisprotocol/sapphire-paratime/compat.js';
+
+import {
+  MockKeyFetcher,
   fetchRuntimePublicKey,
   fetchRuntimePublicKeyByChainId,
-} from '@oasisprotocol/sapphire-paratime/compat.js';
+} from '@oasisprotocol/sapphire-paratime/calldatapublickey.js';
 import { Mock as MockCipher } from '@oasisprotocol/sapphire-paratime/cipher.js';
 import { CHAIN_ID, verifySignedCall } from './utils';
 
-jest.mock('@oasisprotocol/sapphire-paratime/compat.js', () => ({
-  ...jest.requireActual('@oasisprotocol/sapphire-paratime/compat.js'),
+jest.mock('@oasisprotocol/sapphire-paratime/calldatapublickey.js', () => ({
+  ...jest.requireActual('@oasisprotocol/sapphire-paratime/calldatapublickey.js'),
   fetchRuntimePublicKeyByChainId: jest
     .fn()
     .mockReturnValue(new Uint8Array(Buffer.alloc(32, 8))),
 }));
 
 const real_fetchRuntimePublicKeyByChainId = jest.requireActual(
-  '@oasisprotocol/sapphire-paratime/compat.js',
+  '@oasisprotocol/sapphire-paratime/calldatapublickey.js',
 ).fetchRuntimePublicKeyByChainId;
 
 const secretKey =
@@ -28,6 +32,7 @@ const secretKey =
 const wallet = new ethers.Wallet(secretKey);
 const to = '0xb5ed90452AAC09f294a0BE877CBf2Dc4D55e096f';
 const cipher = new MockCipher();
+const fetcher = new MockKeyFetcher(cipher);
 const data = Buffer.from([1, 2, 3, 4, 5]);
 
 class MockEIP1193Provider {
@@ -94,6 +99,10 @@ class MockEIP1193Provider {
       if (method === 'oasis_callDataPublicKey') {
         return {
           key: `0x${Buffer.alloc(32, 42).toString('hex')}`,
+          checksum: '0x',
+          epoch: 1,
+          signature: '0x',
+          chainId: CHAIN_ID
         };
       }
       throw new Error(
@@ -140,7 +149,7 @@ describe('fetchRuntimePublicKey', () => {
     const upstream = new ethers.BrowserProvider(new MockEIP1193Provider());
     const pk = await fetchRuntimePublicKey(upstream);
     expect(fetchRuntimePublicKeyByChainId).not.toHaveBeenCalled();
-    expect(pk).toEqual(new Uint8Array(Buffer.alloc(32, 42)));
+    expect(pk.key).toEqual(new Uint8Array(Buffer.alloc(32, 42)));
   });
 
   it('non public key provider', async () => {
@@ -148,32 +157,32 @@ describe('fetchRuntimePublicKey', () => {
       new MockNonRuntimePublicKeyProvider(),
     );
     // This will have retrieved the key from testnet or mainnet
-    expect(pk).not.toEqual(new Uint8Array(Buffer.alloc(32, 8)));
+    expect(pk.key).not.toEqual(new Uint8Array(Buffer.alloc(32, 8)));
   });
 
   it('ethers signer', async () => {
-    const wrapped = wrap(wallet, { cipher }).connect(
+    const wrapped = wrap(wallet, { fetcher: fetcher }).connect(
       new ethers.BrowserProvider(new MockEIP1193Provider()),
     );
     const pk = await fetchRuntimePublicKey(wrapped);
     expect(fetchRuntimePublicKeyByChainId).not.toHaveBeenCalled();
-    expect(pk).toEqual(new Uint8Array(Buffer.alloc(32, 42)));
+    expect(pk.key).toEqual(new Uint8Array(Buffer.alloc(32, 42)));
   });
 });
 
 describe('ethers signer', () => {
   it('proxy', async () => {
-    const wrapped = wrap(wallet, { cipher });
+    const wrapped = wrap(wallet, { fetcher });
     expect(wrapped.address).toEqual(
       '0x11e244400Cf165ade687077984F09c3A037b868F',
     );
     expect(await wrapped.getAddress()).toEqual(wrapped.address);
-    expect((wrapped as any).sapphire).toMatchObject({ cipher });
+    expect((wrapped as any).sapphire).toMatchObject({ fetcher });
   });
 
   it('unsigned call/estimateGas', async () => {
     const upstreamProvider = new MockEIP1193Provider();
-    const wrapped = wrap(wallet, { cipher }).connect(
+    const wrapped = wrap(wallet, { fetcher }).connect(
       new ethers.BrowserProvider(upstreamProvider),
     );
     const callRequest = {
@@ -206,7 +215,7 @@ describe('ethers signer', () => {
 
   runTestBattery(async () => {
     const provider = new MockEIP1193Provider();
-    const signer = wrap(wallet, { cipher }).connect(
+    const signer = wrap(wallet, { fetcher }).connect(
       new ethers.BrowserProvider(provider),
     );
     return [signer, provider, signer.signTransaction.bind(signer)];
@@ -220,11 +229,11 @@ describe('ethers provider', () => {
   beforeEach(() => {
     upstreamProvider = new MockEIP1193Provider();
     const provider = new ethers.BrowserProvider(upstreamProvider);
-    wrapped = wrap(provider, { cipher });
+    wrapped = wrap(provider, { fetcher });
   });
 
   it('proxy', async () => {
-    expect((wrapped as any).sapphire).toMatchObject({ cipher });
+    expect((wrapped as any).sapphire).toMatchObject({ fetcher });
   });
 
   it('unsigned call/estimateGas', async () => {
@@ -254,15 +263,15 @@ describe('ethers provider', () => {
 
 describe('window.ethereum', () => {
   it('proxy', async () => {
-    const wrapped = wrap(new MockEIP1193Provider(), { cipher });
+    const wrapped = wrap(new MockEIP1193Provider(), { fetcher });
     expect(wrapped.isMetaMask).toBe(false);
     expect(wrapped.isConnected()).toBe(false);
-    expect((wrapped as any).sapphire).toMatchObject({ cipher });
+    expect((wrapped as any).sapphire).toMatchObject({ fetcher });
   });
 
   runTestBattery(async () => {
     const provider = new MockEIP1193Provider();
-    const wrapped = wrap(provider, { cipher });
+    const wrapped = wrap(provider, { fetcher });
     const signer = await new ethers.BrowserProvider(wrapped).getSigner();
     const rawSign = async (...args: unknown[]) => {
       const raw = await wrapped.request({
@@ -401,12 +410,15 @@ describe('fetchPublicKeyByChainId', () => {
       .reply(200, {
         result: {
           key: `0x${Buffer.from(publicKey).toString('hex')}`,
-          // TODO: checksum and signature
+          checksum: '0x',
+          epoch: 1,
+          signature: '0x',
+          chainId: CHAIN_ID
         },
       });
 
     const response = await real_fetchRuntimePublicKeyByChainId(chainId, opts);
-    expect(response).not.toHaveLength(0);
+    expect(response.key).not.toHaveLength(0);
 
     scope.done();
   }

--- a/clients/js/test/compat.spec.ts
+++ b/clients/js/test/compat.spec.ts
@@ -4,9 +4,7 @@ import nock from 'nock';
 import fetchImpl from 'node-fetch';
 import nacl from 'tweetnacl';
 
-import {
-  wrap,
-} from '@oasisprotocol/sapphire-paratime/compat.js';
+import { wrap } from '@oasisprotocol/sapphire-paratime/compat.js';
 
 import {
   MockKeyFetcher,
@@ -17,7 +15,9 @@ import { Mock as MockCipher } from '@oasisprotocol/sapphire-paratime/cipher.js';
 import { CHAIN_ID, verifySignedCall } from './utils';
 
 jest.mock('@oasisprotocol/sapphire-paratime/calldatapublickey.js', () => ({
-  ...jest.requireActual('@oasisprotocol/sapphire-paratime/calldatapublickey.js'),
+  ...jest.requireActual(
+    '@oasisprotocol/sapphire-paratime/calldatapublickey.js',
+  ),
   fetchRuntimePublicKeyByChainId: jest
     .fn()
     .mockReturnValue(new Uint8Array(Buffer.alloc(32, 8))),
@@ -102,7 +102,7 @@ class MockEIP1193Provider {
           checksum: '0x',
           epoch: 1,
           signature: '0x',
-          chainId: CHAIN_ID
+          chainId: CHAIN_ID,
         };
       }
       throw new Error(
@@ -413,7 +413,7 @@ describe('fetchPublicKeyByChainId', () => {
           checksum: '0x',
           epoch: 1,
           signature: '0x',
-          chainId: CHAIN_ID
+          chainId: CHAIN_ID,
         },
       });
 

--- a/contracts/test/eip155.ts
+++ b/contracts/test/eip155.ts
@@ -70,7 +70,7 @@ describe('EIP-155', function () {
     const tx = await testContract.example();
     expect(entropy(tx.data)).gte(EXPECTED_ENTROPY_ENCRYPTED);
     expect(tx.data).not.eq(calldata);
-    expect(tx.data.length).eq(218);
+    expect(tx.data.length).eq(236);
   });
 
   /// Verify that contracts can sign transactions for submission with an unwrapped provider

--- a/contracts/test/eip155.ts
+++ b/contracts/test/eip155.ts
@@ -70,7 +70,7 @@ describe('EIP-155', function () {
     const tx = await testContract.example();
     expect(entropy(tx.data)).gte(EXPECTED_ENTROPY_ENCRYPTED);
     expect(tx.data).not.eq(calldata);
-    expect(tx.data.length).eq(236);
+    expect(tx.data.length).gt(230);
   });
 
   /// Verify that contracts can sign transactions for submission with an unwrapped provider

--- a/contracts/test/gas.ts
+++ b/contracts/test/gas.ts
@@ -4,8 +4,6 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { GasTests } from '../typechain-types/contracts/tests/Gas.sol/GasTests';
 
-const GAS_MARGIN_OF_ERROR = 5;
-
 describe('Gas Padding', function () {
   let contract: GasTests;
 
@@ -15,37 +13,22 @@ describe('Gas Padding', function () {
   });
 
   it('Gas Padding works as Expected', async () => {
-    const expectedGas = 122746;
-
     let tx = await contract.testConstantTime(1, 100000);
     let receipt = await tx.wait();
-    expect(receipt!.cumulativeGasUsed).within(
-      expectedGas - GAS_MARGIN_OF_ERROR,
-      expectedGas + GAS_MARGIN_OF_ERROR,
-    );
+    const initialGasUsed = receipt!.cumulativeGasUsed;
 
     tx = await contract.testConstantTime(2, 100000);
     receipt = await tx.wait();
-    expect(receipt!.cumulativeGasUsed).within(
-      expectedGas - GAS_MARGIN_OF_ERROR,
-      expectedGas + GAS_MARGIN_OF_ERROR,
-    );
+    expect(receipt!.cumulativeGasUsed).eq(initialGasUsed);
 
-    tx = await contract.testConstantTime(1, 100000);
+    tx = await contract.testConstantTime(1, 110000);
     receipt = await tx.wait();
-    expect(receipt!.cumulativeGasUsed).within(
-      expectedGas - GAS_MARGIN_OF_ERROR,
-      expectedGas + GAS_MARGIN_OF_ERROR,
-    );
+    expect(receipt!.cumulativeGasUsed).eq(initialGasUsed+10000n);
 
     // Note: calldata isn't included in gas padding
     // Thus when the value is 0 it will use 4 gas instead of 16 gas
-    // XXX: sometimes this is off by 1 gas!
     tx = await contract.testConstantTime(0, 100000);
     receipt = await tx.wait();
-    expect(receipt?.cumulativeGasUsed).within(
-      expectedGas - 10 - GAS_MARGIN_OF_ERROR,
-      expectedGas - 10,
-    );
+    expect(receipt?.cumulativeGasUsed).eq(initialGasUsed-12n);
   });
 });

--- a/contracts/test/gas.ts
+++ b/contracts/test/gas.ts
@@ -23,12 +23,12 @@ describe('Gas Padding', function () {
 
     tx = await contract.testConstantTime(1, 110000);
     receipt = await tx.wait();
-    expect(receipt!.cumulativeGasUsed).eq(initialGasUsed+10000n);
+    expect(receipt!.cumulativeGasUsed).eq(initialGasUsed + 10000n);
 
     // Note: calldata isn't included in gas padding
     // Thus when the value is 0 it will use 4 gas instead of 16 gas
     tx = await contract.testConstantTime(0, 100000);
     receipt = await tx.wait();
-    expect(receipt?.cumulativeGasUsed).eq(initialGasUsed-12n);
+    expect(receipt?.cumulativeGasUsed).eq(initialGasUsed - 12n);
   });
 });

--- a/contracts/test/gas.ts
+++ b/contracts/test/gas.ts
@@ -4,6 +4,8 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { GasTests } from '../typechain-types/contracts/tests/Gas.sol/GasTests';
 
+const GAS_MARGIN_OF_ERROR = 5;
+
 describe('Gas Padding', function () {
   let contract: GasTests;
 
@@ -17,15 +19,24 @@ describe('Gas Padding', function () {
 
     let tx = await contract.testConstantTime(1, 100000);
     let receipt = await tx.wait();
-    expect(receipt!.cumulativeGasUsed).within(expectedGas - 1, expectedGas + 2);
+    expect(receipt!.cumulativeGasUsed).within(
+      expectedGas - GAS_MARGIN_OF_ERROR,
+      expectedGas + GAS_MARGIN_OF_ERROR,
+    );
 
     tx = await contract.testConstantTime(2, 100000);
     receipt = await tx.wait();
-    expect(receipt!.cumulativeGasUsed).within(expectedGas - 1, expectedGas + 2);
+    expect(receipt!.cumulativeGasUsed).within(
+      expectedGas - GAS_MARGIN_OF_ERROR,
+      expectedGas + GAS_MARGIN_OF_ERROR,
+    );
 
     tx = await contract.testConstantTime(1, 100000);
     receipt = await tx.wait();
-    expect(receipt!.cumulativeGasUsed).within(expectedGas - 2, expectedGas + 2);
+    expect(receipt!.cumulativeGasUsed).within(
+      expectedGas - GAS_MARGIN_OF_ERROR,
+      expectedGas + GAS_MARGIN_OF_ERROR,
+    );
 
     // Note: calldata isn't included in gas padding
     // Thus when the value is 0 it will use 4 gas instead of 16 gas

--- a/contracts/test/gas.ts
+++ b/contracts/test/gas.ts
@@ -13,7 +13,7 @@ describe('Gas Padding', function () {
   });
 
   it('Gas Padding works as Expected', async () => {
-    const expectedGas = 122735;
+    const expectedGas = 122746;
 
     let tx = await contract.testConstantTime(1, 100000);
     let receipt = await tx.wait();

--- a/contracts/test/gas.ts
+++ b/contracts/test/gas.ts
@@ -44,7 +44,7 @@ describe('Gas Padding', function () {
     tx = await contract.testConstantTime(0, 100000);
     receipt = await tx.wait();
     expect(receipt?.cumulativeGasUsed).within(
-      expectedGas - 13,
+      expectedGas - 10 - GAS_MARGIN_OF_ERROR,
       expectedGas - 10,
     );
   });


### PR DESCRIPTION
This should fix several long-standing issues with call encryption.

Previously the `Cipher` object would be created and maintained with the same keys throughout the duration of the session, it also did not support the new `Epoch` flag which specifies which calldata public key was being used to encrypt the request (requiring the server to try several).

This would cause problems, like when you leave a dApp open for a while your transactions would fail with 'tag verification failed'.

This introduces several changes:

 * New Cipher instance is used for every request
 * calldata public key is cached (5 minutes by default)
 * The `epoch` parameter is passed in the encryption envelope
 * Debug `scripts/proxy.js` shows epoch status too.

This means that leaving dApps open for prolonged periods of time will be OK.

---------------------

Follow-up notes:

 * Gas tests in `contracts/` had a small rewrite, because of the variance they were longer a sufficient test of what they were supposed to do check for! They've been made relative instead.