### PR TITLE
examples: added require() reversion message check to ethers v6 client

### DIFF
--- a/examples/ethersv6-ts-esm/src/index.ts
+++ b/examples/ethersv6-ts-esm/src/index.ts
@@ -16,6 +16,8 @@ async function testTheContract(contract:BaseContract, signerAddr?:string)
         assert( addr === ZeroAddress );
     }
 
+    // Verifies that calling a function which does require(false,"ThisIsAnError")
+    // Will return the correct error message in the exception to Ethers
     try {
         await contract.getFunction("testViewRevert()").staticCall();
         assert(false);
@@ -25,6 +27,8 @@ async function testTheContract(contract:BaseContract, signerAddr?:string)
         assert(e.reason == 'ThisIsAnError');
     }
 
+    // Verifies that calling a function which does revert CustomError(someInteger)
+    // Will return the correctly encoded custom error type to Ethers
     try {
         await contract.getFunction("testCustomRevert()").staticCall();
         assert(false);

--- a/examples/ethersv6-ts-esm/src/index.ts
+++ b/examples/ethersv6-ts-esm/src/index.ts
@@ -17,6 +17,15 @@ async function testTheContract(contract:BaseContract, signerAddr?:string)
     }
 
     try {
+        await contract.getFunction("testViewRevert()").staticCall();
+        assert(false);
+    }
+    catch(e:any) {
+        assert(e.code == 'CALL_EXCEPTION');
+        assert(e.reason == 'ThisIsAnError');
+    }
+
+    try {
         await contract.getFunction("testCustomRevert()").staticCall();
         assert(false);
     }


### PR DESCRIPTION
Double check that reversion with error message works with Ethers v6