### PR TITLE
contracts: bump to v0.2.8

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is inspired by [Keep a Changelog].
 
  * Declare `@openzeppelin/contracts` as a dependency
 
+### Removed
+
+ - Minimally used `Context` from `opl/Endpoint.sol`
+
 ## 0.2.7 (2024-01-17)
 
 ### Fixed

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is inspired by [Keep a Changelog].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 
+## 0.2.8 (2024-03-15)
+
+### Fixed
+
+ * Declare `@openzeppelin/contracts` as a dependency
+
 ## 0.2.7 (2024-01-17)
 
 ### Fixed

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisprotocol/sapphire-contracts",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "license": "Apache-2.0",
   "description": "Solidity smart contract library for confidential contract development",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/contracts",


### PR DESCRIPTION
## Description

Release patch version of contracts to include dependencies as seen in #180. This PR is blocked by #289.

Let's also get in #290.

## TODO

- [x] Test OPL locally. [BSC](https://testnet.bscscan.com/tx/0x3512947e3d34f9d52ad98af01588e47c8c3e3e6e8667608341ff26fa5b83bb4f) and [Sapphire](https://explorer.oasis.io/testnet/sapphire/tx/0x8fc8f90df9f74e84295c4a0742d4c8cb06ec342b54c0c23283114b4fdf6ece5c).