### PR TITLE
Fix CI dependencies

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -85,6 +85,10 @@ jobs:
           version: 8
           run_install: false
 
+      - name: Install dependencies
+        run: |
+          pnpm install
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 


### PR DESCRIPTION
## Description

We need to `pnpm install` or otherwise install dependencies before generating docs. https://github.com/oasisprotocol/sapphire-paratime/actions/runs/8301914337/job/22724066016