### PR TITLE
Added Makefile to `runtime` directory to make debug build for testing

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -1,8 +1,16 @@
+ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+SAPPHIRE_DEV_DOCKER=ghcr.io/oasisprotocol/sapphire-localnet:latest
+
 all:
 
-debug:
+build-debug:
 	OASIS_UNSAFE_SKIP_AVR_VERIFY=1 OASIS_UNSAFE_SKIP_KM_POLICY=1 OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1 OASIS_UNSAFE_USE_LOCALNET_CHAINID=1 cargo build
-	ls -lah target/debug
+
+pull:
+	docker pull $(SAPPHIRE_DEV_DOCKER)
+
+debug: build-debug
+	docker run --rm -ti -p8545:8545 -p8546:8546 -v $(ROOT_DIR)/target/debug/sapphire-paratime:/runtime.elf $(SAPPHIRE_DEV_DOCKER) -test-mnemonic -n 4
 
 clean:
 	cargo clean

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -1,0 +1,8 @@
+all:
+
+debug:
+	OASIS_UNSAFE_SKIP_AVR_VERIFY=1 OASIS_UNSAFE_SKIP_KM_POLICY=1 OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1 OASIS_UNSAFE_USE_LOCALNET_CHAINID=1 cargo build
+	ls -lah target/debug
+
+clean:
+	cargo clean

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -52,7 +52,7 @@ git checkout directory.
 
 If rust toolchain is not installed on your device, you can install it like this:
 
-```
+```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 ```

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -129,7 +129,8 @@ The [sapphire-localnet] Docker container can be launched with a locally built
 debug build of the Sapphire paratime. The `Makefile` contains commands to build
 and then bind-mount the executable into the container.
 
-    make debug
+```shell
+make debug
 
 This can be very useful when debugging or testing new features against Ethereum
 compatible RPC clients.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -52,6 +52,7 @@ git checkout directory.
 
 If rust toolchain is not installed on your device, you can install it like this:
 
+```
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 ```
@@ -121,3 +122,16 @@ The resulting SGX binary is located at
 
 _NOTE: The SGX binary is always statically linked so it doesn't exhibit the
 portability issues the ELF binary has._
+
+## Debugging
+
+The [sapphire-localnet] Docker container can be launched with a locally built
+debug build of the Sapphire paratime. The `Makefile` contains commands to build
+and then bind-mount the executable into the container.
+
+    make debug
+
+This can be very useful when debugging or testing new features against Ethereum
+compatible RPC clients.
+
+[sapphire-localnet]: https://github.com/oasisprotocol/oasis-web3-gateway/pkgs/container/sapphire-localnet


### PR DESCRIPTION
This can be used in conjunction with `sapphire-localnet` to run a custom debug build of Sapphire runtime without rebuilding the oasis-web3-gateway image.

Example of bind-mounting sapphire-paratime executable:

    SAPPHIRE_DEV_DOCKER=ghcr.io/oasisprotocol/sapphire-localnet:latest
    docker run --rm -ti -p8545:8545 -p8546:8546 -v $SOURCE/sapphire-paratime/runtime/target/debug/sapphire-paratime:/runtime.elf $(SAPPHIRE_DEV_DOCKER) -to 'test test test test test test test test test test test junk' -n 4

out of curiosity, here is a Dockerfile that does a full oasis-web3-gateway build with a specific branch: https://gist.github.com/CedarMist/87255bf16f48db3a5b6f7f03d72ccb40 - although it still requires a branch on sapphire-paratime to update Cargo.toml with the correct dependency from oasis-sdk