### PR TITLE
Hardhat example comment issue

### DIFF
--- a/examples/hardhat/scripts/run-counter.ts
+++ b/examples/hardhat/scripts/run-counter.ts
@@ -1,4 +1,4 @@
-// Usage: pnpm hardhat run --network <network> scripts/deploy-bridge-adapter-v1.ts
+// Usage: pnpm hardhat run --network <network> scripts/run-counter.ts
 
 import { ethers } from 'hardhat';
 


### PR DESCRIPTION
The comment with a command that hints on the way how the script file should be used references some other file instead of the script file the comment is contained in.