### PR TITLE
Update Python client instructions

### DIFF
--- a/clients/py/README.md
+++ b/clients/py/README.md
@@ -14,12 +14,15 @@ make
 from web3 import Web3
 from sapphirepy import sapphire
 
-# Setup your Web3 provider with a signing account
+# Setup your Web3 provider with a signing account.
 w3 = Web3(Web3.HTTPProvider('http://localhost:8545'))
 w3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))
 
-# Finally, wrap the provider to add Sapphire end-to-end encryption
+# Finally, wrap the provider to add Sapphire end-to-end encryption.
 w3 = sapphire.wrap(w3)
+# Optionally, query Oasis Web3 Gateway for the gas price.
+# from web3.gas_strategies.rpc import rpc_gas_price_strategy
+# w3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
 ```
 
 The Sapphire middleware for Web3.py ensures all transactions, gas estimates and


### PR DESCRIPTION
## Description

Add instructions for `web3.py` usage with minimal additional infrastructure.

Devs should select recommended gas strategy as per https://github.com/oasisprotocol/oasis-web3-gateway/issues/501