### PR TITLE
sapphire-contracts: Add EIP-4361 SIWE parser and base contract

### DIFF
--- a/contracts/contracts/DateTime.sol
+++ b/contracts/contracts/DateTime.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+/**
+ * @title Utility for converting date and time to timestamp
+ * @notice Considers leap year, but not leap second.
+ * @custom:attribution https://github.com/pipermerriam/ethereum-datetime/blob/master/contracts/DateTime.sol
+ */
+library DateTime {
+    uint16 private constant ORIGIN_YEAR = 1970;
+
+    function isLeapYear(uint16 year) internal pure returns (bool) {
+        if (year % 4 != 0) {
+            return false;
+        }
+        if (year % 100 != 0) {
+            return true;
+        }
+        if (year % 400 != 0) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @notice Convert year, month, day, hour, minute, second to Unix timestamp.
+     * @dev Leap second is not supported.
+     */
+    function toTimestamp(
+        uint16 year,
+        uint8 month,
+        uint8 day,
+        uint8 hour,
+        uint8 minute,
+        uint8 second
+    ) internal pure returns (uint256 timestamp) {
+        uint16 i;
+
+        // Year
+        // TODO: Rewrite to O(1) time implementation.
+        for (i = ORIGIN_YEAR; i < year; i++) {
+            if (isLeapYear(i)) {
+                timestamp += 366 days;
+            } else {
+                timestamp += 365 days;
+            }
+        }
+
+        // Month
+        // TODO: Use constants for monthDayCounts (hex-encoded string?), rewrite to O(1) time implementation.
+        uint32[12] memory monthDayCounts;
+        monthDayCounts[0] = 31;
+        if (isLeapYear(year)) {
+            monthDayCounts[1] = 29;
+        } else {
+            monthDayCounts[1] = 28;
+        }
+        monthDayCounts[2] = 31;
+        monthDayCounts[3] = 30;
+        monthDayCounts[4] = 31;
+        monthDayCounts[5] = 30;
+        monthDayCounts[6] = 31;
+        monthDayCounts[7] = 31;
+        monthDayCounts[8] = 30;
+        monthDayCounts[9] = 31;
+        monthDayCounts[10] = 30;
+        monthDayCounts[11] = 31;
+
+        for (i = 1; i < month; i++) {
+            timestamp += monthDayCounts[i - 1] * 1 days;
+        }
+
+        // Day
+        timestamp += uint32(day - 1) * 1 days;
+
+        // Hour
+        timestamp += uint32(hour) * 1 hours;
+
+        // Minute
+        timestamp += uint16(minute) * 1 minutes;
+
+        // Second
+        timestamp += second;
+
+        return timestamp;
+    }
+}

--- a/contracts/contracts/SiweParser.sol
+++ b/contracts/contracts/SiweParser.sol
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {DateTime} from "./DateTime.sol";
+
+struct ParsedSiweMessage {
+    bytes schemeDomain;
+    address addr;
+    bytes statement;
+    bytes uri;
+    bytes version;
+    uint256 chainId;
+    bytes nonce;
+    bytes issuedAt;
+    bytes expirationTime;
+    bytes notBefore;
+    bytes requestId;
+    bytes[] resources;
+}
+
+/**
+ * @title On-chain parser for EIP-4361 SIWE message
+ * @notice Call parseSiweMsg() and provide the EIP-4361 SIWE message. The parser
+ * will generate the ParsedSiweMessage struct which you can then use to
+ * extract the authentication information in your on-chain contract.
+ */
+library SiweParser {
+    /// Invalid length of the hex-encoded address
+    error InvalidAddressLength();
+    /// Invalid length of the nonce
+    error InvalidNonce();
+
+    /**
+     * @notice Convert string containing hex address without 0x prefix to solidity address object.
+     */
+    function _hexStringToAddress(bytes memory s)
+        internal
+        pure
+        returns (address)
+    {
+        if (s.length != 40) {
+            revert InvalidAddressLength();
+        }
+
+        bytes memory r = new bytes(s.length / 2);
+        for (uint256 i = 0; i < s.length / 2; ++i) {
+            r[i] = bytes1(
+                _fromHexChar(uint8(s[2 * i])) *
+                    16 +
+                    _fromHexChar(uint8(s[2 * i + 1]))
+            );
+        }
+        return address(bytes20(r));
+    }
+
+    function _fromHexChar(uint8 c) internal pure returns (uint8) {
+        if (bytes1(c) >= bytes1("0") && bytes1(c) <= bytes1("9")) {
+            return c - uint8(bytes1("0"));
+        }
+        if (bytes1(c) >= bytes1("a") && bytes1(c) <= bytes1("f")) {
+            return 10 + c - uint8(bytes1("a"));
+        }
+        if (bytes1(c) >= bytes1("A") && bytes1(c) <= bytes1("F")) {
+            return 10 + c - uint8(bytes1("A"));
+        }
+        return 0;
+    }
+
+    /**
+     * @notice Substring.
+     */
+    function _substr(
+        bytes memory str,
+        uint256 startIndex,
+        uint256 endIndex
+    ) internal pure returns (bytes memory) {
+        bytes memory result = new bytes(endIndex - startIndex);
+        for (uint256 i = startIndex; i < endIndex && i < str.length; i++) {
+            result[i - startIndex] = str[i];
+        }
+        return result;
+    }
+
+    /**
+     * @notice String to Uint using decimal format. No error handling.
+     */
+    function _parseUint(bytes memory b) internal pure returns (uint256) {
+        uint256 result = 0;
+        for (uint256 i = 0; i < b.length; i++) {
+            result = result * 10 + (uint256(uint8(b[i])) - 0x30);
+        }
+        return (result);
+    }
+
+    /**
+     * @notice Parse "NAME: VALUE" in str starting at index i and ending at \n or end of bytes.
+     * @return VALUE and new i, if NAME matched; otherwise empty value and old i.
+     */
+    function _parseField(
+        bytes calldata str,
+        string memory name,
+        uint256 i
+    ) internal pure returns (bytes memory, uint256) {
+        uint256 j = i;
+        for (; j < str.length; j++) {
+            if (str[j] == ":") {
+                // Delimiter found, check the name.
+                if (keccak256(_substr(str, i, j)) != keccak256(bytes(name))) {
+                    return ("", i);
+                }
+
+                // Skip :
+                j++;
+                if (j < str.length && str[j] == " ") {
+                    // Skip blank
+                    j++;
+                }
+
+                i = j;
+                break;
+            }
+        }
+
+        for (; j < str.length; j++) {
+            if (str[j] == 0x0a) {
+                return (_substr(str, i, j), j + 1);
+            }
+        }
+        return (_substr(str, i, j), j);
+    }
+
+    /**
+     * @notice Parse bullets, one per line in str starting at i.
+     * @return Array of parsed values and a new i.
+     */
+    function _parseArray(bytes calldata str, uint256 i)
+        internal
+        pure
+        returns (bytes[] memory, uint256)
+    {
+        // First count the number of resources.
+        uint256 j = i;
+        uint256 count = 0;
+        for (; j < str.length - 1; j++) {
+            if (str[j] == "-" && str[j + 1] == " ") {
+                j += 2;
+                count++;
+            } else {
+                break;
+            }
+            while (j < str.length && str[j] != 0x0a) {
+                j++;
+            }
+        }
+
+        // Then build an array.
+        bytes[] memory values = new bytes[](count);
+        j = i;
+        for (uint256 c = 0; j < str.length - 1 && c != count; j++) {
+            if (str[j] == "-" && str[j + 1] == " ") {
+                i = j + 2;
+            }
+            while (j < str.length && str[j] != 0x0a) {
+                j++;
+            }
+            values[c] = _substr(str, i, j);
+            c++;
+            if (j == str.length) {
+                j--; // Subtract 1 because of the outer loop.
+            }
+        }
+        return (values, j);
+    }
+
+    /**
+     * @notice Parse SIWE message.
+     * @return ParsedSiweMessage struct with populated fields from the message.
+     */
+    function parseSiweMsg(bytes calldata siweMsg)
+        internal
+        pure
+        returns (ParsedSiweMessage memory)
+    {
+        ParsedSiweMessage memory p;
+        uint256 i = 0;
+
+        // dApp Domain.
+        for (; i < siweMsg.length; i++) {
+            if (siweMsg[i] == " ") {
+                p.schemeDomain = _substr(siweMsg, 0, i);
+                break;
+            }
+        }
+
+        i += 50; // " wants you to sign in with your Ethereum account:\n"
+
+        // Address.
+        // TODO: Verify the mixed-case checksum.
+        p.addr = _hexStringToAddress(_substr(siweMsg, i += 2, i += 40));
+        i += 2; // End of address new line + New line.
+
+        // (Optional) statement.
+        if (i < siweMsg.length && siweMsg[i] != "\n") {
+            for (uint256 j = i; j < siweMsg.length; j++) {
+                if (siweMsg[j] == 0x0a) {
+                    p.statement = _substr(siweMsg, i, j);
+                    i = j + 1; // End of statement new line.
+                    break;
+                }
+            }
+        }
+
+        i++; // New line.
+
+        (p.uri, i) = _parseField(siweMsg, "URI", i);
+        (p.version, i) = _parseField(siweMsg, "Version", i);
+        bytes memory chainId;
+        (chainId, i) = _parseField(siweMsg, "Chain ID", i);
+        p.chainId = _parseUint(chainId);
+        (p.nonce, i) = _parseField(siweMsg, "Nonce", i);
+        if (p.nonce.length < 8) {
+            revert InvalidNonce();
+        }
+        (p.issuedAt, i) = _parseField(siweMsg, "Issued At", i);
+        (p.expirationTime, i) = _parseField(siweMsg, "Expiration Time", i);
+        (p.notBefore, i) = _parseField(siweMsg, "Not Before", i);
+        (p.requestId, i) = _parseField(siweMsg, "Request ID", i);
+
+        // Parse resources, if they exist.
+        uint256 newI;
+        (, newI) = _parseField(siweMsg, "Resources", i);
+        if (newI != i) {
+            (p.resources, i) = _parseArray(siweMsg, newI);
+        }
+
+        return p;
+    }
+
+    /**
+     * @notice Parse RFC 3339 (ISO 8601) string to timestamp.
+     */
+    function timestampFromIso(bytes memory str)
+        internal
+        pure
+        returns (uint256)
+    {
+        return
+            DateTime.toTimestamp(
+                uint16(_parseUint(_substr(str, 0, 4))),
+                uint8(_parseUint(_substr(str, 5, 7))),
+                uint8(_parseUint(_substr(str, 8, 10))),
+                uint8(_parseUint(_substr(str, 11, 13))),
+                uint8(_parseUint(_substr(str, 14, 16))),
+                uint8(_parseUint(_substr(str, 17, 19)))
+            );
+    }
+}

--- a/contracts/contracts/auth/A13e.sol
+++ b/contracts/contracts/auth/A13e.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {SignatureRSV} from "../EthereumUtils.sol";
+
+/**
+ * @title Interface for authenticatable contracts
+ * @notice This is the interface for universal authentication mechanism (e.g.
+ * SIWE):
+ * 1. The user-facing app calls login() to generate the bearer token on-chain.
+ * 2. Any smart contract method that requires authentication accept this token
+ *    as an argument. Then, it passes the token to authMsgSender() to verify it
+ *    and obtain the **authenticated** user address. This address can then serve
+ *    as a user ID for authorization.
+ */
+abstract contract A13e {
+    /// A mapping of revoked bearers. Access it directly or use the checkRevokedBearer modifier.
+    mapping(bytes32 => bool) internal _revokedBearers;
+
+    /// The bearer token was revoked
+    error RevokedBearer();
+
+    /**
+     * @notice Reverts if the given bearer was revoked
+     */
+    modifier checkRevokedBearer(bytes calldata bearer) {
+        if (_revokedBearers[keccak256(bearer)]) {
+            revert RevokedBearer();
+        }
+        _;
+    }
+
+    /**
+     * @notice Verify the login message and its signature and generate the
+     * bearer token.
+     */
+    function login(string calldata message, SignatureRSV calldata sig)
+        external
+        view
+        virtual
+        returns (bytes memory);
+
+    /**
+     * @notice Validate the bearer token and return authenticated msg.sender.
+     */
+    function authMsgSender(bytes calldata bearer)
+        internal
+        view
+        virtual
+        returns (address);
+
+    /**
+     * @notice Revoke the bearer token with the corresponding hash.
+     * e.g. In case when the bearer token is leaked or for extra-secure apps on
+     * every logout.
+     */
+    function revokeBearer(bytes32 bearer) internal {
+        _revokedBearers[bearer] = true;
+    }
+}

--- a/contracts/contracts/auth/SiweAuth.sol
+++ b/contracts/contracts/auth/SiweAuth.sol
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+import {SignatureRSV, A13e} from "./A13e.sol";
+import {ParsedSiweMessage, SiweParser} from "../SiweParser.sol";
+import {Sapphire} from "../Sapphire.sol";
+
+struct Bearer {
+    string domain; // [ scheme "://" ] domain.
+    address userAddr;
+    uint256 validUntil; // in Unix timestamp.
+}
+
+/**
+ * @title Base contract for SIWE-based authentication
+ * @notice Inherit this contract, if you wish to enable SIWE-based
+ * authentication for your contract methods that require authenticated calls.
+ * The smart contract needs to be bound to a domain (passed in constructor).
+ *
+ * #### Example
+ *
+ * ```solidity
+ * contract MyContract is SiweAuth {
+ *   address private _owner;
+ *
+ *   modifier onlyOwner(bytes calldata bearer) {
+ *     if (authMsgSender(bearer) != _owner) {
+ *       revert("not allowed");
+ *     }
+ *     _;
+ *   }
+ *
+ *   constructor(string memory domain) SiweAuth(domain) {
+ *     _owner = msg.sender;
+ *   }
+ *
+ *   function getSecretMessage(bytes calldata bearer) external view onlyOwner(bearer) returns (string memory) {
+ *     return "Very secret message";
+ *   }
+ * }
+ * ```
+ */
+contract SiweAuth is A13e {
+    /// Domain which the dApp is associated with
+    string private _domain;
+    /// Encryption key which the bearer tokens are encrypted with
+    bytes32 private _bearerEncKey;
+    /// Default bearer token validity, if no expiration-time provided
+    uint256 private constant DEFAULT_VALIDITY = 24 hours;
+
+    /// Chain ID in the SIWE message does not match the actual chain ID
+    error ChainIdMismatch();
+    /// Domain in the SIWE message does not match the domain of a dApp
+    error DomainMismatch();
+    /// User address in the SIWE message does not match the message signer's address
+    error AddressMismatch();
+    /// The Not before value in the SIWE message is still in the future
+    error NotBeforeInFuture();
+    /// The bearer token validity or the Expires value in the SIWE message is in the past
+    error Expired();
+
+    /**
+     * @notice Instantiate the contract which uses SIWE for authentication and
+     * runs on the specified domain.
+     */
+    constructor(string memory inDomain) {
+        _bearerEncKey = bytes32(Sapphire.randomBytes(32, ""));
+        _domain = inDomain;
+    }
+
+    function login(string calldata siweMsg, SignatureRSV calldata sig)
+        external
+        view
+        override
+        returns (bytes memory)
+    {
+        Bearer memory b;
+
+        // Derive the user's address from the signature.
+        bytes memory eip191msg = abi.encodePacked(
+            "\x19Ethereum Signed Message:\n",
+            Strings.toString(bytes(siweMsg).length),
+            siweMsg
+        );
+        address addr = ecrecover(
+            keccak256(eip191msg),
+            uint8(sig.v),
+            sig.r,
+            sig.s
+        );
+        b.userAddr = addr;
+
+        ParsedSiweMessage memory p = SiweParser.parseSiweMsg(bytes(siweMsg));
+
+        if (p.chainId != block.chainid) {
+            revert ChainIdMismatch();
+        }
+
+        if (keccak256(p.schemeDomain) != keccak256(bytes(_domain))) {
+            revert DomainMismatch();
+        }
+        b.domain = string(p.schemeDomain);
+
+        if (p.addr != addr) {
+            revert AddressMismatch();
+        }
+
+        if (
+            p.notBefore.length != 0 &&
+            block.timestamp <= SiweParser.timestampFromIso(p.notBefore)
+        ) {
+            revert NotBeforeInFuture();
+        }
+
+        if (p.expirationTime.length != 0) {
+            // Compute expected block number at expiration time.
+            uint256 expirationTime = SiweParser.timestampFromIso(
+                p.expirationTime
+            );
+            b.validUntil = expirationTime;
+        } else {
+            // Otherwise, just take the default validity.
+            b.validUntil = block.timestamp + DEFAULT_VALIDITY;
+        }
+        if (block.timestamp >= b.validUntil) {
+            revert Expired();
+        }
+
+        bytes memory encB = Sapphire.encrypt(
+            _bearerEncKey,
+            0,
+            abi.encode(b),
+            ""
+        );
+        return encB;
+    }
+
+    /**
+     * @notice Return the domain associated with the dApp.
+     */
+    function domain() public view returns (string memory) {
+        return _domain;
+    }
+
+    function authMsgSender(bytes calldata bearer)
+        internal
+        view
+        override
+        checkRevokedBearer(bearer)
+        returns (address)
+    {
+        bytes memory bearerEncoded = Sapphire.decrypt(
+            _bearerEncKey,
+            0,
+            bearer,
+            ""
+        );
+        Bearer memory b = abi.decode(bearerEncoded, (Bearer));
+
+        if (keccak256(bytes(b.domain)) != keccak256(bytes(_domain))) {
+            revert DomainMismatch();
+        }
+        if (b.validUntil < block.timestamp) {
+            revert Expired();
+        }
+
+        return b.userAddr;
+    }
+}

--- a/contracts/contracts/tests/DateTimeTests.sol
+++ b/contracts/contracts/tests/DateTimeTests.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {DateTime} from "../DateTime.sol";
+
+contract DateTimeTests {
+    function testIsLeapYear(uint16 year) external pure returns (bool) {
+        return DateTime.isLeapYear(year);
+    }
+
+    function testToTimestamp(
+        uint16 year,
+        uint8 month,
+        uint8 day,
+        uint8 hour,
+        uint8 minute,
+        uint8 second
+    ) external pure returns (uint256 timestamp) {
+        return DateTime.toTimestamp(year, month, day, hour, minute, second);
+    }
+}

--- a/contracts/contracts/tests/SiweParserTests.sol
+++ b/contracts/contracts/tests/SiweParserTests.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {ParsedSiweMessage, SiweParser} from "../SiweParser.sol";
+
+contract SiweParserTests {
+    function testHexStringToAddress(bytes memory addr)
+        external
+        view
+        returns (address)
+    {
+        return SiweParser._hexStringToAddress(addr);
+    }
+
+    function testFromHexChar(uint8 c) external view returns (uint8) {
+        return SiweParser._fromHexChar(c);
+    }
+
+    function testSubstr(
+        bytes memory str,
+        uint256 startIndex,
+        uint256 endIndex
+    ) external view returns (bytes memory) {
+        return SiweParser._substr(str, startIndex, endIndex);
+    }
+
+    function testParseUint(bytes memory b) external view returns (uint256) {
+        return SiweParser._parseUint(b);
+    }
+
+    function testParseField(
+        bytes calldata str,
+        string memory name,
+        uint256 i
+    ) external view returns (bytes memory value, uint256) {
+        return SiweParser._parseField(str, name, i);
+    }
+
+    function testParseArray(bytes calldata str, uint256 i)
+        external
+        view
+        returns (bytes[] memory values, uint256 count)
+    {
+        return SiweParser._parseArray(str, i);
+    }
+
+    function testParseSiweMsg(bytes calldata siweMsg)
+        external
+        view
+        returns (ParsedSiweMessage memory)
+    {
+        return SiweParser.parseSiweMsg(siweMsg);
+    }
+
+    function testTimestampFromIso(bytes memory str)
+        external
+        pure
+        returns (uint256)
+    {
+        return SiweParser.timestampFromIso(str);
+    }
+}

--- a/contracts/contracts/tests/auth/SiweAuthTests.sol
+++ b/contracts/contracts/tests/auth/SiweAuthTests.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {EthereumUtils, SignatureRSV} from "../../EthereumUtils.sol";
+import {SiweAuth} from "../../auth/SiweAuth.sol";
+
+contract SiweAuthTests is SiweAuth {
+    address private _owner;
+
+    constructor(string memory domain) SiweAuth(domain) {
+        _owner = msg.sender;
+    }
+
+    function testVerySecretMessage(bytes calldata bearer)
+        external
+        view
+        returns (string memory)
+    {
+        if (authMsgSender(bearer) != _owner) {
+            revert("not allowed");
+        }
+        return "Very secret message";
+    }
+
+    function testLogin(string calldata message, SignatureRSV calldata sig)
+        external
+        view
+        returns (bytes memory)
+    {
+        return this.login(message, sig);
+    }
+
+    function testAuthMsgSender(bytes calldata bearer)
+        external
+        view
+        returns (address)
+    {
+        return authMsgSender(bearer);
+    }
+
+    function testRevokeBearer(bytes32 bearer) external {
+        return revokeBearer(bearer);
+    }
+}

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -47,6 +47,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "prettier-plugin-solidity": "1.0.0-beta.24",
+    "siwe": "^2.3.2",
     "solhint": "^3.3.7",
     "solidity-coverage": "^0.8.2",
     "ts-node": "^10.9.1",

--- a/contracts/test/auth.ts
+++ b/contracts/test/auth.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from 'chai';
+import { config, ethers } from 'hardhat';
+import { Signer } from 'ethers';
+import { SiweMessage } from 'siwe';
+import '@nomicfoundation/hardhat-chai-matchers';
+
+import { SiweAuthTests__factory } from '../typechain-types/factories/contracts/tests';
+import { SiweAuthTests } from '../typechain-types/contracts/tests/auth/SiweAuthTests';
+import { NETWORKS } from '@oasisprotocol/sapphire-paratime';
+
+describe('Auth', function () {
+  async function deploy(domain: string) {
+    const SiweAuthTests_factory = await ethers.getContractFactory(
+      'SiweAuthTests',
+    );
+    const siweAuthTests = await SiweAuthTests_factory.deploy(domain);
+    await siweAuthTests.waitForDeployment();
+    return siweAuthTests;
+  }
+
+  async function siweMsg(
+    domain: string,
+    signerIdx: number,
+    expiration?: Date,
+  ): Promise<string> {
+    return new SiweMessage({
+      domain,
+      address: await (await ethers.provider.getSigner(signerIdx)).getAddress(),
+      statement: `I accept the ExampleOrg Terms of Service: http://${domain}/tos`,
+      uri: `http://${domain}:5173`,
+      version: '1',
+      chainId: Number((await ethers.provider.getNetwork()).chainId),
+      expirationTime: expiration ? expiration.toISOString() : undefined,
+    }).toMessage();
+  }
+
+  // Signs the given message as ERC-191 "personal_sign" message.
+  async function erc191sign(msg: string, account: Signer) {
+    return ethers.Signature.from(await account.signMessage(msg));
+  }
+
+  it('Should login', async function () {
+    // Skip this test on non-sapphire chains.
+    // It requires on-chain encryption and/or signing.
+    if (
+      Number((await ethers.provider.getNetwork()).chainId) !=
+      NETWORKS.localnet.chainId
+    ) {
+      this.skip();
+    }
+
+    const siweAuthTests = await deploy('localhost');
+
+    // Correct login.
+    const accounts = config.networks.hardhat.accounts;
+    const account = ethers.HDNodeWallet.fromMnemonic(
+      ethers.Mnemonic.fromPhrase(accounts.mnemonic),
+      accounts.path + '/0',
+    );
+    const siweStr = await siweMsg('localhost', 0);
+    await expect(
+      await siweAuthTests.testLogin(
+        siweStr,
+        await erc191sign(siweStr, account),
+      ),
+    ).lengthOf.to.be.greaterThan(2); // Test if not 0x or empty.
+
+    // Wrong domain.
+    const siweStrWrongDomain = await siweMsg('localhost2', 0);
+    await expect(
+      siweAuthTests.testLogin(
+        siweStrWrongDomain,
+        await erc191sign(siweStrWrongDomain, account),
+      ),
+    ).to.be.reverted;
+
+    // Mismatch signature based on the SIWE message.
+    const siweStrWrongSig = await siweMsg('localhost', 1);
+    await expect(
+      siweAuthTests.testLogin(
+        siweStrWrongSig,
+        await erc191sign(siweStrWrongSig, account),
+      ),
+    ).to.be.reverted;
+
+    // Expired login.
+    let now = new Date();
+    const siweStrExpired = await siweMsg(
+      'localhost',
+      0,
+      new Date(Date.now() - 10_000), // Expired 10 seconds ago.
+    );
+    await expect(
+      siweAuthTests.testLogin(
+        siweStrExpired,
+        await erc191sign(siweStrExpired, account),
+      ),
+    ).to.be.reverted;
+  });
+
+  it('Should call authenticated method', async function () {
+    // Skip this test on non-sapphire chains.
+    // It require on-chain encryption and/or signing.
+    if (
+      Number((await ethers.provider.getNetwork()).chainId) !=
+      NETWORKS.localnet.chainId
+    ) {
+      this.skip();
+    }
+
+    const siweAuthTests = await deploy('localhost');
+
+    // Author should read a very secret message.
+    const accounts = config.networks.hardhat.accounts;
+    const account = ethers.HDNodeWallet.fromMnemonic(
+      ethers.Mnemonic.fromPhrase(accounts.mnemonic),
+      accounts.path + '/0',
+    );
+    const siweStr = await siweMsg('localhost', 0);
+    const bearer = await siweAuthTests.testLogin(
+      siweStr,
+      await erc191sign(siweStr, account),
+    );
+    await expect(await siweAuthTests.testVerySecretMessage(bearer)).to.be.equal(
+      'Very secret message',
+    );
+
+    // Anyone else trying to read the very secret message should fail.
+    const acc2 = ethers.HDNodeWallet.fromMnemonic(
+      ethers.Mnemonic.fromPhrase(accounts.mnemonic),
+      accounts.path + '/1',
+    );
+    const siweStr2 = await siweMsg('localhost', 1);
+    const bearer2 = await siweAuthTests.testLogin(
+      siweStr2,
+      await erc191sign(siweStr2, acc2),
+    );
+    await expect(siweAuthTests.testVerySecretMessage(bearer2)).to.be.reverted;
+
+    // Same user, hijacked bearer from another contract/domain.
+    const siweAuthTests2 = await deploy('localhost2');
+    const siweStr3 = await siweMsg('localhost2', 0);
+    const bearer3 = await siweAuthTests2.testLogin(
+      siweStr3,
+      await erc191sign(siweStr3, account),
+    );
+    await expect(siweAuthTests.testVerySecretMessage(bearer3)).to.be.reverted;
+
+    // Expired bearer.
+    const siweStr4 = await siweMsg('localhost', 0, new Date(Date.now() + 10)); // Expire after 0.01 seconds.
+    const bearer4 = await siweAuthTests.testLogin(
+      siweStr4,
+      await erc191sign(siweStr4, account),
+    );
+    // Wait for 2 blocks. The first block may still have a timestamp earlier than the expiration time.
+    await new Promise(async (r) => {
+      const desiredBlockNumber = (await ethers.provider.getBlockNumber()) + 2;
+      ethers.provider.on('block', (blockNumber) => {
+        if (blockNumber == desiredBlockNumber) {
+          r();
+        }
+      });
+    });
+    await expect(siweAuthTests.testVerySecretMessage(bearer4)).to.be.reverted;
+
+    // Revoke bearer.
+    const bearer5 = await siweAuthTests.testLogin(
+      siweStr,
+      await erc191sign(siweStr, account),
+    );
+    await siweAuthTests.testRevokeBearer(ethers.keccak256(bearer5));
+    await expect(siweAuthTests.testVerySecretMessage(bearer5)).to.be.reverted;
+  });
+});

--- a/contracts/test/datetime.ts
+++ b/contracts/test/datetime.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+import { DateTimeTests__factory } from '../typechain-types/factories/contracts/tests';
+import { DateTimeTests } from '../typechain-types/contracts/tests/DateTimeTests';
+
+describe('DateTime', function () {
+  async function deploy() {
+    const DateTimeTests_factory = await ethers.getContractFactory(
+      'DateTimeTests',
+    );
+    const dateTimeTests = await DateTimeTests_factory.deploy();
+    await dateTimeTests.waitForDeployment();
+    return { dateTimeTests };
+  }
+
+  it('isLeapYear', async function () {
+    const { dateTimeTests } = await deploy();
+
+    expect(await dateTimeTests.testIsLeapYear(2023)).eq(false);
+    expect(await dateTimeTests.testIsLeapYear(2020)).eq(true);
+    expect(await dateTimeTests.testIsLeapYear(2000)).eq(true);
+    expect(await dateTimeTests.testIsLeapYear(1900)).eq(false);
+  });
+
+  it('toTimestamp', async function () {
+    const { dateTimeTests } = await deploy();
+
+    const date = '2024-07-10T10:24:49Z';
+    expect(await dateTimeTests.testToTimestamp(2024, 7, 10, 10, 24, 49)).eq(
+      Date.parse(date) / 1000,
+    );
+  });
+});

--- a/contracts/test/gas.ts
+++ b/contracts/test/gas.ts
@@ -23,7 +23,10 @@ describe('Gas Padding', function () {
 
     tx = await contract.testConstantTime(1, 110000);
     receipt = await tx.wait();
-    expect(receipt!.cumulativeGasUsed).eq(initialGasUsed + 10000n);
+    // TODO: Workaround for flaky gas used https://github.com/oasisprotocol/sapphire-paratime/issues/337.
+    expect(receipt!.cumulativeGasUsed)
+      .gte(initialGasUsed + 10000n)
+      .lte(initialGasUsed + 10001n);
 
     // Note: calldata isn't included in gas padding
     // Thus when the value is 0 it will use 4 gas instead of 16 gas

--- a/contracts/test/siweparser.ts
+++ b/contracts/test/siweparser.ts
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SiweMessage } from 'siwe';
+import '@nomicfoundation/hardhat-chai-matchers';
+
+import { SiweParserTests__factory } from '../typechain-types/factories/contracts/tests';
+import {
+  SiweParserTests,
+  ParsedSiweMessageStruct,
+} from '../typechain-types/contracts/tests/SiweParserTests';
+
+describe('SiweParser', function () {
+  async function deploy() {
+    const SiweParserTests_factory = await ethers.getContractFactory(
+      'SiweParserTests',
+    );
+    const siweParserTests = await SiweParserTests_factory.deploy();
+    await siweParserTests.waitForDeployment();
+    return { siweParserTests };
+  }
+
+  it('hexStringToAddress', async function () {
+    const { siweParserTests } = await deploy();
+
+    const addr = await siweParserTests.testHexStringToAddress(
+      ethers.toUtf8Bytes((await ethers.getSigners())[0].address.slice(2)),
+    );
+    expect(addr.toString()).eq((await ethers.getSigners())[0].address);
+  });
+
+  it('fromHexChar', async function () {
+    const { siweParserTests } = await deploy();
+
+    expect(await siweParserTests.testFromHexChar(97)).eq(10); // a
+    expect(await siweParserTests.testFromHexChar(65)).eq(10); // A
+    expect(await siweParserTests.testFromHexChar(57)).eq(9); // 9
+  });
+
+  it('substr', async function () {
+    const { siweParserTests } = await deploy();
+
+    expect(
+      await siweParserTests.testSubstr(
+        ethers.toUtf8Bytes('hello world'),
+        0,
+        11,
+      ),
+    ).eq(ethers.hexlify(ethers.toUtf8Bytes('hello world')));
+    expect(
+      await siweParserTests.testSubstr(
+        ethers.toUtf8Bytes('hello world'),
+        6,
+        11,
+      ),
+    ).eq(ethers.hexlify(ethers.toUtf8Bytes('world')));
+    expect(
+      await siweParserTests.testSubstr(ethers.toUtf8Bytes('hello world'), 0, 5),
+    ).eq(ethers.hexlify(ethers.toUtf8Bytes('hello')));
+  });
+
+  it('parserUint', async function () {
+    const { siweParserTests } = await deploy();
+
+    expect(
+      await siweParserTests.testParseUint(ethers.toUtf8Bytes('123456')),
+    ).eq(123456);
+  });
+
+  it('parseField', async function () {
+    const { siweParserTests } = await deploy();
+
+    expect(
+      await siweParserTests.testParseField(
+        ethers.toUtf8Bytes('hello: world\n'),
+        'hello',
+        0,
+      ),
+    ).deep.eq([ethers.hexlify(ethers.toUtf8Bytes('world')), 13]);
+    expect(
+      await siweParserTests.testParseField(
+        ethers.toUtf8Bytes('hello: world'),
+        'hello',
+        0,
+      ),
+    ).deep.eq([ethers.hexlify(ethers.toUtf8Bytes('world')), 12]);
+    expect(
+      await siweParserTests.testParseField(
+        ethers.toUtf8Bytes('foo: bar\nhello: world\n'),
+        'foo',
+        0,
+      ),
+    ).deep.eq([ethers.hexlify(ethers.toUtf8Bytes('bar')), 9]);
+    expect(
+      await siweParserTests.testParseField(
+        ethers.toUtf8Bytes('foo: bar\nhello: world\n'),
+        'hello',
+        0,
+      ),
+    ).deep.eq(['0x', 0]);
+    expect(
+      await siweParserTests.testParseField(
+        ethers.toUtf8Bytes('foo: bar\nhello: world\n'),
+        'hello',
+        9,
+      ),
+    ).deep.eq([ethers.hexlify(ethers.toUtf8Bytes('world')), 22]);
+    expect(
+      await siweParserTests.testParseField(
+        ethers.toUtf8Bytes('URI: http://localhost:5173\n'),
+        'URI',
+        0,
+      ),
+    ).deep.eq([
+      ethers.hexlify(ethers.toUtf8Bytes('http://localhost:5173')),
+      27,
+    ]);
+    expect(
+      await siweParserTests.testParseField(
+        ethers.toUtf8Bytes('Resources:\n'),
+        'Resources',
+        0,
+      ),
+    ).deep.eq([ethers.hexlify(ethers.toUtf8Bytes('')), 11]);
+    expect(
+      await siweParserTests.testParseField(
+        ethers.toUtf8Bytes('Resources:'),
+        'Resources',
+        0,
+      ),
+    ).deep.eq([ethers.hexlify(ethers.toUtf8Bytes('')), 10]);
+  });
+
+  it('parseArray', async function () {
+    const { siweParserTests } = await deploy();
+
+    expect(
+      await siweParserTests.testParseArray(
+        ethers.toUtf8Bytes('- abc\n- bcd'),
+        0,
+      ),
+    ).deep.eq([
+      [
+        ethers.hexlify(ethers.toUtf8Bytes('abc')),
+        ethers.hexlify(ethers.toUtf8Bytes('bcd')),
+      ],
+      11,
+    ]);
+    expect(
+      await siweParserTests.testParseArray(
+        ethers.toUtf8Bytes('- abc\n- bcd\n'),
+        0,
+      ),
+    ).deep.eq([
+      [
+        ethers.hexlify(ethers.toUtf8Bytes('abc')),
+        ethers.hexlify(ethers.toUtf8Bytes('bcd')),
+      ],
+      12,
+    ]);
+    expect(
+      await siweParserTests.testParseArray(
+        ethers.toUtf8Bytes('- abc\n- bcd\nsomething that is not array anymore'),
+        0,
+      ),
+    ).deep.eq([
+      [
+        ethers.hexlify(ethers.toUtf8Bytes('abc')),
+        ethers.hexlify(ethers.toUtf8Bytes('bcd')),
+      ],
+      12,
+    ]);
+    expect(
+      await siweParserTests.testParseArray(
+        ethers.toUtf8Bytes('something before the array:\n- abc\n- bcd\n'),
+        28,
+      ),
+    ).deep.eq([
+      [
+        ethers.hexlify(ethers.toUtf8Bytes('abc')),
+        ethers.hexlify(ethers.toUtf8Bytes('bcd')),
+      ],
+      40,
+    ]);
+  });
+
+  it('parseSiweMsg full', async function () {
+    const { siweParserTests } = await deploy();
+    const siweMsg = new SiweMessage({
+      domain: 'example.com:5173',
+      scheme: 'http',
+      address: (await ethers.getSigners())[0].address,
+      statement: `I accept the ExampleOrg Terms of Service: http://example.com/tos`,
+      uri: `http://example.com:5173/login`,
+      version: '1',
+      chainId: Number((await ethers.provider.getNetwork()).chainId),
+      nonce: 'abcdef01',
+      issuedAt: '2024-07-10T10:24:49Z',
+      expirationTime: '2024-07-11T10:24:49Z',
+      notBefore: '2024-07-10T10:24:50Z',
+      requestId: 'john%40example.com%3A1234%2Fmy%20very%20secret%20request',
+      resources: ['http://example.com/accounts', 'http://example.com/users'],
+    });
+
+    const parsedSiweMsg: ParsedSiweMessageStruct =
+      await siweParserTests.testParseSiweMsg(
+        ethers.toUtf8Bytes(siweMsg.toMessage()),
+      );
+    expect(parsedSiweMsg.schemeDomain).eq(
+      ethers.hexlify(
+        ethers.toUtf8Bytes(siweMsg.scheme + '://' + siweMsg.domain),
+      ),
+    );
+    expect(parsedSiweMsg.addr).eq(siweMsg.address);
+    expect(parsedSiweMsg.statement).eq(
+      ethers.hexlify(ethers.toUtf8Bytes(siweMsg.statement!)),
+    );
+    expect(parsedSiweMsg.uri).eq(
+      ethers.hexlify(ethers.toUtf8Bytes(siweMsg.uri)),
+    );
+    expect(parsedSiweMsg.version).eq(
+      ethers.hexlify(ethers.toUtf8Bytes(siweMsg.version)),
+    );
+    expect(parsedSiweMsg.chainId).eq(siweMsg.chainId);
+    expect(parsedSiweMsg.nonce).eq(
+      ethers.hexlify(ethers.toUtf8Bytes(siweMsg.nonce)),
+    );
+    expect(parsedSiweMsg.issuedAt).eq(
+      ethers.hexlify(ethers.toUtf8Bytes(siweMsg.issuedAt!)),
+    );
+    expect(parsedSiweMsg.expirationTime).eq(
+      ethers.hexlify(ethers.toUtf8Bytes(siweMsg.expirationTime!)),
+    );
+    expect(parsedSiweMsg.notBefore).eq(
+      ethers.hexlify(ethers.toUtf8Bytes(siweMsg.notBefore!)),
+    );
+    expect(parsedSiweMsg.requestId).eq(
+      ethers.hexlify(ethers.toUtf8Bytes(siweMsg.requestId!)),
+    );
+    for (let i = 0; i < parsedSiweMsg.resources.length; i++) {
+      expect(parsedSiweMsg.resources[i]).eq(
+        ethers.hexlify(ethers.toUtf8Bytes(siweMsg.resources![i])),
+      );
+    }
+  });
+
+  it('parseSiweMsg minimal', async function () {
+    const { siweParserTests } = await deploy();
+    const siweMsg = new SiweMessage({
+      domain: 'example.com',
+      address: (await ethers.getSigners())[0].address,
+      uri: `http://example.com`,
+      version: '1',
+      chainId: Number((await ethers.provider.getNetwork()).chainId),
+      nonce: 'abcdef01',
+      issuedAt: '2024-07-10T10:24:49Z',
+    });
+
+    const parsedSiweMsg: ParsedSiweMessageStruct =
+      await siweParserTests.testParseSiweMsg(
+        ethers.toUtf8Bytes(siweMsg.toMessage()),
+      );
+    expect(parsedSiweMsg.schemeDomain).eq(
+      ethers.hexlify(ethers.toUtf8Bytes(siweMsg.domain)),
+    );
+    expect(parsedSiweMsg.addr).eq(siweMsg.address);
+    expect(parsedSiweMsg.uri).eq(
+      ethers.hexlify(ethers.toUtf8Bytes(siweMsg.uri)),
+    );
+    expect(parsedSiweMsg.version).eq(
+      ethers.hexlify(ethers.toUtf8Bytes(siweMsg.version)),
+    );
+    expect(parsedSiweMsg.chainId).eq(siweMsg.chainId);
+    expect(parsedSiweMsg.nonce).eq(
+      ethers.hexlify(ethers.toUtf8Bytes(siweMsg.nonce)),
+    );
+    expect(parsedSiweMsg.issuedAt).eq(
+      ethers.hexlify(ethers.toUtf8Bytes(siweMsg.issuedAt!)),
+    );
+  });
+
+  it('parseSiweMsg invalid', async function () {
+    const { siweParserTests } = await deploy();
+    const siweMsg = new SiweMessage({
+      domain: 'example.com:5173',
+      scheme: 'http',
+      address: (await ethers.getSigners())[0].address,
+      statement: `I accept the ExampleOrg Terms of Service: http://example.com/tos`,
+      uri: `http://example.com:5173/login`,
+      version: '1',
+      chainId: Number((await ethers.provider.getNetwork()).chainId),
+      nonce: 'abcdef01',
+      issuedAt: '2024-07-10T10:24:49Z',
+      expirationTime: '2024-07-11T10:24:49Z',
+      notBefore: '2024-07-10T10:24:50Z',
+      requestId: 'john%40example.com%3A1234%2Fmy%20very%20secret%20request',
+      resources: ['http://example.com/accounts', 'http://example.com/users'],
+    }).toMessage();
+    const siweMsgInvalidNonce = siweMsg.replace('abcdef01', 'abcdef0');
+
+    await expect(
+      siweParserTests.testParseSiweMsg(ethers.toUtf8Bytes(siweMsgInvalidNonce)),
+    ).to.be.reverted;
+  });
+
+  it('timestampFromIso', async function () {
+    const { siweParserTests } = await deploy();
+
+    const date = '2024-07-10T10:24:49Z';
+    expect(
+      await siweParserTests.testTimestampFromIso(
+        ethers.hexlify(ethers.toUtf8Bytes(date)),
+      ),
+    ).eq(Date.parse(date) / 1000);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   clients/js:
@@ -159,6 +163,9 @@ importers:
       prettier-plugin-solidity:
         specifier: 1.0.0-beta.24
         version: 1.0.0-beta.24(prettier@2.8.8)
+      siwe:
+        specifier: ^2.3.2
+        version: 2.3.2(ethers@6.9.0)
       solhint:
         specifier: ^3.3.7
         version: 3.4.1
@@ -4168,6 +4175,36 @@ packages:
       antlr4ts: 0.5.0-alpha.4
     dev: true
 
+  /@spruceid/siwe-parser@2.1.2:
+    resolution: {integrity: sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ==}
+    dependencies:
+      '@noble/hashes': 1.3.2
+      apg-js: 4.4.0
+      uri-js: 4.4.1
+      valid-url: 1.0.9
+    dev: true
+
+  /@stablelib/binary@1.0.1:
+    resolution: {integrity: sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==}
+    dependencies:
+      '@stablelib/int': 1.0.1
+    dev: true
+
+  /@stablelib/int@1.0.1:
+    resolution: {integrity: sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==}
+    dev: true
+
+  /@stablelib/random@1.0.2:
+    resolution: {integrity: sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==}
+    dependencies:
+      '@stablelib/binary': 1.0.1
+      '@stablelib/wipe': 1.0.1
+    dev: true
+
+  /@stablelib/wipe@1.0.1:
+    resolution: {integrity: sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==}
+    dev: true
+
   /@surma/rollup-plugin-off-main-thread@2.2.3:
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
     dependencies:
@@ -5461,6 +5498,10 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  /apg-js@4.4.0:
+    resolution: {integrity: sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q==}
+    dev: true
 
   /arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
@@ -15045,6 +15086,18 @@ packages:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
 
+  /siwe@2.3.2(ethers@6.9.0):
+    resolution: {integrity: sha512-aSf+6+Latyttbj5nMu6GF3doMfv2UYj83hhwZgUF20ky6fTS83uVhkQABdIVnEuS8y1bBdk7p6ltb9SmlhTTlA==}
+    peerDependencies:
+      ethers: ^5.6.8 || ^6.0.8
+    dependencies:
+      '@spruceid/siwe-parser': 2.1.2
+      '@stablelib/random': 1.0.2
+      ethers: 6.9.0
+      uri-js: 4.4.1
+      valid-url: 1.0.9
+    dev: true
+
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -16689,6 +16742,10 @@ packages:
       '@jridgewell/trace-mapping': 0.3.20
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+    dev: true
+
+  /valid-url@1.0.9:
+    resolution: {integrity: sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==}
     dev: true
 
   /validate-npm-package-license@3.0.4:
@@ -18362,7 +18419,3 @@ packages:
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
Fixes #327 

This PR:
- adds `contracts/SiweParser.sol`, an on-chain parser for SIWE messages
- adds `contracts/auth/A13e.sol`, an abstract interface for authenticated queries (an alternative to signed queries which will get deprecated in https://github.com/oasisprotocol/sapphire-paratime/pull/303)
- adds `contracts/auth/SiweAuth.sol`, an on-chain authenticator for SIWE.
- tests, natspec docs + example

TODO:
- [ ] ~make SiweParser self-contained (merge DateTime into SiweParser?)~ (this doesn't actually improve anything, just adds clutter)
- [x] use error constants in SiweParser and SiweAuth

### Before (signed queries)

```solidity
contract MyContract {
  address private _owner;

  modifier onlyOwner() {
    if (msg.sender != _owner) {
      revert("not allowed");
    }
    _;
  }

  constructor() {
    _owner = msg.sender;
  }

  function getSecretMessage() external view onlyOwner returns (string memory) {
    return "Very secret message";
  }
}
```

### After (on-chain auth)

```solidity
import {SiweAuth} from  "@oasisprotocol/sapphire-contracts/contracts/auth/SiweAuth.sol"

contract MyContract is SiweAuth {
  address private _owner;

  modifier onlyOwner(bytes calldata bearer) {
    if (authMsgSender(bearer) != _owner) {
      revert("not allowed");
    }
    _;
  }

  constructor(string memory domain) SiweAuth(domain) {
    _owner = msg.sender;
  }

  function getSecretMessage(bytes calldata bearer) external view onlyOwner(bearer) returns (string memory) {
    return "Very secret message";
  }
}
```