### PR TITLE
workflow: Fix Ethers V6 publish regex

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,7 +47,7 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           REF_NAME: ${{ github.ref_name }}
         run: |
-          echo "NPM_PACKAGE=$(echo $REF_NAME | grep -oE '(clients/js|contracts|integrations/(hardhat|wagmi-v2|viem-v2))')" >> $GITHUB_OUTPUT
+          echo "NPM_PACKAGE=$(echo $REF_NAME | grep -oE '(clients/js|contracts|integrations/(ethers-v6|hardhat|wagmi-v2|viem-v2))')" >> $GITHUB_OUTPUT
       - name: Publish ${{ github.ref_name }} to NPM
         uses: JS-DevTools/npm-publish@v3
         with:


### PR DESCRIPTION
## Description

We needed to add the `ethers-v6` JS package to the publishing regex.