### PR TITLE
docs: Update quickstart code references

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -112,8 +112,8 @@ Start by pasting [Vigil.sol] into `contracts/Vigil.sol`.
 While you're there, also place [run-vigil.ts] into `scripts/run-vigil.ts`.
 We'll need that later.
 
-[Vigil.sol]: https://github.com/oasisprotocol/sapphire-paratime/blob/main/examples/hardhat/contracts/Vigil.sol
-[run-vigil.ts]: https://github.com/oasisprotocol/sapphire-paratime/blob/main/examples/hardhat/scripts/run-vigil.ts
+[Vigil.sol]: https://github.com/oasisprotocol/sapphire-paratime/blob/clients/js/v1.3.2/examples/hardhat/contracts/Vigil.sol
+[run-vigil.ts]: https://github.com/oasisprotocol/sapphire-paratime/blob/clients/js/v1.3.2/examples/hardhat/scripts/run-vigil.ts
 
 #### Vigil.sol, the interesting parts
 
@@ -203,5 +203,5 @@ out the official [Oasis starter] files.
 
 [social-media]: https://github.com/oasisprotocol/docs/blob/main/docs/get-involved/README.md#social-media-channels
 [guide]: guide.mdx
-[hardhat-example]: https://github.com/oasisprotocol/sapphire-paratime/tree/main/examples/hardhat
+[hardhat-example]: https://github.com/oasisprotocol/sapphire-paratime/blob/clients/js/v1.3.2/examples/hardhat-boilerplate
 [`@oasisprotocol/sapphire-hardhat`]: https://www.npmjs.com/package/@oasisprotocol/sapphire-hardhat


### PR DESCRIPTION
## Description

After Viem and Wagmi V2 changes in https://github.com/oasisprotocol/sapphire-paratime/pull/303, some code examples are out of date. Closes https://github.com/oasisprotocol/sapphire-paratime/issues/351