### PR TITLE
packaging: use PNPM for publishing, with correct tags

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,12 +47,11 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           REF_NAME: ${{ github.ref_name }}
         run: |
-          echo "NPM_PACKAGE=$(echo $REF_NAME | grep -oE '(clients/js|contracts|integrations/(hardhat|wagmi-v2|viem-v2))')" >> $GITHUB_OUTPUT
+          echo "NPM_PACKAGE=$(echo $REF_NAME | grep -oE '(clients/js|contracts|integrations/(ethers-v6|hardhat|wagmi-v2|viem-v2))')" >> $GITHUB_OUTPUT
+          echo "NPM_TAG=$(echo $REF_NAME | grep -oP '(?<=\-)(rc|next|alpha|beta)' || echo 'latest')" >> $GITHUB_OUTPUT
       - name: Publish ${{ github.ref_name }} to NPM
-        uses: JS-DevTools/npm-publish@v3
-        with:
-          # Build runs as a prepublish script
-          ignore-scripts: false
-          token: ${{ secrets.NPM_TOKEN }}
-          package: ${{ steps.extract-tag.outputs.NPM_PACKAGE }}
-          access: public
+        run: pnpm publish --access public --no-git-checks --tag ${{ steps.extract-tag.outputs.NPM_TAG }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+        working-directory: ${{ steps.extract-tag.outputs.NPM_PACKAGE }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,8 +50,9 @@ jobs:
           echo "NPM_PACKAGE=$(echo $REF_NAME | grep -oE '(clients/js|contracts|integrations/(ethers-v6|hardhat|wagmi-v2|viem-v2))')" >> $GITHUB_OUTPUT
           echo "NPM_TAG=$(echo $REF_NAME | grep -oP '(?<=\-)(rc|next|alpha|beta)' || echo 'latest')" >> $GITHUB_OUTPUT
       - name: Publish ${{ github.ref_name }} to NPM
-        run: pnpm publish --access public --no-git-checks --tag ${{ steps.extract-tag.outputs.NPM_TAG }}
+        run: pnpm publish --access public --no-git-checks --tag $NPM_TAG
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          NPM_TAG: ${{ steps.extract-tag.outputs.NPM_TAG }}
         working-directory: ${{ steps.extract-tag.outputs.NPM_PACKAGE }}


### PR DESCRIPTION
fixes: #362
includes: #358

extracts the following tags:

 * rc
 * next
 * alpha
 * beta

also enables NPM provenance when publishing

We can change the dist-tag for the `latest` tag: https://stackoverflow.com/questions/67813980/how-to-point-latest-dist-tag-to-a-previous-version-in-npm

```bash
npm dist-tag add <pkg name>@<version> latest
```

And release new versions under the appropriate `alpha` or `beta` tags. Maybe as @matevz recommended we should just use `next` ?