### PR TITLE
packaging: bump versions + add CHANGELOG entries

### DIFF
--- a/clients/js/CHANGELOG.md
+++ b/clients/js/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is inspired by [Keep a Changelog].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 
+## 2.0.0-next.1 (2024-08)
+
+### Fixed
+
+- Use PNPM to publish packaging, so `workspace:^` links in package.json get translated to their correct versions.
+
 ## 2.0.0-alpha.1 (2024-06)
 
 ### Added

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@oasisprotocol/sapphire-paratime",
   "license": "Apache-2.0",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-next.1",
   "description": "The Sapphire ParaTime Web3 integration library.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/clients/js",
   "repository": {

--- a/integrations/ethers-v6/CHANGELOG.md
+++ b/integrations/ethers-v6/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+All notables changes to this project are documented in this file.
+
+The format is inspired by [Keep a Changelog].
+
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
+
+## 6.0.0-next.1 (2024-08)
+
+### Fixed
+
+ - Use PNPM to publish packaging, so `workspace:^` links in package.json get translated to their correct versions.

--- a/integrations/ethers-v6/package.json
+++ b/integrations/ethers-v6/package.json
@@ -2,7 +2,7 @@
 	"type": "module",
 	"name": "@oasisprotocol/sapphire-ethers-v6",
 	"license": "Apache-2.0",
-	"version": "6.0.0-alpha.0",
+	"version": "6.0.0-next.1",
 	"description": "Ethers v6 support for the Oasis Sapphire ParaTime.",
 	"homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/ethers-v6",
 	"repository": {

--- a/integrations/hardhat/CHANGELOG.md
+++ b/integrations/hardhat/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+All notables changes to this project are documented in this file.
+
+The format is inspired by [Keep a Changelog].
+
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
+
+## 2.22.2-next.0 (2024-08)
+
+### Fixed
+
+- Use PNPM to publish packaging, so `workspace:^` links in package.json get translated to their correct versions.

--- a/integrations/hardhat/package.json
+++ b/integrations/hardhat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oasisprotocol/sapphire-hardhat",
   "license": "Apache-2.0",
-  "version": "2.22.2",
+  "version": "2.22.2-next.0",
   "description": "A Hardhat plugin for developing on the Sapphire ParaTime.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/hardhat",
   "repository": {

--- a/integrations/viem-v2/CHANGELOG.md
+++ b/integrations/viem-v2/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+All notables changes to this project are documented in this file.
+
+The format is inspired by [Keep a Changelog].
+
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
+
+## 2.0.0-next.1 (2024-08)
+
+### Fixed
+
+ - Use PNPM to publish packaging, so `workspace:^` links in package.json get translated to their correct versions.

--- a/integrations/viem-v2/package.json
+++ b/integrations/viem-v2/package.json
@@ -2,7 +2,7 @@
 	"type": "module",
 	"name": "@oasisprotocol/sapphire-viem-v2",
 	"license": "Apache-2.0",
-	"version": "2.0.0-alpha.0",
+	"version": "2.0.0-next.1",
 	"description": "Viem support for the Oasis Sapphire ParaTime.",
 	"homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/viem-v2",
 	"repository": {

--- a/integrations/wagmi-v2/CHANGELOG.md
+++ b/integrations/wagmi-v2/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+All notables changes to this project are documented in this file.
+
+The format is inspired by [Keep a Changelog].
+
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
+
+## 2.0.0-next.1 (2024-08)
+
+### Fixed
+
+ - Use PNPM to publish packaging, so `workspace:^` links in package.json get translated to their correct versions.

--- a/integrations/wagmi-v2/package.json
+++ b/integrations/wagmi-v2/package.json
@@ -2,7 +2,7 @@
 	"type": "module",
 	"name": "@oasisprotocol/sapphire-wagmi-v2",
 	"license": "Apache-2.0",
-	"version": "2.0.0-alpha.0",
+	"version": "2.0.0-next.1",
 	"description": "Wagmi & Viem support for the Oasis Sapphire ParaTime.",
 	"homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/wagmi-v2",
 	"repository": {


### PR DESCRIPTION
re: #362
re: #363

for the following packages:

 * oasisprotocol/sapphire-paratime
 * oasisprotocol/sapphire-ethers-v6
 * oasisprotocol/sapphire-hardhat
 * oasisprotocol/sapphire-viem-v2
 * oasisprotocol/sapphire-wagmi-v2

They will be released under the `next` tag, to test updated publish.yaml workflow
after publishing the bundlephobia links in the main README.md should work
It should also be possible to install the packages & resolve their dependencies.