### PR TITLE
packaging: permissions necessary for provenance pubishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,7 @@ on:
 # See: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds
 permissions:
   id-token: write # to enable use of OIDC for npm provenance
+  contents: read
 
 jobs:
   publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,11 @@ on:
       - integrations/viem-v2/v[0-9]+.[0-9]+.[0-9]+*
       - integrations/wagmi-v2/v[0-9]+.[0-9]+.[0-9]+*
 
+# See: https://docs.npmjs.com/generating-provenance-statements
+# See: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds
+permissions:
+  id-token: write # to enable use of OIDC for npm provenance
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@oasisprotocol/sapphire-paratime",
   "license": "Apache-2.0",
-  "version": "2.0.0-next.2",
+  "version": "2.0.0-next.3",
   "description": "The Sapphire ParaTime Web3 integration library.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/clients/js",
   "repository": {


### PR DESCRIPTION
Publishing with pnpm failed as we're trying to publish with provenance, but it doesn't have the necessary permissions in the workflow.

This error message was in logs:

```
npm notice Publishing to https://registry.npmjs.org/ with tag next and public access
npm error code EUSAGE
npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
```

See:
 * https://github.blog/news-insights/product-news/introducing-artifact-attestations-now-in-public-beta/
 * https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
 * https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds
 * https://docs.npmjs.com/generating-provenance-statements