### PR TITLE
contracts: add support for core.CallDataPublicKey and core.CurrentEpoch

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is inspired by [Keep a Changelog].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 
+## 0.2.11 (2024-09)
+
+### Added
+
+ * `Subcall.sol` support for `core.CallDataPublicKey` and `core.CurrentEpoch`
+
 ## 0.2.10 (2024-08-20)
 
 ### Added

--- a/contracts/contracts/tests/SubcallTests.sol
+++ b/contracts/contracts/tests/SubcallTests.sol
@@ -120,4 +120,25 @@ contract SubcallTests {
     {
         return Subcall._parseCBORUint(result, offset);
     }
+
+    event RawResult(uint64, bytes);
+
+    function testParseCallDataPublicKey(bytes memory data)
+        external
+        pure
+        returns (uint256 epoch, Subcall.CallDataPublicKey memory public_key)
+    {
+        (epoch, public_key) = Subcall._parseCBORCallDataPublicKey(data);
+    }
+
+    function testCoreCallDataPublicKey()
+        external
+        returns (uint256 epoch, Subcall.CallDataPublicKey memory public_key)
+    {
+        (epoch, public_key) = Subcall.coreCallDataPublicKey();
+    }
+
+    function testCoreCurrentEpoch() external returns (uint256 epoch) {
+        return Subcall.coreCurrentEpoch();
+    }
 }

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisprotocol/sapphire-contracts",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "license": "Apache-2.0",
   "description": "Solidity smart contract library for confidential contract development",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/contracts",


### PR DESCRIPTION
Adds two methods to `Subcall.sol`

 * `coreCallDataPublicKey`
 * `coreCurrentEpoch`