### PR TITLE
docs: Fix broken links to Vigil.sol contract

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -197,6 +197,15 @@ repository.
 
 :::
 
+:::info Example
+
+If your project involves building both a contract backend and a web frontend,
+we recommend that you check out the official [Oasis starter] files.
+
+[Oasis starter]: https://github.com/oasisprotocol/demo-starter
+
+:::
+
 [block explorer]: https://explorer.oasis.io/testnet/sapphire/tx/0x3303dea5d48291d1564cad573f21fc71fcbdc2b862e17e056287fd9207e3bc53
 [guide-transaction-calls]: guide.mdx#transactions--calls
 [Hardhat boilerplate repo]: https://github.com/NomicFoundation/hardhat-boilerplate

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -112,8 +112,8 @@ Start by pasting [Vigil.sol] into `contracts/Vigil.sol`.
 While you're there, also place [run-vigil.ts] into `scripts/run-vigil.ts`.
 We'll need that later.
 
-[Vigil.sol]: https://github.com/oasisprotocol/sapphire-paratime/blob/main/examples/hardhat/contracts/Vigil.sol
-[run-vigil.ts]: https://github.com/oasisprotocol/sapphire-paratime/blob/main/examples/hardhat/scripts/run-vigil.ts
+[Vigil.sol]: https://github.com/oasisprotocol/sapphire-paratime/blob/stable/clients/js/1.x/examples/hardhat/contracts/Vigil.sol
+[run-vigil.ts]: https://github.com/oasisprotocol/sapphire-paratime/blob/stable/clients/js/1.x/examples/hardhat/scripts/run-vigil.ts
 
 #### Vigil.sol, the interesting parts
 
@@ -203,5 +203,5 @@ out the official [Oasis starter] files.
 
 [social-media]: https://github.com/oasisprotocol/docs/blob/main/docs/get-involved/README.md#social-media-channels
 [guide]: guide.mdx
-[hardhat-example]: https://github.com/oasisprotocol/sapphire-paratime/tree/main/examples/hardhat
+[hardhat-example]: https://github.com/oasisprotocol/sapphire-paratime/blob/stable/clients/js/1.x/examples/hardhat
 [`@oasisprotocol/sapphire-hardhat`]: https://www.npmjs.com/package/@oasisprotocol/sapphire-hardhat


### PR DESCRIPTION
Fixes broken links introduced in https://github.com/oasisprotocol/sapphire-paratime/pull/303

Now points to the stable/clients/js/1.x branch.