### PR TITLE
integrations: Remove extra fetching of runtime public key

### DIFF
--- a/integrations/viem-v2/src/index.ts
+++ b/integrations/viem-v2/src/index.ts
@@ -123,9 +123,6 @@ export async function createSapphireSerializer<
 	const fetcher = new KeyFetcher();
 	const provider = client as EthereumProvider;
 	await fetcher.fetch(provider);
-	setTimeout(async () => {
-		await fetcher.fetch(provider);
-	}, fetcher.timeoutMilliseconds);
 
 	const wrappedSerializer = ((tx, sig?) => {
 		if (!sig) {


### PR DESCRIPTION
## Description

Address Node timeout issue encountered by [developers](https://discord.com/channels/748635004384313474/960599114993762304/1279839606719643650).

> Im using the alpha of @oasisprotocol/sapphire-viem-v2, and it looks like when using it, node process wont naturally terminate (w/o a call to exit() ). I think that its the fault of this timer

https://github.com/oasisprotocol/sapphire-paratime/blob/77a2bea6b11e8cbd87da8c15c725ee01b77b381b/integrations/viem-v2/src/index.ts#L126-L128

## Resolution

I don't think we need the second `fetch`.