### PR TITLE
docs: Mention demo-starter-go and demo-starter-py

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -190,14 +190,14 @@ transactions!
 Should you have any questions or ideas to share, feel free to reach out to us
 on [discord and other social media channels][social-media].
 
-:::info Example
+:::info Example: Hardhat boilerplate
 
 You can download a full working example from the [Sapphire ParaTime examples]
 repository.
 
 :::
 
-:::info Example
+:::info Example: Starter project
 
 If your project involves building both a contract backend and a web frontend,
 we recommend that you check out the official [Oasis starter] files.

--- a/docs/gasless.md
+++ b/docs/gasless.md
@@ -196,7 +196,7 @@ const receipt = await ethers.provider.getTransactionReceipt(plainResp.hash);
 if (!receipt || receipt.status != 1) throw new Error('tx failed');
 ```
 
-:::info Example
+:::info Example: On-Chain Signer
 
 You can download a complete on-chain signer example based on the above snippets
 from the [Sapphire ParaTime examples] repository.
@@ -246,7 +246,7 @@ of the transactions is not deterministic and nonces could mismatch. To overcome
 this, relayer can randomly pick a signer from the **pool of signers**. When the
 transaction is relayed, don't forget to reimburse the signer of the transaction!
 
-:::info Example
+:::info Example: Voting dApp
 
 All the above points are considered in the [Demo Voting dApp][demo-voting].
 You can explore the code and also try out a deployed gasless version of the

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -197,7 +197,7 @@ out the official [Oasis starter] files.
 
 :::info Example: Go and Python
 
-Are you building your dApp in langauges other than TypeScript? Check out the
+Are you building your dApp in languages other than TypeScript? Check out the
 official [Oasis starter project for Go] and the [Oasis starter project for Python].
 
 [Oasis starter project for Go]: https://github.com/oasisprotocol/demo-starter-go

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -179,19 +179,29 @@ questions, please check out the [guide] and join the discussion on the
 
 Best of luck on your future forays into confidentiality!
 
-:::info Example
+:::info Example: Hardhat
 
 Visit the Sapphire ParaTime repository to download the [Hardhat][hardhat-example]
 example of this quickstart.
 
 :::
 
-:::info Example
+:::info Example: Starter project
 
 If your project involves building a web frontend, we recommend that you check
 out the official [Oasis starter] files.
 
 [Oasis starter]: https://github.com/oasisprotocol/demo-starter
+
+:::
+
+:::info Example: Go and Python
+
+Are you building your dApp in langauges other than TypeScript? Check out the
+official [Oasis starter project for Go] and the [Oasis starter project for Python].
+
+[Oasis starter project for Go]: https://github.com/oasisprotocol/demo-starter-go
+[Oasis starter project for Python]: https://github.com/oasisprotocol/demo-starter-py
 
 :::
 


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/demo-starter-go/issues/2.

This PR:
- adds demo-starter-go and demo-starter-py references
- makes usage of  `:::info Example:` consistent

Merge after https://github.com/oasisprotocol/demo-starter-py/pull/1.