### PR TITLE
packaging: remove semver tags from package versions

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@oasisprotocol/sapphire-paratime",
   "license": "Apache-2.0",
-  "version": "2.0.0-next.3",
+  "version": "2.0.0",
   "description": "The Sapphire ParaTime Web3 integration library.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/clients/js",
   "repository": {

--- a/integrations/ethers-v6/package.json
+++ b/integrations/ethers-v6/package.json
@@ -2,7 +2,7 @@
 	"type": "module",
 	"name": "@oasisprotocol/sapphire-ethers-v6",
 	"license": "Apache-2.0",
-	"version": "6.0.0-next.1",
+	"version": "6.0.0",
 	"description": "Ethers v6 support for the Oasis Sapphire ParaTime.",
 	"homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/ethers-v6",
 	"repository": {

--- a/integrations/hardhat/package.json
+++ b/integrations/hardhat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oasisprotocol/sapphire-hardhat",
   "license": "Apache-2.0",
-  "version": "2.22.2-next.0",
+  "version": "2.22.2-next.1",
   "description": "A Hardhat plugin for developing on the Sapphire ParaTime.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/hardhat",
   "repository": {

--- a/integrations/viem-v2/CHANGELOG.md
+++ b/integrations/viem-v2/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is inspired by [Keep a Changelog].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 
+## 2.0.1 (2024-09)
+
+https://github.com/oasisprotocol/sapphire-paratime/milestone/5
+
+### Fixed
+
+ - Viem v2 hangs in Node due to referenced interval timer
+   - https://github.com/oasisprotocol/sapphire-paratime/pull/383
+
 ## 2.0.0-next.1 (2024-08)
 
 ### Fixed

--- a/integrations/viem-v2/package.json
+++ b/integrations/viem-v2/package.json
@@ -2,7 +2,7 @@
 	"type": "module",
 	"name": "@oasisprotocol/sapphire-viem-v2",
 	"license": "Apache-2.0",
-	"version": "2.0.0-next.1",
+	"version": "2.0.0",
 	"description": "Viem support for the Oasis Sapphire ParaTime.",
 	"homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/viem-v2",
 	"repository": {

--- a/integrations/viem-v2/package.json
+++ b/integrations/viem-v2/package.json
@@ -2,7 +2,7 @@
 	"type": "module",
 	"name": "@oasisprotocol/sapphire-viem-v2",
 	"license": "Apache-2.0",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Viem support for the Oasis Sapphire ParaTime.",
 	"homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/viem-v2",
 	"repository": {

--- a/integrations/wagmi-v2/package.json
+++ b/integrations/wagmi-v2/package.json
@@ -2,7 +2,7 @@
 	"type": "module",
 	"name": "@oasisprotocol/sapphire-wagmi-v2",
 	"license": "Apache-2.0",
-	"version": "2.0.0-next.1",
+	"version": "2.0.0",
 	"description": "Wagmi & Viem support for the Oasis Sapphire ParaTime.",
 	"homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/wagmi-v2",
 	"repository": {


### PR DESCRIPTION
So, need to re-release packages to get versioning working correctly.

So, we're going to archive:

 * `@oasisprotocol/sapphire-paratime` v2.0.0-alpha.0 on the `latest` tag
 * `@oasisprotocol/sapphire-paratime` v2.0.0-next.3 on the `next` tag

Then release `@oasisprotocol/sapphire-paratime` v2.0.0 on the `next` tag

The `sapphire-viem-v2`, `sapphire-ethers-v6`, `sapphire-hardhat` and `sapphire-wagmi-v2` packages will be published on their own `latest` tags.

Meaning people who `npm install @oasisprotocol/sapphire-paratime` will get v1.x by default, but if you install `@oasisprotocol/sapphire-ethers-v6` you'll get `@oasisprotocol/sapphire-paratime` v2 as a dependency.

This means we'll be tagging `clients/js/v2.0.0-next` (to publish to the `next` dist-tag on NPMJS), but `integrations/ethers-v6/v6.0.0` (to publish to `latest`).

Version resolution for dependencies on package.json will ignore the dist-tags, but adhere to any semver rules.