### PR TITLE
integrations/ethers-v6: make sapphire-paratime a non-optional dependency

### DIFF
--- a/integrations/ethers-v6/package.json
+++ b/integrations/ethers-v6/package.json
@@ -48,9 +48,6 @@
 	"peerDependenciesMeta": {
 		"typescript": {
 			"optional": true
-		},
-		"@oasisprotocol/sapphire-paratime": {
-			"optional": true
 		}
 	},
 	"devDependencies": {


### PR DESCRIPTION
Fixes: #395