### PR TITLE
clients/js: fix lint warnings in tests

### DIFF
--- a/clients/js/test/utils.ts
+++ b/clients/js/test/utils.ts
@@ -5,7 +5,6 @@ import {
   hexlify,
   isCallDataPublicKeyQuery,
 } from '@oasisprotocol/sapphire-paratime';
-import { SUBCALL_ADDR, CALLDATAPUBLICKEY_CALLDATA } from '../src/constants';
 import { encode as cborEncode } from 'cborg';
 import nacl from 'tweetnacl';
 import { AbiCoder } from 'ethers';


### PR DESCRIPTION
Other PRs are showing minor warnings.
This hides the warnings by removing the unused vars.