### PR TITLE
docs: Update main Sapphire page content

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -1,23 +1,18 @@
 import DocCardList from '@theme/DocCardList';
 import {findSidebarItem} from '@site/src/sidebarUtils';
-import {AddSapphireToMetaMask as S, AddSapphireTestnetToMetaMask as ST} from '@site/src/AddToMetaMask';
 
 # Sapphire ParaTime
 
-Sapphire is our official confidential ParaTime providing a smart contract
-development environment with [Ethereum Virtual Machine (EVM)] compatibility.
-
-As the official confidential EVM-compatible ParaTime on the Oasis Network,
-Sapphire allows for:
+Sapphire is our official confidential ParaTime for smart contract development
+with [Ethereum Virtual Machine (EVM)] compatibility.
 
 * Confidential state, end-to-end encryption, confidential randomness
-* EVM compatibility
 * Easy integration with EVM-based dApps, such as DeFi, NFT, Metaverse and
-  crypto gaming
+crypto gaming
 * Scalability: increased throughput of transactions
 * Low-cost: 99%+ lower fees than Ethereum
 * 6 second finality (1 block)
-* Cross-chain bridge to enable cross-chain interoperability (upcoming)
+* Cross-chain bridges to enable cross-chain interoperability
 
 If you are not bound to EVM and you wish to develop dApps with more
 fine-grained confidentiality, check out the
@@ -25,103 +20,41 @@ fine-grained confidentiality, check out the
 
 [Ethereum Virtual Machine (EVM)]: https://ethereum.org/en/developers/docs/evm/
 
-## Chain Information
+### Getting Started
 
-### Mainnet
+Develop and deploy a dApp on Sapphire:
+- follow along with a video walkthrough via [quickstart][quickstart]
+- start with a working dApp [demo][demo]
+- explore showcase dApps deployed on Sapphire on the [playground][playground]
 
-- Network name: `sapphire`
-- Long network name: `Oasis Sapphire`
-- Chain ID:
-  - Hex: `0x5afe`
-  - Decimal: `23294`
+[quickstart]: ./quickstart.mdx
+[playground]: https://playground.oasis.io/
+[demo]: https://github.com/oasisprotocol/demo-starter
 
-### Testnet
+### Understanding EVM compatibility
 
-- Network name: `sapphire-testnet`
-- Long network name: `Oasis Sapphire Testnet`
-- Chain ID:
-  - Hex: `0x5aff`
-  - Decimal: `23295`
+Get to know the differences between Sapphire and Ethereum, and learn about
+the high level concepts of developing a confidential smart contract with our
+[guide][guide].
 
-## RPC Endpoints
+[guide]: ./guide.mdx
 
-:::danger
+### Building on Sapphire
 
-The RPC endpoint is a *point of trust*. Beside traffic rate limiting, it can
-also perform censorship or even a man-in-the-middle attack. If you have security
-considerations, we strongly recommend that you set up your own [ParaTime client
-node][paratime-client-node] and the [Web3-compatible gateway].
+Take your existing dApp building knowledge and add Sapphire with our developer
+[cheatsheet](./images/cheatsheet.pdf).
 
-:::
+### Network Information
 
-[Web3-compatible gateway]: ../../node/web3.mdx
-[paratime-client-node]: ../../node/run-your-node/paratime-client-node.mdx
+See crucial network information [here][network].
 
-You can connect to one of the public Web3 gateways below (in alphabetic order):
+[network]: ./network.mdx
 
-| Provider                    | Mainnet RPC URLs                                                        | Testnet RPC URLs                                                                           | Supports Confidential Queries |
-|-----------------------------|-------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|-------------------------------|
-| [1RPC]                      | <S rpcs={['https://1rpc.io/oasis/sapphire']} />                         | *N/A*                                                                                      | Yes                           |
-| [Oasis Protocol Foundation] | <S rpcs={['https://sapphire.oasis.io','wss://sapphire.oasis.io/ws']} /> | <ST rpcs={['https://testnet.sapphire.oasis.io','wss://testnet.sapphire.oasis.io/ws']} /> | Yes                           |
+### Faucet
 
-[Oasis Protocol Foundation]: https://oasisprotocol.org
+Visit the [faucet][faucet] to obtain testnet tokens for development purposes.
 
-Public RPCs may have rate limits or traffic restrictions. For professional,
-dedicated RPC endpoints, consider the following providers (in alphabetic order):
-
-| Provider     | Instructions                           | Pricing                       | Supports Confidential Queries |
-|--------------|----------------------------------------|-------------------------------|-------------------------------|
-| [1RPC]       | [docs.1rpc.io][1RPC-docs]              | [Pricing][1RPC-pricing]       | Yes                           |
-| [Chainstack] | [docs.chainstack.com][Chainstack-docs] | [Pricing][Chainstack-pricing] | Yes                           |
-
-
-[1RPC]: https://www.1rpc.io/
-[1RPC-docs]: https://docs.1rpc.io/guide/how-to-use-1rpc
-[1RPC-pricing]: https://www.1rpc.io/#pricing
-[Chainstack]: https://chainstack.com/build-better-with-oasis-sapphire/
-[Chainstack-docs]: https://docs.chainstack.com/docs/oasis-sapphire-tooling
-[Chainstack-pricing]: https://chainstack.com/pricing/
-
-## Block Explorers
-
-| Name (Provider)                               | Mainnet URL                                | Testnet URL                                | EIP-3091 compatible |
-|-----------------------------------------------|--------------------------------------------|--------------------------------------------|---------------------|
-| Oasis Explorer ([Oasis Protocol Foundation])  | https://explorer.oasis.io/mainnet/sapphire | https://explorer.oasis.io/testnet/sapphire | Yes                 |
-| Oasis Scan ([Bit Cat])                        | [https://www.oasisscan.com/paratimes/000…279](https://www.oasisscan.com/paratimes/000000000000000000000000000000000000000000000000f80306c9858e7279) | [https://testnet.oasisscan.com/paratimes/000…f6c](https://testnet.oasisscan.com/paratimes/000000000000000000000000000000000000000000000000a6d1e3ebf60dff6c) | No |
-
-[Bit Cat]: https://www.bitcat365.com/
-
-## Indexers
-
-| Name (Provider)      | Mainnet URL                                                    | Testnet URL                                            | Documentation                              |
-|--------------------|------------------------------------------------------------------|--------------------------------------------------------|--------------------------------------------|
-| [Covalent]                   | `https://api.covalenthq.com/v1/oasis-sapphire-mainnet` | `https://api.covalenthq.com/v1/oasis-sapphire-testnet` | [Unified API docs][Covalent-docs]          |
-| [Goldsky Subgraph][Goldsky]  | *N/A*                                                  | *N/A*                                                  | [Documentation site][Goldsky-docs]         |
-| Oasis Nexus ([Oasis Protocol Foundation]) | `https://nexus.oasis.io/v1/`              | `https://testnet.nexus.oasis.io/v1/`                   | [API][Nexus-docs]                          |
-| Oasis Scan ([Bit Cat])       | `https://api.oasisscan.com/mainnet/v2`                 | `https://api.oasisscan.com/testnet/v2`                 | [Mainnet Runtime API][OasisScan-Mainnet-docs], [Testnet Runtime API][OasisScan-Testnet-docs] |
-| [SubQuery Network][SubQuery] | *N/A*                                                  | *N/A*                                                  | [SubQuery Academy][SubQuery-docs], [QuickStart][SubQuery-quickstart], [Starter project][SubQuery-starter] |
-
-[Covalent]: https://www.covalenthq.com/
-[Covalent-docs]: https://www.covalenthq.com/docs/unified-api/
-[Nexus-docs]: https://nexus.oasis.io/v1/spec/v1.html
-[Goldsky]: https://goldsky.com
-[Goldsky-docs]: https://docs.goldsky.com/subgraphs/deploying-subgraphs
-[OasisScan-Testnet-docs]: https://api.oasisscan.com/testnet/swagger-ui/#/runtime-controller
-[OasisScan-Mainnet-docs]: https://api.oasisscan.com/mainnet/swagger-ui/#/runtime-controller
-[SubQuery]: https://subquery.network
-[SubQuery-docs]: https://academy.subquery.network/
-[SubQuery-quickstart]: https://academy.subquery.network/quickstart/quickstart.html
-[SubQuery-starter]: https://github.com/subquery/ethereum-subql-starter/tree/main/Oasis/oasis-sapphire-starter
-
-:::note
-
-If you are running your own Sapphire endpoint, a block explorer, or an indexer
-and wish to be added to these docs, open an issue at
-[github.com/oasisprotocol/docs].
-
-:::
-
-[github.com/oasisprotocol/docs]: https://github.com/oasisprotocol/docs
+[faucet]: https://faucet.testnet.oasis.io/
 
 ## See also
 

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -213,7 +213,7 @@ we recommend that you check out the official [Oasis starter] files.
 [Hardhat tutorial]: https://hardhat.org/tutorial
 [line 66]: https://github.com/NomicFoundation/hardhat-boilerplate/blob/13bd712c1285b2de572f14d20e6a750ae08565c0/contracts/Token.sol#L66
 [quickstart]: quickstart.mdx#add-the-sapphire-testnet-to-hardhat
-[sapphire-testnet]: ./README.mdx#testnet
+[sapphire-testnet]: ./network.mdx#testnet
 [Sapphire ParaTime examples]: https://github.com/oasisprotocol/sapphire-paratime/tree/main/examples/hardhat-boilerplate
 [social-media]: https://github.com/oasisprotocol/docs/blob/main/docs/get-involved/README.md#social-media-channels
 [pnpm]: https://pnpm.io

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -185,7 +185,7 @@ Sapphire is programmable using any language that targets the EVM, such as Solidi
 Fe or Vyper. If you prefer to use an Ethereum framework like Hardhat or Foundry,
 you can also use those with Sapphire; all you need to do is set your Web3 gateway URL.
 You can find the details of the Oasis Sapphire Web3 endpoints
-[here](https://github.com/oasisprotocol/docs/blob/main/docs/dapp/sapphire/README.mdx#rpc-endpoints).
+[here](https://github.com/oasisprotocol/docs/blob/main/docs/dapp/sapphire/network.mdx#rpc-endpoints).
 
 ### Transactions & Calls
 


### PR DESCRIPTION
## Description

Use new Sapphire page content and update anchors to reference Network page.

Fix links introduced in #402.

```sh
  Exhaustive list of all broken anchors found:
  - Broken anchor on source page path = /dapp/sapphire/browser:
     -> linking to /dapp/sapphire/#testnet
  - Broken anchor on source page path = /dapp/sapphire/guide:
     -> linking to /dapp/sapphire/#rpc-endpoints
```
https://github.com/oasisprotocol/docs/actions/runs/10951224600/job/30407909516?pr=940