### PR TITLE
packaging: bump clients/js to 2.0.1 and update CHANGELOG

### DIFF
--- a/clients/js/CHANGELOG.md
+++ b/clients/js/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is inspired by [Keep a Changelog].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 
+## 2.0.1 (2024-09)
+
+https://github.com/oasisprotocol/sapphire-paratime/milestone/2?closed=1
+
+### Fixed
+
+- Use `core.CallDataPublicKey` subcall, instead of `oasis_callDataPublicKey` RPC call
+
 ## 2.0.0-next.1 (2024-08)
 
 ### Fixed

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@oasisprotocol/sapphire-paratime",
   "license": "Apache-2.0",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The Sapphire ParaTime Web3 integration library.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/clients/js",
   "repository": {


### PR DESCRIPTION
Ready to release `@oasisprotocol/sapphire-paratime` package on npmjs

Need to tag `clients/js/v2.0.1-next`