### PR TITLE
docs: Remove cbridge listings for deprecated networks Goerli and Mumbai

### DIFF
--- a/docs/_fetch-cbridge-tokens.py
+++ b/docs/_fetch-cbridge-tokens.py
@@ -12,7 +12,11 @@ def format_result(data):
     for p in data['pegged_pair_configs']:
         org_chain = chains[p['org_chain_id']]
         pegged_chain = chains[p['pegged_chain_id']]
-        if p['org_chain_id'] in [0x5afe,0x5aff] or p['pegged_chain_id'] in [0x5afe,0x5aff]:
+        org_chain_is_sapph = p['org_chain_id'] in [0x5afe,0x5aff]
+        pegged_chain_is_sapph = p['pegged_chain_id'] in [0x5afe,0x5aff]
+        chain_is_not_deprecated = (p['org_chain_id'] not in [0x5, 0x13881] and
+                                   p['pegged_chain_id'] not in [0x5, 0x13881])
+        if (org_chain_is_sapph or pegged_chain_is_sapph) and chain_is_not_deprecated:
             src_url = org_chain['explore_url'] + 'address/' + p["org_token"]["token"]["address"]
             dest_url = pegged_chain['explore_url'] + 'address/' + p["pegged_token"]["token"]["address"]
             print(f'| {org_chain["name"]} ({org_chain["id"]}) | {p["org_token"]["token"]["symbol"]} | [`{p["org_token"]["token"]["address"]}`]({src_url}) | {pegged_chain["name"]} ({pegged_chain["id"]}) | [`{p["pegged_token"]["token"]["address"]}`]({dest_url}) |')

--- a/docs/addresses.md
+++ b/docs/addresses.md
@@ -44,9 +44,7 @@ description: List of Standard Contract Addresses
 <!-- WARNING: please don't manually update the table! -->
 | Source Chain | Token Name | Source Address | Dest. Chain | Dest Address |
 | ------------ | ---------- | -------------- | ----------- | ------------ |
-| Goerli (5) | USDT | [`0xf4B2cbc3bA04c478F0dC824f4806aC39982Dce73`](https://goerli.etherscan.io/address/0xf4B2cbc3bA04c478F0dC824f4806aC39982Dce73) | Oasis Sapphire Testnet (23295) | [`0xa55C7E1274bE5db2275a0BDd055f81e8263b7954`](https://testnet.explorer.sapphire.oasis.dev/address/0xa55C7E1274bE5db2275a0BDd055f81e8263b7954) |
 | Oasis Sapphire Testnet (23295) | wROSE | [`0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94`](https://testnet.explorer.sapphire.oasis.dev/address/0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94) | BSC Testnet (97) | [`0x26a6f43BaEDD1767c283e2555A9E1236E5aE3A55`](https://testnet.bscscan.com/address/0x26a6f43BaEDD1767c283e2555A9E1236E5aE3A55) |
-| Oasis Sapphire Testnet (23295) | wROSE | [`0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94`](https://testnet.explorer.sapphire.oasis.dev/address/0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94) | Polygon Mumbai (80001) | [`0xE9533976C590200E32d95C53f06AE12d292cFc47`](https://mumbai.polygonscan.com/address/0xE9533976C590200E32d95C53f06AE12d292cFc47) |
 
 ## Deployments
 


### PR DESCRIPTION
## Description

Update fetch script to ignore Goerli and Mumbai. Close https://github.com/oasisprotocol/docs/issues/962