### PR TITLE
integrations/viem: doctests

### DIFF
--- a/integrations/viem-v2/README.md
+++ b/integrations/viem-v2/README.md
@@ -21,6 +21,7 @@ any unsigned communication, for example when using [hardhat-viem] pass the
 [hardhat-viem]: https://hardhat.org/hardhat-runner/docs/advanced/using-viem
 
 ```typescript
+import hre from "hardhat";
 import { sapphireLocalnet, sapphireHttpTransport } from '@oasisprotocol/sapphire-viem-v2';
 
 const publicClient = await hre.viem.getPublicClient({
@@ -35,7 +36,11 @@ transactions when using a local wallet client you must not only provide the
 `transport` parameter, but must also wrap the wallet client, as such:
 
 ```typescript
+import { createWalletClient } from 'viem'
+import { english, generateMnemonic, mnemonicToAccount } from 'viem/accounts';
 import { sapphireLocalnet, sapphireHttpTransport, wrapWalletClient } from '@oasisprotocol/sapphire-viem-v2';
+
+const account = mnemonicToAccount(generateMnemonic(english));
 
 const walletClient = await wrapWalletClient(createWalletClient({
 	account,

--- a/integrations/viem-v2/README.md
+++ b/integrations/viem-v2/README.md
@@ -2,38 +2,52 @@
 
 A plugin for [Viem] 2.x that encrypts transactions, gas estimations and calls to
 the Oasis Sapphire network to enable end-to-end encryption between the dApp and
-smart contracts.
+smart contracts. It provides three functions which can be used together or
+separately, see the guides below for usage instructions:
+
+ * `sapphireHttpTransport` - [Transport] that intercepts & encrypts requests.
+ * `wrapWalletClient` - Wraps a [WalletClient], to provide encryption.
+ * `createSapphireSerializer` - [Transaction serializer], that encrypts calldata.
 
 [Viem]: https://viem.sh/
+[WalletClient]: https://viem.sh/docs/clients/wallet.html
+[Transaction serializer]: https://viem.sh/docs/chains/serializers#api
+[Transport]: https://viem.sh/docs/clients/transports/http
 
 ## Usage
 
-First install the package.
+Add the package to your project:
 
 ```
 npm install @oasisprotocol/sapphire-viem-v2 viem@2.x
 ```
 
-Next you must ensure that any clients use the `sapphireHttpTransport()` to encrypt
-any unsigned communication, for example when using [hardhat-viem] pass the
-`transport` parameter when constructing a Public Client:
+For local testing the chain configuration for `sapphireLocalnet` is available
+in the `@oasisprotocol/sapphire-viem-v2` package installed above. The Sapphire
+`mainnet` and `testnet` configurations are available in `viem/chains`:
 
-[hardhat-viem]: https://hardhat.org/hardhat-runner/docs/advanced/using-viem
-
-```typescript
-import hre from "hardhat";
-import { sapphireLocalnet, sapphireHttpTransport } from '@oasisprotocol/sapphire-viem-v2';
-
-const publicClient = await hre.viem.getPublicClient({
-	chain: sapphireLocalnet,
-	transport: sapphireHttpTransport()
-});
+```ts
+import { sapphireLocalnet } from '@oasisprotocol/sapphire-viem-v2';
+import { sapphire, sapphireTestnet } from 'viem/chains';
 ```
 
-The Sapphire transport will only encrypt transactions if connected to an
-in-browser wallet provider which accepts `eth_sendTransaction` calls. To encrypt
-transactions when using a local wallet client you must not only provide the
-`transport` parameter, but must also wrap the wallet client, as such:
+## Encryption
+
+Use the `sapphireHttpTransport()` transport to automatically intercept and
+encrypt the calldata provided to the `eth_estimateGas`, `eth_call` and
+`eth_sendTransaction` JSON-RPC calls.
+
+Transaction calldata will be encrypted while using the in-browser wallet
+provider (`window.ethereum`) because this uses the `eth_sendTransaction`
+JSON-RPC call to sign transactions.
+
+> [!IMPORTANT]
+> To encrypt transactions when using a local wallet client you must not only
+> provide the `transport` parameter, but must also wrap the wallet client.
+
+This example creates local wallet that is then wrapped with `wrapWalletClient`
+which replaces the transaction serializer with one which performs Sapphire
+encryption:
 
 ```typescript
 import { createWalletClient } from 'viem'
@@ -49,10 +63,6 @@ const walletClient = await wrapWalletClient(createWalletClient({
 }));
 ```
 
-### Chains
-
-The chain configuration for `sapphireLocalnet` is available in the `@oasisprotocol/sapphire-viem-v2` package as seen above.
-The Sapphire `mainnet` and `testnet` configurations are available in `viem/chains`
-```ts
-import { sapphire, sapphireTestnet } from 'viem/chains';
-```
+Be careful to verify that any transactions which contain sensitive information
+are encrypted by checking the Oasis block explorer and looking for the green
+lock icon.

--- a/integrations/viem-v2/hardhat.config.cjs
+++ b/integrations/viem-v2/hardhat.config.cjs
@@ -1,0 +1,2 @@
+require("@nomicfoundation/hardhat-viem");
+module.exports = {};

--- a/integrations/viem-v2/package.json
+++ b/integrations/viem-v2/package.json
@@ -61,7 +61,6 @@
 		"@biomejs/biome": "^1.7.0",
 		"@types/node": "^18.19.31",
 		"@zaeny/literate": "^1.0.8",
-		"hardhat": "^2.22.12",
 		"rimraf": "^6.0.1",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.4.5",

--- a/integrations/viem-v2/package.json
+++ b/integrations/viem-v2/package.json
@@ -59,7 +59,6 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.7.0",
-		"@nomicfoundation/hardhat-viem": "~2.0.0",
 		"@types/node": "^18.19.31",
 		"@zaeny/literate": "^1.0.8",
 		"hardhat": "^2.22.12",

--- a/integrations/viem-v2/package.json
+++ b/integrations/viem-v2/package.json
@@ -60,7 +60,6 @@
 	"devDependencies": {
 		"@biomejs/biome": "^1.7.0",
 		"@types/node": "^18.19.31",
-		"@zaeny/literate": "^1.0.8",
 		"rimraf": "^6.0.1",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.4.5",

--- a/integrations/viem-v2/package.json
+++ b/integrations/viem-v2/package.json
@@ -59,7 +59,11 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.7.0",
+		"@nomicfoundation/hardhat-viem": "~2.0.0",
 		"@types/node": "^18.19.31",
+		"@zaeny/literate": "^1.0.8",
+		"hardhat": "^2.22.12",
+		"rimraf": "^6.0.1",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.4.5",
 		"vitest": "^1.6.0"

--- a/integrations/viem-v2/test/docs.test.ts
+++ b/integrations/viem-v2/test/docs.test.ts
@@ -1,8 +1,17 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { extractCode } from "@zaeny/literate";
 import { rimraf } from "rimraf";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const EXTRACT_CODE_RX = /\`\`\`(?<lang>\w+)\s*(?<content>[\s\S]*?)\`\`\`/gm;
+
+function extractCode (markdown:string) {
+	return Array.from(markdown.matchAll(EXTRACT_CODE_RX), (_) => {
+		return {
+			lang:_.groups?.['lang'],
+			content:_.groups!['content']
+		}});
+}
 
 const TEST_DIR = join(process.cwd(), "test-modules");
 
@@ -20,6 +29,7 @@ describe("README.md", async () => {
 		it(`Code snippet #${index + 1}`, async () => {
 			const fileName = join(TEST_DIR, `example_${index + 1}.ts`);
 			await writeFile(fileName, content);
+			console.log(fileName, content);
 			await expect(import(fileName)).resolves.not.toThrow();
 		});
 	}

--- a/integrations/viem-v2/test/docs.test.ts
+++ b/integrations/viem-v2/test/docs.test.ts
@@ -5,12 +5,13 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const EXTRACT_CODE_RX = /\`\`\`(?<lang>\w+)\s*(?<content>[\s\S]*?)\`\`\`/gm;
 
-function extractCode (markdown:string) {
+function extractCode(markdown: string) {
 	return Array.from(markdown.matchAll(EXTRACT_CODE_RX), (_) => {
 		return {
-			lang:_.groups?.['lang'],
-			content:_.groups!['content']
-		}});
+			lang: _.groups?.lang,
+			content: _.groups?.content,
+		};
+	});
 }
 
 const TEST_DIR = join(process.cwd(), "test-modules");
@@ -26,11 +27,13 @@ describe("README.md", async () => {
 		await readFile("./README.md", "utf8"),
 	).entries()) {
 		const content = c.content;
-		it(`Code snippet #${index + 1}`, async () => {
-			const fileName = join(TEST_DIR, `example_${index + 1}.ts`);
-			await writeFile(fileName, content);
-			console.log(fileName, content);
-			await expect(import(fileName)).resolves.not.toThrow();
-		});
+		if (content) {
+			it(`Code snippet #${index + 1}`, async () => {
+				const fileName = join(TEST_DIR, `example_${index + 1}.ts`);
+				await writeFile(fileName, content);
+				console.log(fileName, content);
+				await expect(import(fileName)).resolves.not.toThrow();
+			});
+		}
 	}
 });

--- a/integrations/viem-v2/test/docs.test.ts
+++ b/integrations/viem-v2/test/docs.test.ts
@@ -1,0 +1,26 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { extractCode } from "@zaeny/literate";
+import { rimraf } from "rimraf";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const TEST_DIR = join(process.cwd(), "test-modules");
+
+describe("README.md", async () => {
+	beforeAll(async () => {
+		await mkdir(TEST_DIR, { recursive: true });
+	});
+	afterAll(async () => {
+		await rimraf(TEST_DIR);
+	});
+	for (const [index, c] of extractCode(
+		await readFile("./README.md", "utf8"),
+	).entries()) {
+		const content = c.content;
+		it(`Code snippet #${index + 1}`, async () => {
+			const fileName = join(TEST_DIR, `example_${index + 1}.ts`);
+			await writeFile(fileName, content);
+			await expect(import(fileName)).resolves.not.toThrow();
+		});
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   clients/js:
@@ -556,9 +560,21 @@ importers:
       '@biomejs/biome':
         specifier: ^1.7.0
         version: 1.7.0
+      '@nomicfoundation/hardhat-viem':
+        specifier: ~2.0.0
+        version: 2.0.0(hardhat@2.22.12)(typescript@5.4.5)(viem@2.9.19)
       '@types/node':
         specifier: ^18.19.31
         version: 18.19.31
+      '@zaeny/literate':
+        specifier: ^1.0.8
+        version: 1.0.8
+      hardhat:
+        specifier: ^2.22.12
+        version: 2.22.12(ts-node@10.9.2)(typescript@5.4.5)
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@18.19.31)(typescript@5.4.5)
@@ -579,7 +595,7 @@ importers:
         version: link:../viem-v2
       '@wagmi/core':
         specifier: 2.x
-        version: 2.6.17(@types/react@18.2.79)(react@18.2.0)(typescript@5.4.5)(viem@2.9.19)
+        version: 2.6.17(react@18.2.0)(typescript@5.4.5)(viem@2.13.8)
       viem:
         specifier: 2.x
         version: 2.13.8(typescript@5.4.5)
@@ -1305,6 +1321,16 @@ packages:
       '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
+  /@babel/plugin-syntax-flow@7.24.1(@babel/core@7.23.5):
+    resolution: {integrity: sha512-sxi2kLTI5DeW5vDtMUsk4mTPwvlUDbjOnoWayhynCwrw4QXRld4QEYwqzY8JmQXaJUtgUuCIurtSRH5sn4c7mA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.5
+      '@babel/helper-plugin-utils': 7.24.0
+    dev: true
+
   /@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.4):
     resolution: {integrity: sha512-sxi2kLTI5DeW5vDtMUsk4mTPwvlUDbjOnoWayhynCwrw4QXRld4QEYwqzY8JmQXaJUtgUuCIurtSRH5sn4c7mA==}
     engines: {node: '>=6.9.0'}
@@ -1313,6 +1339,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.0
+    dev: false
 
   /@babel/plugin-syntax-import-assertions@7.23.3(@babel/core@7.24.4):
     resolution: {integrity: sha512-lPgDSU+SJLK3xmFDTV2ZRQAiM7UuUjGidwBywFavObCiZc1BeAAcMtHJKUya92hPHO+at63JJPLygilZard8jw==}
@@ -1387,6 +1414,16 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.0
+
+  /@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.23.5):
+    resolution: {integrity: sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.5
+      '@babel/helper-plugin-utils': 7.24.0
+    dev: true
 
   /@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.24.4):
     resolution: {integrity: sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==}
@@ -2466,6 +2503,20 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.0
+
+  /@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.23.5):
+    resolution: {integrity: sha512-5xOpoPguCZCRbo/JeHlloSkTA8Bld1J/E1/kLfD1nsuiW1m8tduTA1ERCgIZokDflX/IBzKcqR3l7VlRgiIfHA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-module-imports': 7.24.3
+      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.23.5)
+      '@babel/types': 7.24.0
+    dev: true
 
   /@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.4):
     resolution: {integrity: sha512-5xOpoPguCZCRbo/JeHlloSkTA8Bld1J/E1/kLfD1nsuiW1m8tduTA1ERCgIZokDflX/IBzKcqR3l7VlRgiIfHA==}
@@ -4419,6 +4470,18 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
+  /@isaacs/cliui@8.0.2:
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: /string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: /strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: /wrap-ansi@7.0.0
+    dev: true
+
   /@isaacs/ttlcache@1.4.1:
     resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
     engines: {node: '>=12'}
@@ -5409,6 +5472,11 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@nomicfoundation/edr-darwin-arm64@0.6.2:
+    resolution: {integrity: sha512-o4A9SaPlxJ1MS6u8Ozqq7Y0ri2XO0jASw+qkytQyBYowNFNReoGqVSs7SCwenYCDiN+1il8+M0VAUq7wOovnCQ==}
+    engines: {node: '>= 18'}
+    dev: true
+
   /@nomicfoundation/edr-darwin-x64@0.3.5:
     resolution: {integrity: sha512-0MrpOCXUK8gmplpYZ2Cy0holHEylvWoNeecFcrP2WJ5DLQzrB23U5JU2MvUzOJ7aL76Za1VXNBWi/UeTWdHM+w==}
     engines: {node: '>= 18'}
@@ -5416,6 +5484,11 @@ packages:
     os: [darwin]
     requiresBuild: true
     optional: true
+
+  /@nomicfoundation/edr-darwin-x64@0.6.2:
+    resolution: {integrity: sha512-WG8BeG2eR3rFC+2/9V1hoPGW7tmNRUcuztdHUijO1h2flRsf2YWv+kEHO+EEnhGkEbgBUiwOrwlwlSMxhe2cGA==}
+    engines: {node: '>= 18'}
+    dev: true
 
   /@nomicfoundation/edr-linux-arm64-gnu@0.3.5:
     resolution: {integrity: sha512-aw9f7AZMiY1dZFNePJGKho2k+nEgFgzUAyyukiKfSqUIMXoFXMf1U3Ujv848czrSq9c5XGcdDa2xnEf3daU3xg==}
@@ -5425,6 +5498,11 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@nomicfoundation/edr-linux-arm64-gnu@0.6.2:
+    resolution: {integrity: sha512-wvHaTmOwuPjRIOqBB+paI3RBdNlG8f3e1F2zWj75EdeWwefimPzzFUs05JxOYuPO0JhDQIn2tbYUgdZbBQ+mqg==}
+    engines: {node: '>= 18'}
+    dev: true
+
   /@nomicfoundation/edr-linux-arm64-musl@0.3.5:
     resolution: {integrity: sha512-cVFRQjyABBlsbDj+XTczYBfrCHprZ6YNzN8gGGSqAh+UGIJkAIRomK6ar27GyJLNx3HkgbuDoi/9kA0zOo/95w==}
     engines: {node: '>= 18'}
@@ -5432,6 +5510,11 @@ packages:
     os: [linux]
     requiresBuild: true
     optional: true
+
+  /@nomicfoundation/edr-linux-arm64-musl@0.6.2:
+    resolution: {integrity: sha512-UrOAxnsywUcEngQM2ZxIuucci0VX29hYxX7jcpwZU50HICCjxNsxnuXYPxv+IM+6gbhBY1FYvYJGW4PJcP1Nyw==}
+    engines: {node: '>= 18'}
+    dev: true
 
   /@nomicfoundation/edr-linux-x64-gnu@0.3.5:
     resolution: {integrity: sha512-CjOg85DfR1Vt0fQWn5U0qi26DATK9tVzo3YOZEyI0JBsnqvk43fUTPv3uUAWBrPIRg5O5kOc9xG13hSpCBBxBg==}
@@ -5441,6 +5524,11 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@nomicfoundation/edr-linux-x64-gnu@0.6.2:
+    resolution: {integrity: sha512-gYxlPLi7fkNcmDmCwZWQa5eOfNcTDundE+TWjpyafxLAjodQuKBD4I0p4XbnuocHjoBEeNzLWdE5RShbZEXEJA==}
+    engines: {node: '>= 18'}
+    dev: true
+
   /@nomicfoundation/edr-linux-x64-musl@0.3.5:
     resolution: {integrity: sha512-hvX8bBGpBydAVevzK8jsu2FlqVZK1RrCyTX6wGHnltgMuBaoGLHYtNHiFpteOaJw2byYMiORc2bvj+98LhJ0Ew==}
     engines: {node: '>= 18'}
@@ -5449,6 +5537,11 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@nomicfoundation/edr-linux-x64-musl@0.6.2:
+    resolution: {integrity: sha512-ev5hy9wmiHZi1GKQ1l6PJ2+UpsUh+DvK9AwiCZVEdaicuhmTfO6fdL4szgE4An8RU+Ou9DeiI1tZcq6iw++Wuw==}
+    engines: {node: '>= 18'}
+    dev: true
+
   /@nomicfoundation/edr-win32-x64-msvc@0.3.5:
     resolution: {integrity: sha512-IJXjW13DY5UPsx/eG5DGfXtJ7Ydwrvw/BTZ2Y93lRLHzszVpSmeVmlxjZP5IW2afTSgMLaAAsqNw4NhppRGN8A==}
     engines: {node: '>= 18'}
@@ -5456,6 +5549,11 @@ packages:
     os: [win32]
     requiresBuild: true
     optional: true
+
+  /@nomicfoundation/edr-win32-x64-msvc@0.6.2:
+    resolution: {integrity: sha512-2ZXVVcmdmEeX0Hb3IAurHUjgU3H1GIk9h7Okosdjgl3tl+BaNHxi84Us+DblynO1LRj8nL/ATeVtSfBuW3Z1vw==}
+    engines: {node: '>= 18'}
+    dev: true
 
   /@nomicfoundation/edr@0.3.5:
     resolution: {integrity: sha512-dPSM9DuI1sr71gqWUMgLo8MjHQWO4+WNDm3iWaT6P4vUFJReZX5qwA5X+3UwIPBry8GvNY084u7yWUvB3/8rqA==}
@@ -5468,6 +5566,19 @@ packages:
       '@nomicfoundation/edr-linux-x64-gnu': 0.3.5
       '@nomicfoundation/edr-linux-x64-musl': 0.3.5
       '@nomicfoundation/edr-win32-x64-msvc': 0.3.5
+
+  /@nomicfoundation/edr@0.6.2:
+    resolution: {integrity: sha512-yPUegN3sTWiAkRatCmGRkuvMgD9HSSpivl2ebAqq0aU2xgC7qmIO+YQPxQ3Z46MUoi7MrTf4e6GpbT4S/8x0ew==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@nomicfoundation/edr-darwin-arm64': 0.6.2
+      '@nomicfoundation/edr-darwin-x64': 0.6.2
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.6.2
+      '@nomicfoundation/edr-linux-arm64-musl': 0.6.2
+      '@nomicfoundation/edr-linux-x64-gnu': 0.6.2
+      '@nomicfoundation/edr-linux-x64-musl': 0.6.2
+      '@nomicfoundation/edr-win32-x64-msvc': 0.6.2
+    dev: true
 
   /@nomicfoundation/ethereumjs-block@5.0.2:
     resolution: {integrity: sha512-hSe6CuHI4SsSiWWjHDIzWhSiAVpzMUcDRpWYzN0T9l8/Rz7xNn3elwVOJ/tAyS0LqL6vitUD78Uk7lQDXZun7Q==}
@@ -6051,6 +6162,22 @@ packages:
       undici: 5.22.1
     transitivePeerDependencies:
       - supports-color
+
+  /@nomicfoundation/hardhat-viem@2.0.0(hardhat@2.22.12)(typescript@5.4.5)(viem@2.9.19):
+    resolution: {integrity: sha512-ilXQKTc1jWHqJ66fAN6TIyCRyormoChOn1yQTCGoBQ+G6QcVCu5FTaGL2r0KUOY4IkTohtphK+UXQrKcxQX5Yw==}
+    peerDependencies:
+      hardhat: ^2.17.0
+      typescript: ~5.0.0
+      viem: ^2.7.6
+    dependencies:
+      abitype: 0.9.8(typescript@5.4.5)
+      hardhat: 2.22.12(ts-node@10.9.2)(typescript@5.4.5)
+      lodash.memoize: 4.1.2
+      typescript: 5.4.5
+      viem: 2.9.19(typescript@5.4.5)
+    transitivePeerDependencies:
+      - zod
+    dev: true
 
   /@nomicfoundation/hardhat-viem@2.0.0(hardhat@2.22.2)(typescript@5.0.4)(viem@2.9.19):
     resolution: {integrity: sha512-ilXQKTc1jWHqJ66fAN6TIyCRyormoChOn1yQTCGoBQ+G6QcVCu5FTaGL2r0KUOY4IkTohtphK+UXQrKcxQX5Yw==}
@@ -7056,7 +7183,6 @@ packages:
       '@noble/curves': 1.2.0
       '@noble/hashes': 1.3.2
       '@scure/base': 1.1.6
-    dev: false
 
   /@scure/bip32@1.3.3:
     resolution: {integrity: sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==}
@@ -7077,7 +7203,6 @@ packages:
     dependencies:
       '@noble/hashes': 1.3.2
       '@scure/base': 1.1.6
-    dev: false
 
   /@scure/bip39@1.2.2:
     resolution: {integrity: sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==}
@@ -8724,6 +8849,32 @@ packages:
       - zod
     dev: false
 
+  /@wagmi/core@2.6.17(react@18.2.0)(typescript@5.4.5)(viem@2.13.8):
+    resolution: {integrity: sha512-Ghr7PlD5HO1YJrsaC52j/csgaigBAiTR7cFiwrY7WdwvWLsR5na4Dv6KfHTU3d3al0CKDLanQdRS5nB4mX1M+g==}
+    peerDependencies:
+      '@tanstack/query-core': '>=5.0.0'
+      typescript: '>=5.0.4'
+      viem: 2.x
+    peerDependenciesMeta:
+      '@tanstack/query-core':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.5(typescript@5.4.5)
+      typescript: 5.4.5
+      viem: 2.13.8(typescript@5.4.5)
+      zustand: 4.4.1(@types/react@18.2.79)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - immer
+      - react
+      - utf-8-validate
+      - zod
+    dev: false
+
   /@walletconnect/core@2.11.0:
     resolution: {integrity: sha512-2Tjp5BCevI7dbmqo/OrCjX4tqgMqwJNQLlQAlphqPfvwlF9+tIu6pGcVbSN3U9zyXzWIZCeleqEaWUeSeET4Ew==}
     dependencies:
@@ -9831,6 +9982,10 @@ packages:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
     dev: true
 
+  /@zaeny/literate@1.0.8:
+    resolution: {integrity: sha512-kIMdfvR3FT6Fc7m0CQuF1e/k1G23l/Nt0d07RR4OOYOu/4bQI78D2AvbEH5rzhm85KCDnY2HA26BqX3a4nqt5w==}
+    dev: true
+
   /abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     deprecated: Use your platform's native atob() and btoa() methods instead
@@ -9877,7 +10032,6 @@ packages:
         optional: true
     dependencies:
       typescript: 5.4.5
-    dev: false
 
   /abitype@1.0.0(typescript@5.0.4):
     resolution: {integrity: sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==}
@@ -9905,7 +10059,6 @@ packages:
         optional: true
     dependencies:
       typescript: 5.4.5
-    dev: false
 
   /abitype@1.0.5(typescript@5.4.5):
     resolution: {integrity: sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==}
@@ -10174,6 +10327,11 @@ packages:
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  /ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+    dev: true
 
   /antlr4@4.13.0:
     resolution: {integrity: sha512-zooUbt+UscjnWyOrsuY/tVFL4rwrAGwOivpQmvmUDE22hy/lUA467Rc1rcixyRwcRUIXFYBwv7+dClDSHdmmew==}
@@ -11400,6 +11558,13 @@ packages:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  /chokidar@4.0.1:
+    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
+    engines: {node: '>= 14.16.0'}
+    dependencies:
+      readdirp: 4.0.1
+    dev: true
 
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -12725,6 +12890,10 @@ packages:
       stream-shift: 1.0.3
     dev: false
 
+  /eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: true
+
   /ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
     dependencies:
@@ -13279,8 +13448,8 @@ packages:
       '@babel/plugin-transform-react-jsx': ^7.14.9
       eslint: ^8.1.0
     dependencies:
-      '@babel/plugin-syntax-flow': 7.24.1(@babel/core@7.24.4)
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.4)
+      '@babel/plugin-syntax-flow': 7.24.1(@babel/core@7.23.5)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.23.5)
       eslint: 8.57.0
       lodash: 4.17.21
       string-natural-compare: 3.0.1
@@ -13897,6 +14066,7 @@ packages:
     dependencies:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
+    bundledDependencies: false
 
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -14598,6 +14768,19 @@ packages:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
     dev: true
 
+  /glob@11.0.0:
+    resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+    dependencies:
+      foreground-child: 3.1.1
+      jackspeak: 4.0.2
+      minimatch: 10.0.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
+    dev: true
+
   /glob@5.0.15:
     resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -14975,6 +15158,71 @@ packages:
       ws: 7.5.9
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /hardhat@2.22.12(ts-node@10.9.2)(typescript@5.4.5):
+    resolution: {integrity: sha512-yok65M+LsOeTBHQsjg//QreGCyrsaNmeLVzhTFqlOvZ4ZE5y69N0wRxH1b2BC9dGK8S8OPUJMNiL9X0RAvbm8w==}
+    hasBin: true
+    peerDependencies:
+      ts-node: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@metamask/eth-sig-util': 4.0.1
+      '@nomicfoundation/edr': 0.6.2
+      '@nomicfoundation/ethereumjs-common': 4.0.4
+      '@nomicfoundation/ethereumjs-tx': 5.0.4
+      '@nomicfoundation/ethereumjs-util': 9.0.4
+      '@nomicfoundation/solidity-analyzer': 0.1.1
+      '@sentry/node': 5.30.0
+      '@types/bn.js': 5.1.5
+      '@types/lru-cache': 5.1.1
+      adm-zip: 0.4.16
+      aggregate-error: 3.1.0
+      ansi-escapes: 4.3.2
+      boxen: 5.1.2
+      chalk: 2.4.2
+      chokidar: 4.0.1
+      ci-info: 2.0.0
+      debug: 4.3.5
+      enquirer: 2.4.1
+      env-paths: 2.2.1
+      ethereum-cryptography: 1.2.0
+      ethereumjs-abi: 0.6.8
+      find-up: 2.1.0
+      fp-ts: 1.19.3
+      fs-extra: 7.0.1
+      glob: 7.2.0
+      immutable: 4.3.5
+      io-ts: 1.10.4
+      json-stream-stringify: 3.1.4
+      keccak: 3.0.4
+      lodash: 4.17.21
+      mnemonist: 0.38.5
+      mocha: 10.4.0
+      p-map: 4.0.0
+      raw-body: 2.5.2
+      resolve: 1.17.0
+      semver: 6.3.1
+      solc: 0.8.26(debug@4.3.5)
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.10
+      ts-node: 10.9.2(@types/node@18.19.31)(typescript@5.4.5)
+      tsort: 0.0.1
+      typescript: 5.4.5
+      undici: 5.28.4
+      uuid: 8.3.2
+      ws: 7.5.9
+    transitivePeerDependencies:
+      - bufferutil
+      - c-kzg
       - supports-color
       - utf-8-validate
     dev: true
@@ -15997,7 +16245,6 @@ packages:
       ws: '*'
     dependencies:
       ws: 8.13.0
-    dev: false
 
   /isows@1.0.4(ws@8.13.0):
     resolution: {integrity: sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==}
@@ -16077,6 +16324,13 @@ packages:
       has-symbols: 1.0.3
       reflect.getprototypeof: 1.0.4
       set-function-name: 2.0.1
+    dev: true
+
+  /jackspeak@4.0.2:
+    resolution: {integrity: sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==}
+    engines: {node: 20 || >=22}
+    dependencies:
+      '@isaacs/cliui': 8.0.2
     dev: true
 
   /jake@10.8.7:
@@ -17280,6 +17534,11 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
+  /json-stream-stringify@3.1.4:
+    resolution: {integrity: sha512-oGoz05ft577LolnXFQHD2CjnXDxXVA5b8lHwfEZgRXQUZeCMo6sObQQRq+NXuHQ3oTeMZHHmmPY2rjVwyqR62A==}
+    engines: {node: '>=7.10.1'}
+    dev: true
+
   /json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -17707,6 +17966,11 @@ packages:
     resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
     engines: {node: 14 || >=16.14}
     dev: false
+
+  /lru-cache@11.0.1:
+    resolution: {integrity: sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==}
+    engines: {node: 20 || >=22}
+    dev: true
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -18151,6 +18415,13 @@ packages:
   /minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
+  /minimatch@10.0.1:
+    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+    engines: {node: 20 || >=22}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimatch@3.0.4:
     resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
     dependencies:
@@ -18188,6 +18459,11 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
       yallist: 3.1.1
+    dev: true
+
+  /minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
     dev: true
 
   /minizlib@1.3.3:
@@ -19032,6 +19308,10 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  /package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+    dev: true
+
   /param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
@@ -19120,6 +19400,14 @@ packages:
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  /path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
+    dependencies:
+      lru-cache: 11.0.1
+      minipass: 7.1.2
+    dev: true
 
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
@@ -20765,6 +21053,11 @@ packages:
     dependencies:
       picomatch: 2.3.1
 
+  /readdirp@4.0.1:
+    resolution: {integrity: sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==}
+    engines: {node: '>= 14.16.0'}
+    dev: true
+
   /readline@1.3.0:
     resolution: {integrity: sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==}
     dev: false
@@ -21095,6 +21388,15 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+
+  /rimraf@6.0.1:
+    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+    dependencies:
+      glob: 11.0.0
+      package-json-from-dist: 1.0.1
+    dev: true
 
   /ripemd160@2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
@@ -21727,6 +22029,22 @@ packages:
     transitivePeerDependencies:
       - debug
 
+  /solc@0.8.26(debug@4.3.5):
+    resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    dependencies:
+      command-exists: 1.2.9
+      commander: 8.3.0
+      follow-redirects: 1.15.6(debug@4.3.5)
+      js-sha3: 0.8.0
+      memorystream: 0.3.1
+      semver: 5.7.2
+      tmp: 0.0.33
+    transitivePeerDependencies:
+      - debug
+    dev: true
+
   /solhint@3.4.1:
     resolution: {integrity: sha512-pzZn2RlZhws1XwvLPVSsxfHrwsteFf5eySOhpAytzXwKQYbTCJV6z8EevYDiSVKMpWrvbKpEtJ055CuEmzp4Xg==}
     hasBin: true
@@ -22140,6 +22458,15 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  /string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+    dev: true
 
   /string.prototype.matchall@4.0.10:
     resolution: {integrity: sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==}
@@ -23751,7 +24078,6 @@ packages:
       - bufferutil
       - utf-8-validate
       - zod
-    dev: false
 
   /vite-node@1.6.0(@types/node@18.19.31):
     resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
@@ -25265,6 +25591,15 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  /wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+    dev: true
+
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -25374,7 +25709,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    dev: false
 
   /ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,9 +560,6 @@ importers:
       '@biomejs/biome':
         specifier: ^1.7.0
         version: 1.7.0
-      '@nomicfoundation/hardhat-viem':
-        specifier: ~2.0.0
-        version: 2.0.0(hardhat@2.22.12)(typescript@5.4.5)(viem@2.9.19)
       '@types/node':
         specifier: ^18.19.31
         version: 18.19.31
@@ -6163,22 +6160,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@nomicfoundation/hardhat-viem@2.0.0(hardhat@2.22.12)(typescript@5.4.5)(viem@2.9.19):
-    resolution: {integrity: sha512-ilXQKTc1jWHqJ66fAN6TIyCRyormoChOn1yQTCGoBQ+G6QcVCu5FTaGL2r0KUOY4IkTohtphK+UXQrKcxQX5Yw==}
-    peerDependencies:
-      hardhat: ^2.17.0
-      typescript: ~5.0.0
-      viem: ^2.7.6
-    dependencies:
-      abitype: 0.9.8(typescript@5.4.5)
-      hardhat: 2.22.12(ts-node@10.9.2)(typescript@5.4.5)
-      lodash.memoize: 4.1.2
-      typescript: 5.4.5
-      viem: 2.9.19(typescript@5.4.5)
-    transitivePeerDependencies:
-      - zod
-    dev: true
-
   /@nomicfoundation/hardhat-viem@2.0.0(hardhat@2.22.2)(typescript@5.0.4)(viem@2.9.19):
     resolution: {integrity: sha512-ilXQKTc1jWHqJ66fAN6TIyCRyormoChOn1yQTCGoBQ+G6QcVCu5FTaGL2r0KUOY4IkTohtphK+UXQrKcxQX5Yw==}
     peerDependencies:
@@ -7183,6 +7164,7 @@ packages:
       '@noble/curves': 1.2.0
       '@noble/hashes': 1.3.2
       '@scure/base': 1.1.6
+    dev: false
 
   /@scure/bip32@1.3.3:
     resolution: {integrity: sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==}
@@ -7203,6 +7185,7 @@ packages:
     dependencies:
       '@noble/hashes': 1.3.2
       '@scure/base': 1.1.6
+    dev: false
 
   /@scure/bip39@1.2.2:
     resolution: {integrity: sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==}
@@ -10032,6 +10015,7 @@ packages:
         optional: true
     dependencies:
       typescript: 5.4.5
+    dev: false
 
   /abitype@1.0.0(typescript@5.0.4):
     resolution: {integrity: sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==}
@@ -10059,6 +10043,7 @@ packages:
         optional: true
     dependencies:
       typescript: 5.4.5
+    dev: false
 
   /abitype@1.0.5(typescript@5.4.5):
     resolution: {integrity: sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==}
@@ -16245,6 +16230,7 @@ packages:
       ws: '*'
     dependencies:
       ws: 8.13.0
+    dev: false
 
   /isows@1.0.4(ws@8.13.0):
     resolution: {integrity: sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==}
@@ -24078,6 +24064,7 @@ packages:
       - bufferutil
       - utf-8-validate
       - zod
+    dev: false
 
   /vite-node@1.6.0(@types/node@18.19.31):
     resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
@@ -25709,6 +25696,7 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: false
 
   /ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -563,9 +563,6 @@ importers:
       '@types/node':
         specifier: ^18.19.31
         version: 18.19.31
-      '@zaeny/literate':
-        specifier: ^1.0.8
-        version: 1.0.8
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -9914,10 +9911,6 @@ packages:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
     dev: true
 
-  /@zaeny/literate@1.0.8:
-    resolution: {integrity: sha512-kIMdfvR3FT6Fc7m0CQuF1e/k1G23l/Nt0d07RR4OOYOu/4bQI78D2AvbEH5rzhm85KCDnY2HA26BqX3a4nqt5w==}
-    dev: true
-
   /abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     deprecated: Use your platform's native atob() and btoa() methods instead
@@ -15557,7 +15550,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.6(debug@4.3.5)
+      follow-redirects: 1.15.6(debug@4.3.4)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -566,9 +566,6 @@ importers:
       '@zaeny/literate':
         specifier: ^1.0.8
         version: 1.0.8
-      hardhat:
-        specifier: ^2.22.12
-        version: 2.22.12(ts-node@10.9.2)(typescript@5.4.5)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -5469,11 +5466,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@nomicfoundation/edr-darwin-arm64@0.6.2:
-    resolution: {integrity: sha512-o4A9SaPlxJ1MS6u8Ozqq7Y0ri2XO0jASw+qkytQyBYowNFNReoGqVSs7SCwenYCDiN+1il8+M0VAUq7wOovnCQ==}
-    engines: {node: '>= 18'}
-    dev: true
-
   /@nomicfoundation/edr-darwin-x64@0.3.5:
     resolution: {integrity: sha512-0MrpOCXUK8gmplpYZ2Cy0holHEylvWoNeecFcrP2WJ5DLQzrB23U5JU2MvUzOJ7aL76Za1VXNBWi/UeTWdHM+w==}
     engines: {node: '>= 18'}
@@ -5481,11 +5473,6 @@ packages:
     os: [darwin]
     requiresBuild: true
     optional: true
-
-  /@nomicfoundation/edr-darwin-x64@0.6.2:
-    resolution: {integrity: sha512-WG8BeG2eR3rFC+2/9V1hoPGW7tmNRUcuztdHUijO1h2flRsf2YWv+kEHO+EEnhGkEbgBUiwOrwlwlSMxhe2cGA==}
-    engines: {node: '>= 18'}
-    dev: true
 
   /@nomicfoundation/edr-linux-arm64-gnu@0.3.5:
     resolution: {integrity: sha512-aw9f7AZMiY1dZFNePJGKho2k+nEgFgzUAyyukiKfSqUIMXoFXMf1U3Ujv848czrSq9c5XGcdDa2xnEf3daU3xg==}
@@ -5495,11 +5482,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@nomicfoundation/edr-linux-arm64-gnu@0.6.2:
-    resolution: {integrity: sha512-wvHaTmOwuPjRIOqBB+paI3RBdNlG8f3e1F2zWj75EdeWwefimPzzFUs05JxOYuPO0JhDQIn2tbYUgdZbBQ+mqg==}
-    engines: {node: '>= 18'}
-    dev: true
-
   /@nomicfoundation/edr-linux-arm64-musl@0.3.5:
     resolution: {integrity: sha512-cVFRQjyABBlsbDj+XTczYBfrCHprZ6YNzN8gGGSqAh+UGIJkAIRomK6ar27GyJLNx3HkgbuDoi/9kA0zOo/95w==}
     engines: {node: '>= 18'}
@@ -5507,11 +5489,6 @@ packages:
     os: [linux]
     requiresBuild: true
     optional: true
-
-  /@nomicfoundation/edr-linux-arm64-musl@0.6.2:
-    resolution: {integrity: sha512-UrOAxnsywUcEngQM2ZxIuucci0VX29hYxX7jcpwZU50HICCjxNsxnuXYPxv+IM+6gbhBY1FYvYJGW4PJcP1Nyw==}
-    engines: {node: '>= 18'}
-    dev: true
 
   /@nomicfoundation/edr-linux-x64-gnu@0.3.5:
     resolution: {integrity: sha512-CjOg85DfR1Vt0fQWn5U0qi26DATK9tVzo3YOZEyI0JBsnqvk43fUTPv3uUAWBrPIRg5O5kOc9xG13hSpCBBxBg==}
@@ -5521,11 +5498,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@nomicfoundation/edr-linux-x64-gnu@0.6.2:
-    resolution: {integrity: sha512-gYxlPLi7fkNcmDmCwZWQa5eOfNcTDundE+TWjpyafxLAjodQuKBD4I0p4XbnuocHjoBEeNzLWdE5RShbZEXEJA==}
-    engines: {node: '>= 18'}
-    dev: true
-
   /@nomicfoundation/edr-linux-x64-musl@0.3.5:
     resolution: {integrity: sha512-hvX8bBGpBydAVevzK8jsu2FlqVZK1RrCyTX6wGHnltgMuBaoGLHYtNHiFpteOaJw2byYMiORc2bvj+98LhJ0Ew==}
     engines: {node: '>= 18'}
@@ -5534,11 +5506,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@nomicfoundation/edr-linux-x64-musl@0.6.2:
-    resolution: {integrity: sha512-ev5hy9wmiHZi1GKQ1l6PJ2+UpsUh+DvK9AwiCZVEdaicuhmTfO6fdL4szgE4An8RU+Ou9DeiI1tZcq6iw++Wuw==}
-    engines: {node: '>= 18'}
-    dev: true
-
   /@nomicfoundation/edr-win32-x64-msvc@0.3.5:
     resolution: {integrity: sha512-IJXjW13DY5UPsx/eG5DGfXtJ7Ydwrvw/BTZ2Y93lRLHzszVpSmeVmlxjZP5IW2afTSgMLaAAsqNw4NhppRGN8A==}
     engines: {node: '>= 18'}
@@ -5546,11 +5513,6 @@ packages:
     os: [win32]
     requiresBuild: true
     optional: true
-
-  /@nomicfoundation/edr-win32-x64-msvc@0.6.2:
-    resolution: {integrity: sha512-2ZXVVcmdmEeX0Hb3IAurHUjgU3H1GIk9h7Okosdjgl3tl+BaNHxi84Us+DblynO1LRj8nL/ATeVtSfBuW3Z1vw==}
-    engines: {node: '>= 18'}
-    dev: true
 
   /@nomicfoundation/edr@0.3.5:
     resolution: {integrity: sha512-dPSM9DuI1sr71gqWUMgLo8MjHQWO4+WNDm3iWaT6P4vUFJReZX5qwA5X+3UwIPBry8GvNY084u7yWUvB3/8rqA==}
@@ -5563,19 +5525,6 @@ packages:
       '@nomicfoundation/edr-linux-x64-gnu': 0.3.5
       '@nomicfoundation/edr-linux-x64-musl': 0.3.5
       '@nomicfoundation/edr-win32-x64-msvc': 0.3.5
-
-  /@nomicfoundation/edr@0.6.2:
-    resolution: {integrity: sha512-yPUegN3sTWiAkRatCmGRkuvMgD9HSSpivl2ebAqq0aU2xgC7qmIO+YQPxQ3Z46MUoi7MrTf4e6GpbT4S/8x0ew==}
-    engines: {node: '>= 18'}
-    dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.6.2
-      '@nomicfoundation/edr-darwin-x64': 0.6.2
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.6.2
-      '@nomicfoundation/edr-linux-arm64-musl': 0.6.2
-      '@nomicfoundation/edr-linux-x64-gnu': 0.6.2
-      '@nomicfoundation/edr-linux-x64-musl': 0.6.2
-      '@nomicfoundation/edr-win32-x64-msvc': 0.6.2
-    dev: true
 
   /@nomicfoundation/ethereumjs-block@5.0.2:
     resolution: {integrity: sha512-hSe6CuHI4SsSiWWjHDIzWhSiAVpzMUcDRpWYzN0T9l8/Rz7xNn3elwVOJ/tAyS0LqL6vitUD78Uk7lQDXZun7Q==}
@@ -11544,13 +11493,6 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
-  /chokidar@4.0.1:
-    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
-    engines: {node: '>= 14.16.0'}
-    dependencies:
-      readdirp: 4.0.1
-    dev: true
-
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
     dev: true
@@ -15147,71 +15089,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /hardhat@2.22.12(ts-node@10.9.2)(typescript@5.4.5):
-    resolution: {integrity: sha512-yok65M+LsOeTBHQsjg//QreGCyrsaNmeLVzhTFqlOvZ4ZE5y69N0wRxH1b2BC9dGK8S8OPUJMNiL9X0RAvbm8w==}
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@ethersproject/abi': 5.7.0
-      '@metamask/eth-sig-util': 4.0.1
-      '@nomicfoundation/edr': 0.6.2
-      '@nomicfoundation/ethereumjs-common': 4.0.4
-      '@nomicfoundation/ethereumjs-tx': 5.0.4
-      '@nomicfoundation/ethereumjs-util': 9.0.4
-      '@nomicfoundation/solidity-analyzer': 0.1.1
-      '@sentry/node': 5.30.0
-      '@types/bn.js': 5.1.5
-      '@types/lru-cache': 5.1.1
-      adm-zip: 0.4.16
-      aggregate-error: 3.1.0
-      ansi-escapes: 4.3.2
-      boxen: 5.1.2
-      chalk: 2.4.2
-      chokidar: 4.0.1
-      ci-info: 2.0.0
-      debug: 4.3.5
-      enquirer: 2.4.1
-      env-paths: 2.2.1
-      ethereum-cryptography: 1.2.0
-      ethereumjs-abi: 0.6.8
-      find-up: 2.1.0
-      fp-ts: 1.19.3
-      fs-extra: 7.0.1
-      glob: 7.2.0
-      immutable: 4.3.5
-      io-ts: 1.10.4
-      json-stream-stringify: 3.1.4
-      keccak: 3.0.4
-      lodash: 4.17.21
-      mnemonist: 0.38.5
-      mocha: 10.4.0
-      p-map: 4.0.0
-      raw-body: 2.5.2
-      resolve: 1.17.0
-      semver: 6.3.1
-      solc: 0.8.26(debug@4.3.5)
-      source-map-support: 0.5.21
-      stacktrace-parser: 0.1.10
-      ts-node: 10.9.2(@types/node@18.19.31)(typescript@5.4.5)
-      tsort: 0.0.1
-      typescript: 5.4.5
-      undici: 5.28.4
-      uuid: 8.3.2
-      ws: 7.5.9
-    transitivePeerDependencies:
-      - bufferutil
-      - c-kzg
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /hardhat@2.22.2(ts-node@10.9.1)(typescript@4.9.5):
     resolution: {integrity: sha512-0xZ7MdCZ5sJem4MrvpQWLR3R3zGDoHw5lsR+pBFimqwagimIOn3bWuZv69KA+veXClwI1s/zpqgwPwiFrd4Dxw==}
     hasBin: true
@@ -15680,7 +15557,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.6(debug@4.3.4)
+      follow-redirects: 1.15.6(debug@4.3.5)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -17518,11 +17395,6 @@ packages:
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
-    dev: true
-
-  /json-stream-stringify@3.1.4:
-    resolution: {integrity: sha512-oGoz05ft577LolnXFQHD2CjnXDxXVA5b8lHwfEZgRXQUZeCMo6sObQQRq+NXuHQ3oTeMZHHmmPY2rjVwyqR62A==}
-    engines: {node: '>=7.10.1'}
     dev: true
 
   /json-stringify-safe@5.0.1:
@@ -21039,11 +20911,6 @@ packages:
     dependencies:
       picomatch: 2.3.1
 
-  /readdirp@4.0.1:
-    resolution: {integrity: sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==}
-    engines: {node: '>= 14.16.0'}
-    dev: true
-
   /readline@1.3.0:
     resolution: {integrity: sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==}
     dev: false
@@ -22014,22 +21881,6 @@ packages:
       tmp: 0.0.33
     transitivePeerDependencies:
       - debug
-
-  /solc@0.8.26(debug@4.3.5):
-    resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    dependencies:
-      command-exists: 1.2.9
-      commander: 8.3.0
-      follow-redirects: 1.15.6(debug@4.3.5)
-      js-sha3: 0.8.0
-      memorystream: 0.3.1
-      semver: 5.7.2
-      tmp: 0.0.33
-    transitivePeerDependencies:
-      - debug
-    dev: true
 
   /solhint@3.4.1:
     resolution: {integrity: sha512-pzZn2RlZhws1XwvLPVSsxfHrwsteFf5eySOhpAytzXwKQYbTCJV6z8EevYDiSVKMpWrvbKpEtJ055CuEmzp4Xg==}
@@ -23494,7 +23345,7 @@ packages:
       typescript: '>=4.3.0'
     dependencies:
       '@types/prettier': 2.7.3
-      debug: 4.3.5
+      debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 7.0.1
       glob: 7.1.7
       js-sha3: 0.8.0


### PR DESCRIPTION
Adds tests to ensure the README.md examples from integrations/viem-v2 can be imported.

This will catch any glaring errors. I think we should extend this to all of the packages in this repo.