### PR TITLE
clients/go: use existing RPC connection to retrieve calldata public key

### DIFF
--- a/.github/workflows/ci-test-go.yaml
+++ b/.github/workflows/ci-test-go.yaml
@@ -1,0 +1,43 @@
+name: ci-test
+
+on:
+  push:
+    branches:
+      - main
+      - stable/*
+      - rc/*
+  pull_request:
+    branches:
+      - main
+      - stable/*
+      - rc/*
+
+jobs:
+  test-client-go:
+    name: test-client-go
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./clients/go
+    services:
+      sapphire-localnet-ci:
+        image: ghcr.io/oasisprotocol/sapphire-localnet:latest
+        ports:
+          - 8545:8545
+          - 8546:8546
+        env:
+          OASIS_DEPOSIT_BINARY: /oasis-deposit -test-mnemonic -n 2
+        options: >-
+          --rm
+          --health-cmd="test -f /CONTAINER_READY"
+          --health-start-period=90s
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.x"
+
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -86,20 +86,3 @@ jobs:
 
       - name: Test JS client
         run: pnpm test:unit
-
-  test-client-go:
-    name: test-client-go
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./clients/go
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.22.x"
-
-      - name: Test
-        run: go test -v ./...

--- a/clients/go/compat.go
+++ b/clients/go/compat.go
@@ -129,8 +129,8 @@ type WrappedBackend struct {
 //
 // If you use cipher over a longer period of time, you should create a new
 // cipher instance every epoch to refresh the ParaTime's ephemeral key!
-func NewCipher(chainID uint64) (Cipher, error) {
-	runtimePublicKey, epoch, err := GetRuntimePublicKey(chainID)
+func NewCipher(c *ethclient.Client) (Cipher, error) {
+	runtimePublicKey, epoch, err := GetRuntimePublicKey(c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch runtime callata public key: %w", err)
 	}
@@ -151,7 +151,7 @@ func WrapClient(c *ethclient.Client, sign SignerFn) (*WrappedBackend, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch chain ID: %w", err)
 	}
-	cipher, err := NewCipher(chainID.Uint64())
+	cipher, err := NewCipher(c)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes: #421
adds tests for performing a value transfer (doesn't check if encryption works)