### PR TITLE
Initial work to implement Sapphire snap connection

### DIFF
--- a/clients/js/src/cipher.ts
+++ b/clients/js/src/cipher.ts
@@ -216,7 +216,7 @@ export class X25519DeoxysII extends Cipher {
   public override readonly epoch: number | undefined;
 
   private cipher: deoxysii.AEAD;
-  private key: Uint8Array; // Stored for curious users.
+  public secretKey: Uint8Array; // Stored for curious users.
 
   /** Creates a new cipher using an ephemeral keypair stored in memory. */
   static ephemeral(peerPublicKey: BytesLike, epoch?: number): X25519DeoxysII {
@@ -254,8 +254,8 @@ export class X25519DeoxysII extends Cipher {
       .update(naclScalarMult(keypair.secretKey, peerPublicKey))
       .digest().buffer;
 
-    this.key = new Uint8Array(keyBytes);
-    this.cipher = new deoxysii.AEAD(new Uint8Array(this.key)); // deoxysii owns the input
+    this.secretKey = new Uint8Array(keyBytes);
+    this.cipher = new deoxysii.AEAD(new Uint8Array(this.secretKey)); // deoxysii owns the input
   }
 
   public encrypt(

--- a/clients/js/src/cipher.ts
+++ b/clients/js/src/cipher.ts
@@ -80,6 +80,7 @@ function formatFailure(fail: CallFailure): string {
 export abstract class Cipher {
   public abstract kind: CipherKind;
   public abstract publicKey: Uint8Array;
+  public abstract ephemeralKey: Uint8Array;
   public abstract epoch?: number;
 
   public abstract encrypt(
@@ -213,6 +214,7 @@ export abstract class Cipher {
 export class X25519DeoxysII extends Cipher {
   public override readonly kind = CipherKind.X25519DeoxysII;
   public override readonly publicKey: Uint8Array;
+  public override readonly ephemeralKey: Uint8Array;
   public override readonly epoch: number | undefined;
 
   private cipher: deoxysii.AEAD;
@@ -243,6 +245,7 @@ export class X25519DeoxysII extends Cipher {
     super();
 
     this.publicKey = keypair.publicKey;
+    this.ephemeralKey = keypair.secretKey;
     this.epoch = epoch;
 
     // Derive a shared secret using X25519 (followed by hashing to remove ECDH bias).

--- a/clients/js/src/cipher.ts
+++ b/clients/js/src/cipher.ts
@@ -79,7 +79,9 @@ function formatFailure(fail: CallFailure): string {
 
 export abstract class Cipher {
   public abstract kind: CipherKind;
+  // The Sapphire's public key rotated each epoch
   public abstract publicKey: Uint8Array;
+  // The client's keypair for encrypting/decrypting transactions and queries using the X25519-DeoxysII, rotated on-demand.
   public abstract ephemeralKey: Uint8Array;
   public abstract epoch?: number;
 

--- a/clients/js/src/provider.ts
+++ b/clients/js/src/provider.ts
@@ -44,19 +44,22 @@ export function isLegacyProvider<T extends object>(
 
 export interface SapphireWrapOptions {
   fetcher: KeyFetcher;
-  enableSapphireSnap: boolean | undefined;
+  enableSapphireSnap?: boolean;
 }
 
-export function fillOptions(
-  options: SapphireWrapOptions | undefined,
-): SapphireWrapOptions {
+export interface SapphireWrapConfig
+  extends Omit<SapphireWrapOptions, 'fetcher'> {
+  fetcher?: KeyFetcher;
+}
+
+export function fillOptions(options: SapphireWrapConfig | undefined) {
   if (!options) {
     options = {} as SapphireWrapOptions;
   }
   if (!options.fetcher) {
     options.fetcher = new KeyFetcher();
   }
-  return options;
+  return options as SapphireWrapOptions;
 }
 
 // -----------------------------------------------------------------------------
@@ -84,7 +87,7 @@ export function isWrappedEthereumProvider<P extends EIP2696_EthereumProvider>(
  */
 export async function wrapEthereumProvider<P extends EIP2696_EthereumProvider>(
   upstream: P,
-  options?: SapphireWrapOptions,
+  options?: SapphireWrapConfig,
 ): Promise<P> {
   if (isWrappedEthereumProvider(upstream)) {
     return upstream;

--- a/clients/js/src/provider.ts
+++ b/clients/js/src/provider.ts
@@ -85,10 +85,10 @@ export function isWrappedEthereumProvider<P extends EIP2696_EthereumProvider>(
  * @param options (optional) Re-use parameters from other providers
  * @returns Sapphire wrapped provider
  */
-export async function wrapEthereumProvider<P extends EIP2696_EthereumProvider>(
+export function wrapEthereumProvider<P extends EIP2696_EthereumProvider>(
   upstream: P,
-  options?: SapphireWrapConfig,
-): Promise<P> {
+  options?: SapphireWrapOptions,
+): P {
   if (isWrappedEthereumProvider(upstream)) {
     return upstream;
   }
@@ -104,7 +104,7 @@ export async function wrapEthereumProvider<P extends EIP2696_EthereumProvider>(
   // if we do this, don't then re-wrap the send() function
   // only wrap the send() function if there was a request() function
 
-  const request = await makeSapphireRequestFn(upstream, filled_options);
+  const request = makeSapphireRequestFn(upstream, filled_options);
   const hooks: Record<string, unknown> = { request };
 
   // We prefer a request() method, but a provider may expose a send() method
@@ -208,21 +208,20 @@ export function isCallDataPublicKeyQuery(params?: object | readonly unknown[]) {
  * @param options
  * @returns
  */
-export async function makeSapphireRequestFn(
+export function makeSapphireRequestFn(
   provider: EIP2696_EthereumProvider,
   options?: SapphireWrapOptions,
-): Promise<EIP2696_EthereumProvider['request']> {
+): EIP2696_EthereumProvider['request'] {
   if (isWrappedRequestFn(provider.request)) {
     return provider.request;
   }
 
   const filled_options = fillOptions(options);
 
-  const snapId = filled_options.enableSapphireSnap
-    ? await detectSapphireSnap(provider)
-    : undefined;
-
   const f = async (args: EIP1193_RequestArguments) => {
+    const snapId = filled_options.enableSapphireSnap
+      ? await detectSapphireSnap(provider)
+      : undefined;
     const cipher = await filled_options.fetcher.cipher(provider);
     const { method, params } = args;
 

--- a/clients/js/src/provider.ts
+++ b/clients/js/src/provider.ts
@@ -164,8 +164,7 @@ export async function notifySapphireSnap(
   options: SapphireWrapOptions,
   provider: EIP2696_EthereumProvider,
 ) {
-  const secretKey = (cipher as any).secretKey as Uint8Array | undefined;
-  if (secretKey) {
+  if (cipher.ephemeralKey) {
     const peerPublicKey = await options.fetcher.fetch(provider);
     await provider.request({
       method: 'wallet_invokeSnap',
@@ -175,7 +174,7 @@ export async function notifySapphireSnap(
           method: 'setTransactionDecryptKeys',
           params: {
             id: transactionData,
-            ephemeralSecretKey: hexlify(secretKey),
+            ephemeralSecretKey: hexlify(cipher.ephemeralKey),
             peerPublicKey: hexlify(peerPublicKey.key),
             peerPublicKeyEpoch: peerPublicKey.epoch,
           },

--- a/clients/js/src/provider.ts
+++ b/clients/js/src/provider.ts
@@ -176,7 +176,7 @@ async function notifySapphireSnap(
           params: {
             id: transactionData,
             ephemeralSecretKey: hexlify(secretKey),
-            peerPublicKey: peerPublicKey.key,
+            peerPublicKey: hexlify(peerPublicKey.key),
             peerPublicKeyEpoch: peerPublicKey.epoch,
           },
         },

--- a/clients/js/src/provider.ts
+++ b/clients/js/src/provider.ts
@@ -142,7 +142,7 @@ interface SnapInfoT {
 
 const SAPPHIRE_SNAP_PNPM_ID = 'npm:@oasisprotocol/sapphire-snap';
 
-async function detectSapphireSnap(provider: EIP2696_EthereumProvider) {
+export async function detectSapphireSnap(provider: EIP2696_EthereumProvider) {
   try {
     const installedSnaps = (await provider.request({
       method: 'wallet_getSnaps',
@@ -157,7 +157,7 @@ async function detectSapphireSnap(provider: EIP2696_EthereumProvider) {
   }
 }
 
-async function notifySapphireSnap(
+export async function notifySapphireSnap(
   snapId: string,
   cipher: Cipher,
   transactionData: BytesLike,

--- a/clients/js/test/cipher.spec.ts
+++ b/clients/js/test/cipher.spec.ts
@@ -18,7 +18,7 @@ describe('X25519DeoxysII', () => {
     expect(hexlify(cipher.publicKey)).toEqual(
       '0x3046db3fa70ce605457dc47c48837ebd8bd0a26abfde5994d033e1ced68e2576',
     );
-    expect(hexlify(cipher['key'])).toEqual(
+    expect(hexlify(cipher['secretKey'])).toEqual(
       '0xe69ac21066a8c2284e8fdc690e579af4513547b9b31dd144792c1904b45cf586',
     );
 

--- a/integrations/ethers-v6/src/index.ts
+++ b/integrations/ethers-v6/src/index.ts
@@ -21,9 +21,11 @@ import type {
 } from "@oasisprotocol/sapphire-paratime";
 
 import {
+	detectSapphireSnap,
 	fillOptions,
 	isCalldataEnveloped,
 	makeTaggedProxyObject,
+	notifySapphireSnap,
 } from "@oasisprotocol/sapphire-paratime";
 
 export { NETWORKS } from "@oasisprotocol/sapphire-paratime";
@@ -90,11 +92,25 @@ export class SignerHasNoProviderError extends Error {}
 
 function hookEthersSend<
 	C extends Signer["sendTransaction"] | Signer["signTransaction"],
->(send: C, options: SapphireWrapOptions, request: EIP1193_RequestFn): C {
+>(
+	send: C,
+	options: SapphireWrapOptions,
+	request: EIP1193_RequestFn,
+	provider: EIP2696_EthereumProvider | undefined,
+): C {
 	return (async (tx: TransactionRequest) => {
 		if (tx.data) {
 			const cipher = await options.fetcher.cipher({ request });
 			tx.data = hexlify(cipher.encryptCall(tx.data));
+			if (provider) {
+				const snapId = options.enableSapphireSnap
+					? await detectSapphireSnap(provider)
+					: undefined;
+
+				if (snapId !== undefined && tx.data !== undefined) {
+					notifySapphireSnap(snapId, cipher, tx.data, options, provider);
+				}
+			}
 		}
 		return send(tx);
 	}) as C;
@@ -111,8 +127,9 @@ export function wrapEthersSigner<P extends Signer>(
 	const filled_options = fillOptions(options);
 
 	let signer: Signer;
+	let provider: (Provider & EIP2696_EthereumProvider) | undefined;
 	if (upstream.provider) {
-		const provider = wrapEthersProvider(upstream.provider, filled_options);
+		provider = wrapEthersProvider(upstream.provider, filled_options);
 		try {
 			signer = upstream.connect(provider);
 		} catch (e: unknown) {
@@ -140,11 +157,13 @@ export function wrapEthersSigner<P extends Signer>(
 				signer.sendTransaction.bind(signer),
 				filled_options,
 				request,
+				provider,
 			),
 			signTransaction: hookEthersSend(
 				signer.signTransaction.bind(signer),
 				filled_options,
 				request,
+				provider,
 			),
 			call: hookEthersCall(signer, "call", filled_options, request),
 			estimateGas: hookEthersCall(

--- a/integrations/ethers-v6/src/index.ts
+++ b/integrations/ethers-v6/src/index.ts
@@ -16,6 +16,7 @@ import type {
 	EIP1193_RequestArguments,
 	EIP1193_RequestFn,
 	EIP2696_EthereumProvider,
+	SapphireWrapConfig,
 	SapphireWrapOptions,
 } from "@oasisprotocol/sapphire-paratime";
 
@@ -101,7 +102,7 @@ function hookEthersSend<
 
 export function wrapEthersSigner<P extends Signer>(
 	upstream: P,
-	options?: SapphireWrapOptions,
+	options?: SapphireWrapConfig,
 ): P & EIP2696_EthereumProvider {
 	if (isWrappedSigner(upstream)) {
 		return upstream;
@@ -175,7 +176,7 @@ export class ContractRunnerHasNoProviderError extends Error {}
 
 export function wrapEthersProvider<P extends Provider>(
 	provider: P,
-	options?: SapphireWrapOptions,
+	options?: SapphireWrapConfig,
 ): P & EIP2696_EthereumProvider {
 	// Already wrapped, so don't wrap it again.
 	if (isWrappedProvider(provider)) {


### PR DESCRIPTION
fixes #389

This provides the decryption keys to snap.

> [!WARNING]
> If an RPC server pretends to implement the MetaMask snap protocol it could trick users into revealing the transaction encryption key. 
>
> For this reason, we have to explicitly enable Snap support in the dApp, by passing the `enableSapphireSnap` option.

Usage:

```typescript
wrapEthereumProvider(window.ethereum, {enableSapphireSnap:true})
```

```typescript
wrapEthersProvider(ethProvider, { enableSapphireSnap: true })
```

This must only be done if the dApp is sure that the provider it's connecting to is MetaMask.

Next PRs handled by Sapphire team: 

 * Automated tests for `wallet_invokeSnap`
 * Use flask for testing https://docs.metamask.io/snaps/get-started/install-flask/
