### PR TITLE
contracts/tests: Fix flaky SIWE and gas cost

### DIFF
--- a/contracts/test/gas.ts
+++ b/contracts/test/gas.ts
@@ -30,8 +30,11 @@ describe('Gas Padding', function () {
 
     // Note: calldata isn't included in gas padding
     // Thus when the value is 0 it will use 4 gas instead of 16 gas
+    // TODO: Workaround for flaky gas used https://github.com/oasisprotocol/sapphire-paratime/issues/337.
     tx = await contract.testConstantTime(0, 100000);
     receipt = await tx.wait();
-    expect(receipt?.cumulativeGasUsed).eq(initialGasUsed - 12n);
+    expect(receipt?.cumulativeGasUsed)
+      .gte(initialGasUsed - 13n)
+      .lte(initialGasUsed - 12n);
   });
 });


### PR DESCRIPTION
Fixes #443 by waiting for the block with sufficiently new timestamp instead of fixed time.
Another workaround for #337.