### PR TITLE
fix: links to emerald and cipher

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -14,10 +14,6 @@ crypto gaming
 * 6 second finality (1 block)
 * Cross-chain bridges to enable cross-chain interoperability
 
-If you are not bound to EVM and you wish to develop dApps with more
-fine-grained confidentiality, check out the
-[Cipher ParaTime](../cipher/README.mdx).
-
 [Ethereum Virtual Machine (EVM)]: https://ethereum.org/en/developers/docs/evm/
 
 ### Getting Started
@@ -63,6 +59,5 @@ Visit the [faucet][faucet] to obtain testnet tokens for development purposes.
     findSidebarItem('/node/run-your-node/paratime-node'),
     findSidebarItem('/node/run-your-node/paratime-client-node'),
     findSidebarItem('/node/web3'),
-    findSidebarItem('/dapp/emerald/'),
-    findSidebarItem('/dapp/cipher/'),
+    findSidebarItem('/dapp/tools/other-paratimes/'),
 ]} />

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -9,15 +9,14 @@ import {findSidebarItem} from '@site/src/sidebarUtils';
 
 This page mainly describes the differences between Sapphire and Ethereum
 since there are a number of excellent tutorials on developing for Ethereum.
-If you don't know where to begin, the [Hardhat tutorial], [Solidity docs], and
-[Emerald dApp tutorial] are great places to start. You can continue following
-this guide once you've set up your development environment and have deployed
-your contract to a non-confidential EVM network (e.g., Ropsten, Emerald).
+If you don't know where to begin, the [Hardhat tutorial] and the
+[Solidity docs] are great places to start. You can continue following this
+guide once you've set up your development environment and have deployed your
+contract to a non-confidential EVM network (e.g. Sepolia).
 
 
 [Hardhat tutorial]: https://hardhat.org/tutorial
 [Solidity docs]: https://docs.soliditylang.org/en/v0.8.15/solidity-by-example.html
-[Emerald dApp tutorial]: https://github.com/oasisprotocol/docs/blob/main/docs/dapp/emerald/writing-dapps-on-emerald.mdx
 
 ## Oasis Consensus Layer and Sapphire ParaTime
 


### PR DESCRIPTION
fixes the links which get broken through [1041](https://github.com/oasisprotocol/docs/pull/1041)

Merge after https://github.com/oasisprotocol/sapphire-paratime/pull/466