### PR TITLE
ci: Fix Docker options after removing oasis-deposit

### DIFF
--- a/.github/workflows/ci-playwright.yaml
+++ b/.github/workflows/ci-playwright.yaml
@@ -16,7 +16,7 @@ jobs:
           - 8545:8545
           - 8546:8546
         env:
-          OASIS_DEPOSIT_BINARY: /oasis-deposit -test-mnemonic -n 5
+          OASIS_DOCKER_START_EXPLORER: no
         options: >-
           --rm
           --health-cmd="test -f /CONTAINER_READY"

--- a/.github/workflows/ci-test-go.yaml
+++ b/.github/workflows/ci-test-go.yaml
@@ -26,7 +26,7 @@ jobs:
           - 8545:8545
           - 8546:8546
         env:
-          OASIS_DEPOSIT_BINARY: /oasis-deposit -test-mnemonic -n 2
+          OASIS_DOCKER_START_EXPLORER: no
         options: >-
           --rm
           --health-cmd="test -f /CONTAINER_READY"

--- a/.github/workflows/contracts-test.yaml
+++ b/.github/workflows/contracts-test.yaml
@@ -16,7 +16,7 @@ jobs:
           - 8545:8545
           - 8546:8546
         env:
-          OASIS_DEPOSIT_BINARY: /oasis-deposit -test-mnemonic -n 5
+          OASIS_DOCKER_START_EXPLORER: no
         options: >-
           --rm
           --health-cmd="test -f /CONTAINER_READY"


### PR DESCRIPTION
Note that I haven't found a way to pass the script arguments to the end of the Docker run command from GitHub Actions, but the nice part is that they don't really matter, since the test mnemonic and 5 accounts is already the default :man_shrugging:

Closes #465.