### PR TITLE
Update Oasis Scan API urls

### DIFF
--- a/docs/network.mdx
+++ b/docs/network.mdx
@@ -74,7 +74,7 @@ dedicated RPC endpoints, consider the following providers (in alphabetic order):
 | [Covalent]                   | `https://api.covalenthq.com/v1/oasis-sapphire-mainnet` | `https://api.covalenthq.com/v1/oasis-sapphire-testnet` | [Unified API docs][Covalent-docs]          |
 | [Goldsky Subgraph][Goldsky]  | *N/A*                                                  | *N/A*                                                  | [Documentation site][Goldsky-docs]         |
 | Oasis Nexus ([Oasis Protocol Foundation]) | `https://nexus.oasis.io/v1/`              | `https://testnet.nexus.oasis.io/v1/`                   | [API][Nexus-docs]                          |
-| Oasis Scan ([Bit Cat])       | `https://api.oasisscan.com/mainnet/v2`                 | `https://api.oasisscan.com/testnet/v2`                 | [Mainnet Runtime API][OasisScan-Mainnet-docs], [Testnet Runtime API][OasisScan-Testnet-docs] |
+| Oasis Scan ([Bit Cat])       | `https://api.oasisscan.com/v2/mainnet`                 | `https://api.oasisscan.com/v2/testnet`                 | [Runtime API][OasisScan-docs] |
 | [SubQuery Network][SubQuery] | *N/A*                                                  | *N/A*                                                  | [SubQuery Academy][SubQuery-docs], [QuickStart][SubQuery-quickstart], [Starter project][SubQuery-starter] |
 
 [Covalent]: https://www.covalenthq.com/
@@ -82,8 +82,7 @@ dedicated RPC endpoints, consider the following providers (in alphabetic order):
 [Nexus-docs]: https://nexus.oasis.io/v1/spec/v1.html
 [Goldsky]: https://goldsky.com
 [Goldsky-docs]: https://docs.goldsky.com/subgraphs/deploying-subgraphs
-[OasisScan-Testnet-docs]: https://api.oasisscan.com/testnet/swagger-ui/#/runtime-controller
-[OasisScan-Mainnet-docs]: https://api.oasisscan.com/mainnet/swagger-ui/#/runtime-controller
+[OasisScan-docs]: https://api.oasisscan.com/v2/swagger/#/runtime
 [SubQuery]: https://subquery.network
 [SubQuery-docs]: https://academy.subquery.network/
 [SubQuery-quickstart]: https://academy.subquery.network/quickstart/quickstart.html


### PR DESCRIPTION
Docs are referring to deprecated API that will be removed soon. PR updates Oasis Scan links to v2 which is currently used by BitCat.

Part of https://github.com/oasisprotocol/wallet/issues/2086

