### PR TITLE
docs/sapphire/quickstart: Use youtube-nocookie

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -4,7 +4,7 @@ import {findSidebarItem} from '@site/src/sidebarUtils';
 # Quickstart
 
 <p style={{width: '100%'}}>
-<iframe style={{margin: 'auto', display:'block'}} width="560" height="315" src="https://www.youtube.com/embed/LDLz06X_KNY?si=tS1-b1hncG6wo9oL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe style={{margin: 'auto', display:'block'}} width="560" height="315" src="https://www.youtube-nocookie.com/embed/LDLz06X_KNY" title="Deploying a Smart Contract on Oasis Sapphire: A Tutorial" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowFullScreen></iframe>
 </p>
 
 In this tutorial, you will build and deploy a unique dApp that requires


### PR DESCRIPTION
Use the nocookie version of the YouTube embedding for the Sapphire's video tutorial by @CedarMist . Inspired by https://github.com/oasisprotocol/docs/pull/1035.

Also fixes YT integration for Firefox (no fullscreen previously).