### PR TITLE
Add encryptCallData() to gasless chapter and example

### DIFF
--- a/examples/onchain-signer/hardhat.config.ts
+++ b/examples/onchain-signer/hardhat.config.ts
@@ -26,7 +26,17 @@ const config: HardhatUserConfig = {
     'sapphire-testnet': { ...sapphireTestnet, accounts },
     'sapphire-localnet': { ...sapphireLocalnet, accounts },
   },
-  solidity: '0.8.20',
+  solidity: {
+    version: '0.8.20',
+    settings: {
+      // XXX: Needs to match https://github.com/oasisprotocol/sapphire-paratime/blob/main/contracts/hardhat.config.ts
+      optimizer: {
+        enabled: true,
+        runs: (1 << 32) - 1,
+      },
+      viaIR: true,
+    },
+  },
 };
 
 export default config;

--- a/examples/onchain-signer/package.json
+++ b/examples/onchain-signer/package.json
@@ -25,6 +25,7 @@
     "@nomicfoundation/hardhat-verify": "^2.0.2",
     "@oasisprotocol/sapphire-contracts": "workspace:^",
     "@oasisprotocol/sapphire-hardhat": "workspace:^",
+    "@oasisprotocol/sapphire-paratime": "workspace:^",
     "@typechain/ethers-v6": "^0.5.1",
     "@typechain/hardhat": "^9.1.0",
     "@types/mocha": "^9.1.1",


### PR DESCRIPTION
This PR:
- documents `encryptCallData()` in `gasless.md` to generate encrypted gasless transaction
- adds `encryptCallData()` to `examples/onchain-signer` and tests it in combination with the wrapped/unwrapped provider and encrypted/plain gasless tx.
- removes some unneeded sleeps from the onchain-signer tests since the recent sapphire-localnet healthcheck correctly waits that the EVM is spun up before running them

[PREVIEW](https://deploy-preview-477--oasisprotocol-sapphire-paratime.netlify.app/dapp/sapphire/gasless)

Fixes #463.