### PR TITLE
feat: Add Foundry toolkit that enables Sapphire precompile and decryption

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -151,7 +151,7 @@ jobs:
           pip install -r requirements.dev.txt
           pip install sphinx myst-parser
           make wheel
-          pip install dist/sapphire.py-*.whl
+          pip install dist/sapphire_py-*.whl
 
       - name: Build docs
         run: |

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -129,3 +129,57 @@ jobs:
           python3 -mpip install --user -r requirements.dev.txt
           python3 -munittest discover
           python3 -m pytest sapphirepy/tests/
+  
+  test-examples-foundry:
+    name: test-examples-foundry
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./examples/foundry
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install libclang-dev
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+      - name: Install CMake
+        uses: lukka/get-cmake@latest
+
+      - name: Install dependencies
+        run: make build
+
+      - name: Run tests
+        run: forge test
+
+  test-integrations-foundry:
+    name: test-integrations-foundry
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./integrations/foundry
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install libclang-dev
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+      - name: Install CMake
+        uses: lukka/get-cmake@latest
+      
+      - name: Install dependencies
+        run: make build
+      
+      - name: Run tests
+        run: forge test

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,6 @@
 NPM ?= pnpm
 
-SUBDIRS := $(wildcard */.)  # e.g. "foo/. bar/."
+SUBDIRS := $(filter-out foundry/.,$(wildcard */.) )  # all dirs except foundry
 TARGETS := all clean lint test build distclean  # whatever else, but must not contain '/'
 
 # foo/.all bar/.all foo/.clean bar/.clean

--- a/examples/foundry/Makefile
+++ b/examples/foundry/Makefile
@@ -1,0 +1,16 @@
+
+all: build test
+
+build:
+	forge install foundry-rs/forge-std --no-commit --no-git
+	cd lib/oasisprotocol-sapphire-foundry/precompiles && cargo +nightly build --release
+
+test:
+	forge test
+
+clean:
+	forge clean
+	rm -rf cache build lib/oasisprotocol-sapphire-foundry/precompiles/Cargo.lock lib/oasisprotocol-sapphire-foundry/precompiles/target
+
+.PHONY: all build test clean
+

--- a/examples/foundry/README.md
+++ b/examples/foundry/README.md
@@ -1,0 +1,35 @@
+# Foundry example for Sapphire developers
+
+This project showcases Sapphire development with Foundry. 
+
+
+## Overview
+
+Test folder contains a set of Forge tests that access precompiles 
+and demonstrate sapphire-specific functionality. 
+Makefile contains build/test/clean targets.
+
+## Installation
+1. **Requirements**
+   - Foundry:
+      - `curl -L https://foundry.paradigm.xyz | bash`
+      - `foundryup`
+   - Rust (nightly):
+      - `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+      - `rustup toolchain install nightly`
+      - `rustup default nightly`
+   - Make
+
+2. **Install dependencies**
+   - Run `make build` ( Using foundry.toml ) to install dependencies and build rust bindings.
+
+## Run tests
+
+   Steps to run:
+   - Make sure you're in the `sapphire-paratime/examples/foundry` directory
+   - Run forge tests `forge test -vvv`
+
+### A note on fuzz tests:
+   Check out [fuzzing docs](https://book.getfoundry.sh/forge/fuzz-testing)
+
+

--- a/examples/foundry/foundry.toml
+++ b/examples/foundry/foundry.toml
@@ -1,0 +1,23 @@
+[profile.default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+ffi = true
+memory_limit = 1000000000
+
+[soldeer]
+# whether soldeer manages remappings
+remappings_generate = true
+
+# whether soldeer re-generates all remappings when installing, updating or uninstalling deps
+remappings_regenerate = false
+
+# whether to suffix the remapping with the version: `name-a.b.c`
+remappings_version = true
+
+# a prefix to add to the remappings ("@" would give `@name`)
+remappings_prefix = ""
+
+# where to store the remappings ("txt" for `remappings.txt` or "config" for `foundry.toml`)
+# ignored when `soldeer.toml` is used as config (uses `remappings.txt`)
+remappings_location = "txt"

--- a/examples/foundry/lib/oasisprotocol-sapphire-contracts
+++ b/examples/foundry/lib/oasisprotocol-sapphire-contracts
@@ -1,0 +1,1 @@
+../../../contracts/contracts

--- a/examples/foundry/lib/oasisprotocol-sapphire-foundry
+++ b/examples/foundry/lib/oasisprotocol-sapphire-foundry
@@ -1,0 +1,1 @@
+../../../integrations/foundry/lib/oasisprotocol-sapphire-foundry

--- a/examples/foundry/src/CommentBox.sol
+++ b/examples/foundry/src/CommentBox.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract CommentBox {
+    string[] public comments;
+
+    function commentCount() external view returns (uint256) {
+        return comments.length;
+    }
+
+    function comment(string memory commentText) external {
+        comments.push(commentText);
+    }
+}

--- a/examples/foundry/src/Counter.sol
+++ b/examples/foundry/src/Counter.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {SapphireDecryptor} from "lib/oasisprotocol-sapphire-foundry/BinaryContracts.sol";
+
+contract Counter is SapphireDecryptor {
+    uint256 public number;
+    
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+
+    function withdraw() external {
+        payable(msg.sender).transfer(address(this).balance);
+    }
+}

--- a/examples/foundry/src/Gasless.sol
+++ b/examples/foundry/src/Gasless.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {encryptCallData} from "lib/oasisprotocol-sapphire-contracts/CalldataEncryption.sol";
+import {EIP155Signer} from "lib/oasisprotocol-sapphire-contracts/EIP155Signer.sol";
+import {SapphireDecryptor} from "lib/oasisprotocol-sapphire-foundry/BinaryContracts.sol";
+struct EthereumKeypair {
+    address addr;
+    bytes32 secret;
+    uint64 nonce;
+}
+
+// Proxy for gasless transaction.
+contract Gasless is SapphireDecryptor {
+    EthereumKeypair private kp;
+
+    constructor(EthereumKeypair memory keypair) payable {
+        kp = keypair;
+        if (msg.value > 0) {
+            payable(kp.addr).transfer(msg.value);
+        }
+    }
+
+    function makeProxyTx(
+        address innercallAddr,
+        bytes memory innercall
+    ) external view returns (bytes memory output) {
+        bytes memory data = abi.encode(innercallAddr, innercall);
+        return
+            EIP155Signer.sign(
+                kp.addr,
+                kp.secret,
+                EIP155Signer.EthTx({
+                    nonce: kp.nonce,
+                    gasPrice: 100_000_000_000,
+                    gasLimit: 250000,
+                    to: address(this),
+                    value: 0,
+                    data: encryptCallData(abi.encodeCall(this.proxy, data)),
+                    chainId: block.chainid
+                })
+            );
+    }
+
+    function makeProxyTxPlain(
+        address innercallAddr,
+        bytes memory innercall
+    ) external view returns (bytes memory output) {
+        bytes memory data = abi.encode(innercallAddr, innercall);
+        return
+            EIP155Signer.sign(
+                kp.addr,
+                kp.secret,
+                EIP155Signer.EthTx({
+                    nonce: kp.nonce,
+                    gasPrice: 100_000_000_000,
+                    gasLimit: 250000,
+                    to: address(this),
+                    value: 0,
+                    data: abi.encodeCall(this.proxy, data),
+                    chainId: block.chainid
+                })
+            );
+    }
+
+    function proxy(bytes memory data) external payable {
+        (address addr, bytes memory subcallData) = abi.decode(
+            data,
+            (address, bytes)
+        );
+        (bool success, bytes memory outData) = addr.call{value: msg.value}(
+            subcallData
+        );
+        if (!success) {
+            // Add inner-transaction meaningful data in case of error.
+            assembly {
+                revert(add(outData, 32), mload(outData))
+            }
+        }
+        kp.nonce += 1;
+    }
+}

--- a/examples/foundry/test/TestCommentBox.t.sol
+++ b/examples/foundry/test/TestCommentBox.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+import "forge-std/Vm.sol";
+import "lib/oasisprotocol-sapphire-foundry/BaseSapphireTest.sol";
+import "../src/CommentBox.sol";
+import "../src/Gasless.sol";
+
+
+contract CommentBoxTest is SapphireTest {
+    CommentBox commentBox;
+    Gasless gasless;
+    EthereumKeypair wallet;
+
+    function setUp() public override {
+        // Call parent setUp first which deploys the Sapphire precompiles
+        super.setUp();
+        commentBox = new CommentBox();
+        console.log("deployed CommentBox to: ", address(commentBox));
+
+        // Generate signer account for gasless tx
+        bytes32 secret = keccak256(
+            abi.encodePacked(block.timestamp, block.prevrandao)
+        );
+        address walletAddress = vm.addr(uint256(secret));
+        console.logBytes32(secret);
+        vm.deal(walletAddress, 10 ether);
+        
+        wallet = EthereumKeypair({
+            addr: walletAddress,
+            secret: secret,
+            nonce: uint64(vm.getNonce(walletAddress))
+        });
+
+        gasless = new Gasless(wallet);
+        console.log("deployed Gasless to: ", address(gasless));
+        console.log("gasless address: ", wallet.addr);
+    }
+
+    function testComment() public {
+        uint256 prevCommentCount = commentBox.commentCount();
+
+        commentBox.comment("Hello, world!");
+        assertEq(commentBox.commentCount(), prevCommentCount + 1);
+    }
+
+    function testCommentGaslessEncrypted() public {
+        commentGasless("Hello, c10l world", false);
+    }
+
+    function testCommentGaslessPlain() public {
+        commentGasless("Hello, plain world", true);
+    }
+
+
+    function commentGasless(
+        string memory comment,
+        bool plainProxy
+    ) internal {
+        bytes memory innercall = 
+        abi.encodeWithSignature("comment(string)", comment);
+
+        uint256 prevCommentCount = commentBox.commentCount();
+        bytes memory raw_tx;
+        if (plainProxy) {
+            raw_tx = gasless.makeProxyTxPlain(address(commentBox), innercall);
+        } else {
+            raw_tx = gasless.makeProxyTx(address(commentBox), innercall);
+        }
+        vm.broadcastRawTransaction(raw_tx);
+
+        assertEq(commentBox.commentCount(), prevCommentCount + 1);
+    }
+}

--- a/examples/foundry/test/TestCounter.t.sol
+++ b/examples/foundry/test/TestCounter.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
+import "lib/oasisprotocol-sapphire-foundry/BaseSapphireTest.sol";
+import "lib/oasisprotocol-sapphire-contracts/CalldataEncryption.sol";
+import "../src/Counter.sol";
+
+contract TestCounter is SapphireTest {
+    Counter counter;
+
+    receive() external payable {}
+    
+    function setUp() public override {
+        super.setUp(); // Call parent setUp first
+        counter = new Counter();
+    }
+
+    /*
+    Fuzz tests for the Counter contract with different withdraw amounts.
+    */  
+    function testFuzz_Withdraw(uint96 amount) public {
+        console.log("Contract balance: ", address(this).balance);
+        payable(address(counter)).transfer(amount);
+        uint256 preBalance = address(this).balance;
+        counter.withdraw();
+        uint256 postBalance = address(this).balance;
+        assertEq(preBalance + amount, postBalance);
+    }
+
+    /*
+    Test decryption using the SapphireDecryptor contract.  
+    */  
+    function testCounterEncryptCallData() public {
+        // Test encryption using Sapphire Contracts.
+        bytes memory encryptedData = encryptCallData(
+            abi.encodeWithSelector(counter.increment.selector)
+        );
+        // DECODE is a custom precompile for 
+        // testing decryption using hardcoded peer key.
+        // It is not part of the Sapphire EVM.
+        (bool success, bytes memory decryptedData) = DECODE.call(
+            abi.encode(encryptedData
+        ));
+        assertEq(success, true);
+        assertEq(
+            decryptedData, 
+            abi.encodeWithSelector(counter.increment.selector)
+            );
+
+        console.log("Counter number: ", counter.number());
+
+        // counter contract inherits from SapphireDecryptor
+        // Test if it handles the encrypted calldata correctly. 
+        uint256 initialNumber = counter.number();
+        (success, decryptedData) = address(counter).call(encryptedData);
+        assertEq(success, true);
+        assertEq(counter.number(), initialNumber + 1);
+    }
+}

--- a/integrations/Makefile
+++ b/integrations/Makefile
@@ -1,6 +1,6 @@
 NPM ?= pnpm
 
-SUBDIRS := $(wildcard */.)  # e.g. "foo/. bar/."
+SUBDIRS := $(filter-out foundry/.,$(wildcard */.) )  # all dirs except foundry
 TARGETS := all clean lint test build distclean  # whatever else, but must not contain '/'
 
 # foo/.all bar/.all foo/.clean bar/.clean

--- a/integrations/foundry/Makefile
+++ b/integrations/foundry/Makefile
@@ -1,0 +1,15 @@
+
+all: build test
+
+build:
+	forge install foundry-rs/forge-std --no-commit --no-git
+	cd lib/oasisprotocol-sapphire-foundry/precompiles && cargo +nightly build --release
+
+test:
+	forge test
+
+clean:
+	forge clean
+	rm -rf cache build lib/oasisprotocol-sapphire-foundry/precompiles/Cargo.lock lib/oasisprotocol-sapphire-foundry/precompiles/target
+	
+.PHONY: all build test clean

--- a/integrations/foundry/README.md
+++ b/integrations/foundry/README.md
@@ -1,0 +1,66 @@
+# Foundry Package for Sapphire developers
+
+This project implements Sapphire-compatible precompiles 
+for use with forge tests. It includes support for 
+confidential computing capabilities through encryption/decryption handling.
+
+## Overview
+
+This project contains a set of contracts that mock Sapphire's precompile 
+behavior using rust bindings. In addition, it contains SapphireDecryptor, 
+a contract that can decrypt encrypted calldata. SapphireDecryptor works by 
+inheritence and will forward the decrypted calldata to the contract that 
+called it. This is useful, for example, to test the execution of the on-chain 
+generated gasless transactions with encrypted calldata.
+
+## List of precompiles
+
+### Cryptographic Operations
+
+- `RandomBytes`: Generate random bytes
+- `X25519Derive`: Derive shared secrets using X25519
+- `DeoxysiiSeal`: Encrypt data using Deoxys-II
+- `DeoxysiiOpen`: Decrypt data using Deoxys-II
+- `Curve25519ComputePublic`: Compute public keys
+- `DECODE`: decode cbor encoded data and decrypt the calldata. 
+**Warning**: This precompile is not part of 
+the Sapphire EVM. It is only used for
+testing encryption envelope without having to decode the CBOR encoded data 
+in solidity tests.
+
+
+### Key Management
+- `KeypairGenerate`: Generate cryptographic keypairs
+- `Sign`: Sign messages
+- `Verify`: Verify signatures
+
+### Consensus Operations
+- `Subcall`: Enhanced version with CBOR parsing and state management for:
+- Delegations
+- Undelegations
+- Receipt tracking
+
+## Key Features
+
+1. **Sapphire precompiles as contracts**
+   - Can run as native precompiles
+   - Easy import into forge tests
+
+2. **Decryption Base contract**
+   - Enables decryption at contract level
+   - Used as a base contract for other contracts that implement encryption
+
+## Installation
+
+This folder contains precompile contracts and rust bindings that can be 
+imported into separate Foundry projects. 
+To install the dependencies, run `make build` ( Using foundry.toml ).
+
+
+## Usage
+To test the precompiles, run `forge test`.
+
+For a test example, see [sapphire-paratime/examples/foundry].
+[sapphire-paratime/examples/foundry]: https://github.com/oasisprotocol/sapphire-paratime/tree/main/examples/foundry
+
+

--- a/integrations/foundry/foundry.toml
+++ b/integrations/foundry/foundry.toml
@@ -1,0 +1,23 @@
+[profile.default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+ffi = true
+memory_limit = 1000000000
+
+[soldeer]
+# whether soldeer manages remappings
+remappings_generate = true
+
+# whether soldeer re-generates all remappings when installing, updating or uninstalling deps
+remappings_regenerate = false
+
+# whether to suffix the remapping with the version: `name-a.b.c`
+remappings_version = true
+
+# a prefix to add to the remappings ("@" would give `@name`)
+remappings_prefix = ""
+
+# where to store the remappings ("txt" for `remappings.txt` or "config" for `foundry.toml`)
+# ignored when `soldeer.toml` is used as config (uses `remappings.txt`)
+remappings_location = "txt"

--- a/integrations/foundry/lib/oasisprotocol-sapphire-contracts
+++ b/integrations/foundry/lib/oasisprotocol-sapphire-contracts
@@ -1,0 +1,1 @@
+../../../contracts/contracts

--- a/integrations/foundry/lib/oasisprotocol-sapphire-foundry/BaseSapphireTest.sol
+++ b/integrations/foundry/lib/oasisprotocol-sapphire-foundry/BaseSapphireTest.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {console} from "forge-std/console.sol";
+
+import "./BinaryHandler.sol";
+import "./Precompiles.sol";
+
+abstract contract SapphireTest is Test, Precompiles {
+    BinaryHandler binaryHandler;
+
+    function setUp() public virtual {
+        binaryHandler = new BinaryHandler();
+    }
+}

--- a/integrations/foundry/lib/oasisprotocol-sapphire-foundry/BinaryContracts.sol
+++ b/integrations/foundry/lib/oasisprotocol-sapphire-foundry/BinaryContracts.sol
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.11;
+
+import {Vm} from "forge-std/Vm.sol";
+import {console} from "forge-std/console.sol";
+
+// Random Bytes Precompile
+contract RandomBytesPrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata input) external returns (bytes memory) {
+        (uint256 numBytes, bytes memory pers) = abi.decode(input, (uint256, bytes));
+        require(numBytes <= 1024, "Random: too many bytes requested");
+        bytes memory params = abi.encode(numBytes, pers);
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/random_bytes";
+        inputs[1] = vm.toString(params);
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+// X25519 Derive Precompile
+contract X25519DerivePrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata input) external returns (bytes memory) {
+        (bytes32 publicKey, bytes32 privateKey) = abi.decode(input, (bytes32, bytes32));
+        bytes memory params = abi.encodePacked(publicKey, privateKey);
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/x25519_derive";
+        inputs[1] = vm.toString(params);
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+// Deoxysii Seal Precompile
+contract DeoxysiiSealPrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata input) external returns (bytes memory) {
+        (bytes32 key, bytes32 nonce, bytes memory plaintext, bytes memory ad) =
+            abi.decode(input, (bytes32, bytes32, bytes, bytes));
+        bytes memory params = abi.encode(key, nonce, plaintext, ad);
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/deoxysii_seal";
+        inputs[1] = vm.toString(params);
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+// Deoxysii Open Precompile
+contract DeoxysiiOpenPrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata input) external returns (bytes memory) {
+        (bytes32 key, bytes32 nonce, bytes memory ciphertext, bytes memory ad) =
+            abi.decode(input, (bytes32, bytes32, bytes, bytes));
+        bytes memory params = abi.encode(key, nonce, ciphertext, ad);
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/deoxysii_open";
+        inputs[1] = vm.toString(params);
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+// Curve25519 Compute Public Precompile
+contract Curve25519ComputePublicPrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata input) external returns (bytes memory) {
+        bytes32 privateKey = abi.decode(input, (bytes32));
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/curve25519_compute_public";
+        inputs[1] = vm.toString(abi.encodePacked(privateKey));
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+// Keypair Generate Precompile
+contract KeypairGeneratePrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata input) external returns (bytes memory) {
+        (uint256 sigType, bytes memory seed) = abi.decode(input, (uint256, bytes));
+        bytes memory params = abi.encode(sigType, seed);
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/keypair_generate";
+        inputs[1] = vm.toString(params);
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+// Sign Precompile
+contract SignPrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata input) external returns (bytes memory) {
+        (uint256 sigType, bytes memory privateKey, bytes memory context, bytes memory message) =
+            abi.decode(input, (uint256, bytes, bytes, bytes));
+        bytes memory params = abi.encode(sigType, privateKey, context, message);
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/sign";
+        inputs[1] = vm.toString(params);
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+// Verify Precompile
+contract VerifyPrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata input) external returns (bytes memory) {
+        (uint256 sigType, bytes memory publicKey, bytes memory context, bytes memory message, bytes memory signature) =
+            abi.decode(input, (uint256, bytes, bytes, bytes, bytes));
+        bytes memory params = abi.encode(sigType, publicKey, context, message, signature);
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/verify";
+        inputs[1] = vm.toString(params);
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+// Gas Used Precompile
+contract GasUsedPrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata) external returns (bytes memory) {
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/gas_used";
+        inputs[1] = vm.toString(bytes(""));
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+// Pad Gas Precompile
+contract PadGasPrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata input) external returns (bytes memory) {
+        uint128 target = abi.decode(input, (uint128));
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/pad_gas";
+        inputs[1] = vm.toString(abi.encode(target));
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+// Subcall Precompile
+contract SubcallPrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata input) external returns (bytes memory) {
+        (string memory method, bytes memory body) = abi.decode(input, (string, bytes));
+        uint256 blockNumber = uint256(vm.getBlockNumber());
+        bytes32 privateKey = 0x1234567890123456789012345678901234567890123456789012345678901234;
+        bytes memory params = abi.encode(blockNumber, method, body, privateKey);
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/subcall";
+        inputs[1] = vm.toString(params);
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+// Core Calldata Public Key Precompile
+contract CoreCalldataPublicKeyPrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata) external returns (bytes memory) {
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/core_calldata_public_key";
+        inputs[1] = vm.toString(abi.encodePacked(hex"f6"));
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+// Core Current Epoch Precompile
+contract CoreCurrentEpochPrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata) external returns (bytes memory) {
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/core_current_epoch";
+        inputs[1] = vm.toString(abi.encodePacked(hex"f6"));
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+// ROFL Is Authorized Origin Precompile
+contract RoflIsAuthorizedOriginPrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata input) external returns (bytes memory) {
+        bytes21 appId = abi.decode(input, (bytes21));
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/rofl_is_authorized_origin";
+        inputs[1] = vm.toString(abi.encodePacked(hex"55", appId));
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+contract DecodePrecompile {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    fallback(bytes calldata input) external returns (bytes memory) {
+        (bytes memory data) = abi.decode(input, (bytes));
+        bytes32 privateKey = 0x1234567890123456789012345678901234567890123456789012345678901234;
+        bytes memory params = abi.encode(data, privateKey);
+        string[] memory inputs = new string[](2);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/decode";
+        inputs[1] = vm.toString(params);
+        return vm.ffi(inputs);
+    }
+
+    receive() external payable {
+        revert("No ether accepted");
+    }
+}
+
+abstract contract SapphireDecryptor {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+    bytes32 private privateKey_ = 0x1234567890123456789012345678901234567890123456789012345678901234;
+
+    fallback(bytes calldata encryptedData) external payable returns (bytes memory) {
+        // Try to decrypt using rust binary
+        string[] memory inputs = new string[](2);
+        bytes memory params = abi.encode(encryptedData, privateKey_);
+        inputs[0] = "lib/oasisprotocol-sapphire-foundry/precompiles/target/release/decode";
+        inputs[1] = vm.toString(params);
+        bytes memory decryptedData = vm.ffi(inputs);
+
+        // If data was encrypted (different after decryption)
+        if (keccak256(encryptedData) != keccak256(decryptedData)) {
+            // Forward the decrypted calldata to this contract
+            (bool success, bytes memory result) = address(this).call(decryptedData);
+            require(success, "Inner call failed");
+            return result;
+        }
+
+        // If data wasn't encrypted, revert since no matching function was found
+        revert("No matching function");
+    }
+
+    receive() external payable {}
+}

--- a/integrations/foundry/lib/oasisprotocol-sapphire-foundry/BinaryHandler.sol
+++ b/integrations/foundry/lib/oasisprotocol-sapphire-foundry/BinaryHandler.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.11;
+
+import "./Precompiles.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {console} from "forge-std/console.sol";
+import "./BinaryContracts.sol";
+
+contract BinaryHandler is Precompiles {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+    RandomBytesPrecompile randomBytesPrecompile;
+    X25519DerivePrecompile x25519DerivePrecompile;
+    Curve25519ComputePublicPrecompile curve25519ComputePublicPrecompile;
+    DeoxysiiSealPrecompile deoxysiiSealPrecompile;
+    DeoxysiiOpenPrecompile deoxysiiOpenPrecompile;
+    KeypairGeneratePrecompile keypairGeneratePrecompile;
+    SignPrecompile signPrecompile;
+    VerifyPrecompile verifyPrecompile;
+    GasUsedPrecompile gasUsedPrecompile;
+    PadGasPrecompile padGasPrecompile;
+    SubcallPrecompile subcallPrecompile;
+    CoreCalldataPublicKeyPrecompile coreCalldataPublicKeyPrecompile;
+    CoreCurrentEpochPrecompile coreCurrentEpochPrecompile;
+    RoflIsAuthorizedOriginPrecompile roflIsAuthorizedOriginPrecompile;
+    DecodePrecompile decodePrecompile;
+
+    constructor() {
+        // Deploy typed contracts for each precompile
+        vm.etch(RANDOM_BYTES, type(RandomBytesPrecompile).runtimeCode);
+        vm.label(RANDOM_BYTES, "RANDOM_BYTES");
+
+        vm.etch(X25519_DERIVE, type(X25519DerivePrecompile).runtimeCode);
+        vm.label(X25519_DERIVE, "X25519_DERIVE");
+
+        vm.etch(CURVE25519_COMPUTE_PUBLIC, type(Curve25519ComputePublicPrecompile).runtimeCode);
+        vm.label(CURVE25519_COMPUTE_PUBLIC, "CURVE25519_COMPUTE_PUBLIC");
+
+        vm.etch(DEOXYSII_SEAL, type(DeoxysiiSealPrecompile).runtimeCode);
+        vm.label(DEOXYSII_SEAL, "DEOXYSII_SEAL");
+
+        vm.etch(DEOXYSII_OPEN, type(DeoxysiiOpenPrecompile).runtimeCode);
+        vm.label(DEOXYSII_OPEN, "DEOXYSII_OPEN");
+
+        vm.etch(KEYPAIR_GENERATE, type(KeypairGeneratePrecompile).runtimeCode);
+        vm.label(KEYPAIR_GENERATE, "KEYPAIR_GENERATE");
+
+        vm.etch(SIGN, type(SignPrecompile).runtimeCode);
+        vm.label(SIGN, "SIGN");
+
+        vm.etch(VERIFY, type(VerifyPrecompile).runtimeCode);
+        vm.label(VERIFY, "VERIFY");
+
+        vm.etch(GAS_USED, type(GasUsedPrecompile).runtimeCode);
+        vm.label(GAS_USED, "GAS_USED");
+
+        vm.etch(PAD_GAS, type(PadGasPrecompile).runtimeCode);
+        vm.label(PAD_GAS, "PAD_GAS");
+
+        vm.etch(SUBCALL, type(SubcallPrecompile).runtimeCode);
+        vm.label(SUBCALL, "SUBCALL");
+
+        vm.etch(
+            address(bytes20(keccak256(bytes(CORE_CALLDATAPUBLICKEY)))),
+            type(CoreCalldataPublicKeyPrecompile).runtimeCode
+        );
+        vm.label(address(bytes20(keccak256(bytes(CORE_CALLDATAPUBLICKEY)))), "CORE_CALLDATAPUBLICKEY");
+
+        vm.etch(address(bytes20(keccak256(bytes(CORE_CURRENT_EPOCH)))), type(CoreCurrentEpochPrecompile).runtimeCode);
+        vm.label(address(bytes20(keccak256(bytes(CORE_CURRENT_EPOCH)))), "CORE_CURRENT_EPOCH");
+
+        vm.etch(
+            address(bytes20(keccak256(bytes(ROFL_IS_AUTHORIZED_ORIGIN)))),
+            type(RoflIsAuthorizedOriginPrecompile).runtimeCode
+        );
+        vm.label(address(bytes20(keccak256(bytes(ROFL_IS_AUTHORIZED_ORIGIN)))), "ROFL_IS_AUTHORIZED_ORIGIN");
+
+        vm.etch(
+            DECODE, type(DecodePrecompile).runtimeCode
+        );
+        vm.label(DECODE, "DECODE");
+    }
+}

--- a/integrations/foundry/lib/oasisprotocol-sapphire-foundry/Precompiles.sol
+++ b/integrations/foundry/lib/oasisprotocol-sapphire-foundry/Precompiles.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Precompiles {
+    // Random Bytes
+    address public constant RANDOM_BYTES = 0x0100000000000000000000000000000000000001;
+
+    // X25519 Derive
+    address public constant X25519_DERIVE = 0x0100000000000000000000000000000000000002;
+
+    // DeoxysII Seal
+    address public constant DEOXYSII_SEAL = 0x0100000000000000000000000000000000000003;
+
+    // DeoxysII Open
+    address public constant DEOXYSII_OPEN = 0x0100000000000000000000000000000000000004;
+
+    // Keypair Generate
+    address public constant KEYPAIR_GENERATE = 0x0100000000000000000000000000000000000005;
+
+    // Sign
+    address public constant SIGN = 0x0100000000000000000000000000000000000006;
+
+    // Verify
+    address public constant VERIFY = 0x0100000000000000000000000000000000000007;
+
+    // Curve25519 Compute Public
+    address public constant CURVE25519_COMPUTE_PUBLIC = 0x0100000000000000000000000000000000000008;
+
+    address internal constant GAS_USED = 0x0100000000000000000000000000000000000009;
+
+    address internal constant PAD_GAS = 0x010000000000000000000000000000000000000a;
+
+    // Oasis-specific, general precompiles
+    address public constant SHA512_256 = 0x0100000000000000000000000000000000000101;
+    address public constant SHA512 = 0x0100000000000000000000000000000000000102;
+    address public constant SHA384 = 0x0100000000000000000000000000000000000104;
+
+    /// Address of the SUBCALL precompile
+    address public constant SUBCALL = 0x0100000000000000000000000000000000000103;
+
+    /// Address of the DECODE precompile
+    address public constant DECODE = 0x0100000000000000000000000000000000000201;
+
+    // METHODS:
+    // Consensus
+    string public constant CONSENSUS_DELEGATE = "consensus.Delegate";
+    string public constant CONSENSUS_UNDELEGATE = "consensus.Undelegate";
+    string public constant CONSENSUS_WITHDRAW = "consensus.Withdraw";
+    string public constant CONSENSUS_TAKE_RECEIPT = "consensus.TakeReceipt";
+    // Accounts
+    string public constant ACCOUNTS_TRANSFER = "accounts.Transfer";
+    // Core
+    string public constant CORE_CALLDATAPUBLICKEY = "core.CallDataPublicKey";
+    string public constant CORE_CURRENT_EPOCH = "core.CurrentEpoch";
+    string public constant OASIS_CALLDATAPUBLICKEY = "oasis_callDataPublicKey";
+    // ROFL
+    string public constant ROFL_IS_AUTHORIZED_ORIGIN = "rofl.IsAuthorizedOrigin";
+}

--- a/integrations/foundry/lib/oasisprotocol-sapphire-foundry/precompiles/.cargo/config.toml
+++ b/integrations/foundry/lib/oasisprotocol-sapphire-foundry/precompiles/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-feature=+aes,+ssse3"]

--- a/integrations/foundry/lib/oasisprotocol-sapphire-foundry/precompiles/Cargo.toml
+++ b/integrations/foundry/lib/oasisprotocol-sapphire-foundry/precompiles/Cargo.toml
@@ -1,0 +1,85 @@
+[package]
+name = "precompiles"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "random_bytes"
+path = "src/main.rs"
+
+[[bin]]
+name = "x25519_derive"
+path = "src/main.rs"
+
+[[bin]]
+name = "curve25519_compute_public"
+path = "src/main.rs"
+
+[[bin]]
+name = "deoxysii_seal"
+path = "src/main.rs"
+
+[[bin]]
+name = "deoxysii_open"
+path = "src/main.rs"
+
+[[bin]]
+name = "keypair_generate"
+path = "src/main.rs"
+
+[[bin]]
+name = "sign"
+path = "src/main.rs"
+
+[[bin]]
+name = "verify"
+path = "src/main.rs"
+
+[[bin]]
+name = "gas_used"
+path = "src/main.rs"
+
+[[bin]]
+name = "pad_gas"
+path = "src/main.rs"
+
+[[bin]]
+name = "subcall"
+path = "src/main.rs"
+
+[[bin]]
+name = "core_calldata_public_key"
+path = "src/main.rs"
+
+[[bin]]
+name = "core_current_epoch"
+path = "src/main.rs"
+
+[[bin]]
+name = "rofl_is_authorized_origin"
+path = "src/main.rs"
+
+[[bin]]
+name = "decode"
+path = "src/main.rs"
+
+[dependencies]
+ethabi = "18.0"
+hex = "0.4"
+hmac = "0.12"
+once_cell = "1.18"
+sha2 = "0.10"
+x25519-dalek = "2.0"
+rand = "0.8"
+ed25519-dalek = "2.1.1"
+oasis-core-keymanager = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v25.0" }
+oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v25.0" }
+oasis-runtime-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", package = "oasis-runtime-sdk", branch = "main" }
+evm = { git = "https://github.com/oasisprotocol/evm", tag = "v0.39.1-oasis" }
+oasis_cbor = { version = "0.5.1", package = "oasis-cbor" }
+
+[build]
+rustflags = ["-C", "target-feature=+aes,+ssse3"]
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))']
+rustflags = ["-C", "target-feature=+aes,+ssse3"]

--- a/integrations/foundry/lib/oasisprotocol-sapphire-foundry/precompiles/src/main.rs
+++ b/integrations/foundry/lib/oasisprotocol-sapphire-foundry/precompiles/src/main.rs
@@ -1,0 +1,497 @@
+use std::sync::Arc;
+use ethabi::{ParamType, Token};
+use rand::Rng;
+use hex;
+use x25519_dalek; 
+use hmac::{Hmac, Mac};
+use sha2::Sha512_256;
+use std::{env, process};
+use oasis_cbor;
+
+use oasis_runtime_sdk::{
+    core::common::{
+        crypto::{
+            mrae::deoxysii::{DeoxysII, KEY_SIZE, NONCE_SIZE},
+            signature::{Signature, PublicKey as SignaturePublicKey, PrivateKey},
+            x25519,
+        },
+        namespace::{Namespace},
+    },
+    context::Context,
+    core::common::crypto::mrae::deoxysii,
+    // crypto::signature::context::get_chain_context_for,
+    crypto::signature::{
+        self,
+        context::get_chain_context_for,
+        SignatureType,
+        MemorySigner,
+    },
+    keymanager, 
+    module,
+    modules::core::Error,
+    state::CurrentState,
+    types::{
+        transaction::{Call, CallFormat, CallResult},
+        callformat::CallEnvelopeX25519DeoxysII,
+    },
+};
+pub use oasis_core_keymanager::{
+    api::KeyManagerError,
+    crypto::{kdf::Kdf, KeyPair, KeyPairId, SignedPublicKey, StateKey, KEY_PAIR_ID_SIZE},
+    policy::TrustedSigners,
+};
+use oasis_core_runtime::common::crypto::signature::{Signer};
+use oasis_core_runtime::consensus::beacon::EpochTime;
+use evm::{
+    executor::stack::{PrecompileFailure, PrecompileHandle, PrecompileOutput},
+    ExitError, ExitRevert, ExitSucceed,
+};
+const WORD: usize = 32;
+
+#[derive(oasis_cbor::Encode)]
+pub struct CallDataPublicKeyQueryResponse {
+    pub public_key: SignedPublicKey,
+    pub epoch: u64,
+}
+// pub struct PrivateKey(pub ed25519_dalek::SigningKey);
+
+// impl PrivateKey {
+//     pub fn from_bytes(bytes: [u8; 32]) -> Self {
+//         let signing_key = ed25519_dalek::SigningKey::from_bytes(&bytes);
+//         PrivateKey(signing_key)
+//     }
+// }
+
+const PUBLIC_KEY_SIGNATURE_CONTEXT: &[u8] = b"oasis-core/keymanager: pk signature";
+
+
+fn decode_deoxysii_args(input: &[u8]) -> Result<([u8; KEY_SIZE], [u8; NONCE_SIZE], Vec<u8>, Vec<u8>), String> {
+    let call_args = ethabi::decode(
+        &[
+            ParamType::FixedBytes(32), // key
+            ParamType::FixedBytes(32), // nonce
+            ParamType::Bytes,          // plain or ciphertext
+            ParamType::Bytes,          // associated data
+        ],
+        input,
+    ).map_err(|e| e.to_string())?;
+
+    let ad = call_args[3].clone().into_bytes().unwrap();
+    let text = call_args[2].clone().into_bytes().unwrap();
+    let nonce_bytes = call_args[1].clone().into_fixed_bytes().unwrap();
+    let key_bytes = call_args[0].clone().into_fixed_bytes().unwrap();
+
+    let mut nonce = [0u8; NONCE_SIZE];
+    nonce.copy_from_slice(&nonce_bytes[..NONCE_SIZE]);
+    let mut key = [0u8; KEY_SIZE];
+    key.copy_from_slice(&key_bytes[..KEY_SIZE]);
+
+    Ok((key, nonce, text, ad))
+}
+
+fn handle_random_bytes(input: &[u8]) -> Result<Vec<u8>, String> {
+    let call_args = ethabi::decode(
+        &[ParamType::Uint(256), ParamType::Bytes],
+        input,
+    ).map_err(|e| e.to_string())?;
+
+    // let pers_str = call_args[1].clone().into_bytes().unwrap();
+    let num_bytes: u64 = call_args[0].clone().into_uint().unwrap().try_into().unwrap_or(u64::MAX);
+
+    let mut rng = rand::thread_rng();
+    let mut result = Vec::with_capacity(num_bytes as usize);
+    for _ in 0..num_bytes {
+        result.push(rng.gen());
+    }
+
+    Ok(result)
+}
+
+fn handle_x25519_derive(input: &[u8]) -> Result<Vec<u8>, String> {
+    if input.len() != 2 * WORD {
+        return Err("input length must be 64 bytes".into());
+    }
+
+    let mut public = [0u8; WORD];
+    let mut private = [0u8; WORD];
+    
+    public.copy_from_slice(&input[0..WORD]);
+    private.copy_from_slice(&input[WORD..]);
+
+    let public = x25519_dalek::PublicKey::from(public);
+    let private = x25519_dalek::StaticSecret::from(private);
+
+    let mut kdf = <Hmac<Sha512_256> as Mac>::new_from_slice(b"MRAE_Box_Deoxys-II-256-128")
+        .map_err(|e| e.to_string())?;
+    kdf.update(private.diffie_hellman(&public).as_bytes());
+
+    let mut derived_key = [0u8; KEY_SIZE];
+    let digest = kdf.finalize();
+    derived_key.copy_from_slice(&digest.into_bytes()[..KEY_SIZE]);
+
+    Ok(derived_key.to_vec())
+}
+
+fn handle_curve25519_compute_public(input: &[u8]) -> Result<Vec<u8>, String> {
+    if input.len() != WORD {
+        return Err("input length must be 32 bytes".into());
+    }
+
+    let private = <&[u8; WORD]>::try_from(input).unwrap();
+    let secret = x25519_dalek::StaticSecret::from(*private);
+    Ok(x25519_dalek::PublicKey::from(&secret).as_bytes().to_vec())
+}
+
+fn handle_deoxysii_seal(input: &[u8]) -> Result<Vec<u8>, String> {
+    let (key, nonce, text, ad) = decode_deoxysii_args(input)?;
+    let deoxysii = DeoxysII::new(&key);
+    Ok(deoxysii.seal(&nonce, text, ad))
+}
+
+fn handle_deoxysii_open(input: &[u8]) -> Result<Vec<u8>, String> {
+    let (key, nonce, ciphertext, ad) = decode_deoxysii_args(input)?;
+    let deoxysii = DeoxysII::new(&key);
+    deoxysii.open(&nonce, ciphertext, ad).map_err(|_| "decryption failed".into())
+}
+
+fn handle_keypair_generate(input: &[u8]) -> Result<Vec<u8>, String> {
+    let call_args = ethabi::decode(
+        &[
+            ParamType::Uint(256), // method
+            ParamType::Bytes,     // seed
+        ],
+        input,
+    ).map_err(|e| e.to_string())?;
+
+    let seed = call_args[1].clone().into_bytes().unwrap();
+    let method: u8 = call_args[0]
+        .clone()
+        .into_uint()
+        .unwrap()
+        .try_into()
+        .map_err(|_| "method identifier out of bounds")?;
+
+    let sig_type: SignatureType = method
+        .try_into()
+        .map_err(|_| "unknown signature type")?;
+
+    let signer = MemorySigner::new_from_seed(sig_type, &seed).map_err(|e| format!("error creating signer: {}", e))?;
+    
+    let public = signer.public_key().as_bytes().to_vec();
+    let private = signer.to_bytes();
+
+    //let mut result = Vec::new();
+    //result.extend_from_slice(&public);
+    //result.extend_from_slice(&private);
+    let result = ethabi::encode(&[Token::Bytes(public), Token::Bytes(private)]);
+
+    Ok(result)
+}
+
+fn handle_sign(input: &[u8]) -> Result<Vec<u8>, String> {
+    let call_args = ethabi::decode(
+        &[
+            ParamType::Uint(256), // signature type
+            ParamType::Bytes,     // private key
+            ParamType::Bytes,     // context
+            ParamType::Bytes,     // message
+        ],
+        input,
+    ).map_err(|e| e.to_string())?;
+
+    let message = call_args[3].clone().into_bytes().unwrap();
+    let context = call_args[2].clone().into_bytes().unwrap();
+    let pk = call_args[1].clone().into_bytes().unwrap();
+    let method: u8 = call_args[0]
+        .clone()
+        .into_uint()
+        .unwrap()
+        .try_into()
+        .map_err(|_| "signature type identifier out of bounds")?;
+
+    let sig_type: SignatureType = method
+        .try_into()
+        .map_err(|_| "unknown signature type")?;
+
+    let signer = MemorySigner::from_bytes(sig_type, &pk)
+        .map_err(|e| format!("error creating signer: {}", e))?;
+
+    let result = signer.sign_by_type(sig_type, &context, &message)
+        .map_err(|e| format!("error signing message: {}", e))?;
+
+    Ok(result.into())
+}
+
+
+
+fn handle_verify(input: &[u8]) -> Result<Vec<u8>, String> {
+    let mut call_args = ethabi::decode(
+        &[
+            ParamType::Uint(256), // signature type
+            ParamType::Bytes,     // public key
+            ParamType::Bytes,     // context
+            ParamType::Bytes,     // message
+            ParamType::Bytes,     // signature
+        ],
+        input,
+    ).map_err(|e| e.to_string())?;
+
+    let signature = call_args.pop().unwrap().into_bytes().unwrap();
+    let message = call_args.pop().unwrap().into_bytes().unwrap();
+    let ctx_or_hash = call_args.pop().unwrap().into_bytes().unwrap();
+    let pk = call_args.pop().unwrap().into_bytes().unwrap();
+    let method: u8 = call_args
+        .pop()
+        .unwrap()
+        .into_uint()
+        .unwrap()
+        .try_into()
+        .map_err(|_| "signature type identifier out of bounds".to_string())?;
+
+    let sig_type: SignatureType = method
+        .try_into()
+        .map_err(|_| "unknown signature type".to_string())?;
+
+    let signature: signature::Signature = signature.into();
+    let public_key = signature::PublicKey::from_bytes(sig_type, &pk)
+        .map_err(|e| format!("invalid public key: {}", e))?;
+
+    let result = public_key.verify_by_type(sig_type, &ctx_or_hash, &message, &signature);
+    Ok(ethabi::encode(&[Token::Bool(result.is_ok())]))
+}
+
+fn handle_gas_used(input: &[u8]) -> Result<Vec<u8>, String> {
+    // Simply return a fixed gas cost for now since we can't 
+    // actually track gas usage in the standalone binary
+    let used_gas: u64 = 10;
+    
+    // Return the gas usage encoded as uint256
+    Ok(ethabi::encode(&[Token::Uint(used_gas.into())]))
+}
+
+fn handle_pad_gas(input: &[u8]) -> Result<Vec<u8>, String> {
+    // Decode the target gas amount
+    let call_args = ethabi::decode(
+        &[ParamType::Uint(128)],
+        input,
+    ).map_err(|e| e.to_string())?;
+
+    let gas_amount: u64 = call_args[0]
+        .clone()
+        .into_uint()
+        .unwrap()
+        .try_into()
+        .unwrap_or(u64::MAX);
+
+    // For simulation purposes, assume we've used 10 gas so far
+    let used_gas: u64 = 10;
+
+    // Fail if more gas than desired padding was already used
+    if gas_amount < used_gas {
+        return Err("gas pad amount less than already used gas".into());
+    }
+
+    // Return empty output since pad_gas doesn't return anything
+    Ok(Vec::new())
+}
+
+
+fn handle_subcall(input: &[u8]) -> Result<Vec<u8>, String> {
+
+    let call_args = ethabi::decode(
+        &[
+            ParamType::Uint(256), // epoch
+            ParamType::String,    // method
+            ParamType::Bytes,     // body (CBOR)
+            ParamType::FixedBytes(32), // private key
+        ],
+        &input,
+    ).map_err(|e| e.to_string())?;
+ 
+    let body = call_args[2].clone().into_bytes().unwrap();
+    let method = String::from_utf8(call_args[1].clone().into_string().unwrap().into_bytes())
+        .map_err(|_| "method is malformed".to_string())?;
+    let epoch = call_args[0].clone().into_uint().unwrap().try_into().unwrap_or(u64::MAX);
+
+    if method.starts_with("evm.") {
+        return Ok(ethabi::encode(&[
+            Token::Uint(1.into()),    // Error status
+            Token::Bytes("core".into()) // Module name
+        ]));
+    }
+ 
+    match method.as_str() {
+        "core.CallDataPublicKey" => {
+            if body != vec![0xf6] {  // Check for CBOR null
+                return Err("invalid body format".into());
+            }
+            
+            let sk_bytes = call_args[3].clone().into_fixed_bytes().unwrap();
+            let sk = PrivateKey::from_bytes(sk_bytes.clone());
+            let sk_arc = Arc::new(sk);
+            
+            let mut secret_bytes = [0u8; 32];
+            secret_bytes.copy_from_slice(&sk_bytes[..32]);
+            let x25519_secret = x25519_dalek::StaticSecret::from(secret_bytes);
+            let x25519_public = x25519_dalek::PublicKey::from(&x25519_secret);
+            
+            let key = x25519::PublicKey::from(x25519_public);
+            let checksum = [1u8; 32].to_vec();
+            let runtime_id = Namespace::from(vec![1u8; 32]);
+            let key_pair_id = KeyPairId::from(vec![1u8; 32]);
+            let signer: Arc<dyn Signer> = sk_arc;
+    
+            let signed_public_key = SignedPublicKey::new(
+                key,
+                checksum,
+                runtime_id,
+                key_pair_id,
+                Some(EpochTime::from(epoch)),
+                &signer,
+            ).map_err(|e| e.to_string())?;
+
+            let response = CallDataPublicKeyQueryResponse {
+                public_key: SignedPublicKey::from(signed_public_key),
+                epoch: epoch,
+            };
+
+            let response_bytes = oasis_cbor::to_vec(response);
+
+            Ok(ethabi::encode(&[
+                Token::Uint(0.into()),    // Success status
+                Token::Bytes(response_bytes),
+            ]))
+        },
+ 
+        "core.CurrentEpoch" => {
+            if body != vec![0xf6] {
+                return Err("invalid body format".into()); 
+            }
+ 
+            Ok(ethabi::encode(&[
+                Token::Uint(0.into()),
+                Token::Bytes(epoch.to_be_bytes().to_vec()),
+            ]))
+        },
+ 
+        _ => {
+            Ok(ethabi::encode(&[
+                Token::Uint(1.into()),        
+                Token::Bytes("unknown".into())
+            ]))
+        }
+    }
+}
+
+fn handle_decode(input: &[u8]) -> Result<Vec<u8>, String> {
+    // Add debug prints for input data
+    // println!("Raw input: {}", hex::encode(input));
+    
+    let call_args = ethabi::decode(
+        &[
+            ParamType::Bytes,     // calldata
+            ParamType::FixedBytes(32),     // private key
+        ],
+        input,
+    ).map_err(|e| e.to_string())?;
+    
+    let data = call_args[0].clone().into_bytes().unwrap();
+    let private_key = call_args[1].clone().into_fixed_bytes().unwrap();
+    
+    // Debug print private key
+    // println!("Private key: {}", hex::encode(&private_key));
+    
+    let private_key: [u8; 32] = private_key.try_into()
+        .map_err(|_| "private key must be 32 bytes".to_string())?;
+    let private = x25519_dalek::StaticSecret::from(private_key);
+    
+    // Decode CBOR data
+    let call: Call = oasis_cbor::from_slice(&data)
+        .map_err(|e| format!("failed to decode call: {}", e))?;
+
+    match call.format {
+        CallFormat::Plain => {
+            // Return encoded success with the plain call
+            Ok(ethabi::encode(&[
+                Token::Uint(0.into()),    // Success status
+                Token::Bytes(data),       // Original data
+            ]))
+        },
+
+        CallFormat::EncryptedX25519DeoxysII => {
+            // Method must be empty for encrypted format
+            if !call.method.is_empty() {
+                return Ok(ethabi::encode(&[
+                    Token::Uint(1.into()),    // Error status
+                    Token::String("non-empty method".into())
+                ]));
+            }
+
+            // Decode the envelope
+            let envelope: CallEnvelopeX25519DeoxysII = oasis_cbor::from_value(call.body)
+                .map_err(|_| "bad call envelope")?;
+
+            let decrypted = deoxysii::box_open(
+                    &envelope.nonce,
+                    envelope.data.clone(),
+                    vec![],
+                    &envelope.pk.0,
+                    &private,
+                )
+                .map_err(|_| "decryption failed")?;
+            
+            let inner_call: Call = oasis_cbor::from_slice(&decrypted)
+                .map_err(|_| "invalid inner data")?;
+            let data = match inner_call.body {
+                oasis_cbor::Value::ByteString(data) => data,
+                _ => return Err("invalid inner data".to_string())
+            };
+            // Return decrypted data
+            Ok(data)
+        }
+    }
+}
+
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: {} <hex-encoded input>", args[0]);
+        process::exit(1);
+    }
+
+    let input_hex = args[1].trim_start_matches("0x");
+    
+    let input = hex::decode(input_hex).unwrap_or_else(|e| {
+        eprintln!("Failed to decode hex input: {}", e);
+        process::exit(1);
+    });
+
+    let binary_name = args[0].clone();
+    let result = match binary_name.split('/').last().unwrap_or(&binary_name) {
+        "random_bytes" => handle_random_bytes(&input),
+        "x25519_derive" => handle_x25519_derive(&input),
+        "curve25519_compute_public" => handle_curve25519_compute_public(&input),
+        "deoxysii_seal" => handle_deoxysii_seal(&input),
+        "deoxysii_open" => handle_deoxysii_open(&input),
+        "keypair_generate" => handle_keypair_generate(&input),
+        "sign" => handle_sign(&input),
+        "verify" => handle_verify(&input),
+        "gas_used" => handle_gas_used(&input),
+        "pad_gas" => handle_pad_gas(&input),
+        "subcall" => handle_subcall(&input),
+        "decode" => handle_decode(&input),
+        _ => Err("Unknown precompile".into()),
+    };
+
+    match result {
+        Ok(output) => {
+            print!("{}", hex::encode(output));
+            process::exit(0);
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            process::exit(1);
+        }
+    }
+}

--- a/integrations/foundry/test/TestPrecompiles.t.sol
+++ b/integrations/foundry/test/TestPrecompiles.t.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
+import "lib/oasisprotocol-sapphire-foundry/BaseSapphireTest.sol";
+
+contract PrecompileTest is SapphireTest {
+    
+    function setUp() public override {
+        super.setUp();
+    }
+    
+
+    function testRandomBytes() public {
+        // Modify input data encoding - separate the length and string parameters
+        bytes memory inputData = abi.encode(
+            uint(32),  // length of random bytes requested
+            bytes("test")  // additional entropy
+        );
+
+        // Direct low-level call
+        (bool success, bytes memory result) = RANDOM_BYTES.call(inputData);
+        bytes memory randomBytes = result;
+        console.log("Hex result: 0x%s", vm.toString(randomBytes));
+        assertTrue(success, "Direct call failed");
+        assertEq(randomBytes.length, 32, "Incorrect result length");
+        
+        // Test second call gives different result
+        (bool success2, bytes memory result2) = RANDOM_BYTES.call(inputData);
+        assertTrue(success2, "Second direct call failed");
+        assertNotEq(keccak256(result2), keccak256(result), "Results should be different");
+
+        (bool success_static, bytes memory result_static) = RANDOM_BYTES.staticcall(inputData);
+        bytes memory randomBytes_static = result_static;
+        console.log("Hex result staticcall: 0x%s", vm.toString(randomBytes_static));
+        assertTrue(success_static, "Direct call failed");
+        assertEq(randomBytes_static.length, 32, "Incorrect result length");
+        assertNotEq(keccak256(result_static), keccak256(result), "Results should be different");
+    }
+
+    function testX25519Derive() public {
+        // Test vectors from Oasis core 
+        bytes32 publicKey = bytes32(hex"3046db3fa70ce605457dc47c48837ebd8bd0a26abfde5994d033e1ced68e2576");
+        bytes32 privateKey = bytes32(hex"c07b151fbc1e7a11dff926111188f8d872f62eba0396da97c0a24adb75161750");
+        bytes memory expectedOutput = hex"e69ac21066a8c2284e8fdc690e579af4513547b9b31dd144792c1904b45cf586";
+
+        bytes memory inputData = abi.encodePacked(publicKey, privateKey);
+
+        // Direct call
+        (bool success, bytes memory result) = X25519_DERIVE.call(inputData);
+        assertTrue(success, "Direct call failed");
+        assertEq(result, expectedOutput, "Incorrect derived key");
+
+        // Static call
+        (bool successStatic, bytes memory resultStatic) = X25519_DERIVE.staticcall(inputData);
+        assertTrue(successStatic, "Static call failed");
+        assertEq(resultStatic, expectedOutput, "Incorrect derived key from static call");
+    }
+
+    function testCurve25519ComputePublic() public {
+        bytes32 privateKey = bytes32(hex"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+        bytes32 expectedPublic = bytes32(hex"8f40c5adb68f25624ae5b214ea767a6ec94d829d3d7b5e1ad1ba6f3e2138285f");
+
+        (bool success, bytes memory result) = CURVE25519_COMPUTE_PUBLIC.call(abi.encodePacked(privateKey));
+        assertTrue(success, "Direct call failed");
+        assertEq(result, abi.encodePacked(expectedPublic), "Incorrect public key");
+
+        (bool successStatic, bytes memory resultStatic) = CURVE25519_COMPUTE_PUBLIC.staticcall(abi.encodePacked(privateKey));
+        assertTrue(successStatic, "Static call failed");
+        assertEq(resultStatic, abi.encodePacked(expectedPublic), "Incorrect public key from static call");
+
+    }
+
+    function testDeoxysiiSealAndOpen() public {
+        bytes32 key = bytes32("this must be the excelentest key");
+        bytes32 nonce = bytes32("complete noncence, and too long.");
+        bytes memory plaintext = bytes("test message");
+        bytes memory ad = bytes("additional data");
+
+        // Test seal
+        (bool success, bytes memory encrypted_data) = DEOXYSII_SEAL.call(abi.encode(key, nonce, plaintext, ad));
+        assertTrue(success, "Seal call failed");
+        assertNotEq(encrypted_data, plaintext, "Sealed should differ from plaintext");
+
+        // Test open
+        (bool successOpen, bytes memory opened) = DEOXYSII_OPEN.call(abi.encode(key, nonce, encrypted_data, ad));
+        assertTrue(successOpen, "Open call failed");
+        
+        // Log results
+        console.log("Encrypted data:", string(encrypted_data));
+        console.log("Opened data:", string(opened));
+        assertEq(opened, plaintext, "Opened should match original plaintext");
+    }
+
+    function testKeypairGenerateAndSign() public {
+        uint256 sigType = 0; // Ed25519_Oasis
+        bytes memory seed = hex"3031323334353637383930313233343536373839303132333435363738393031";
+        bytes memory message = bytes("test message");
+        bytes memory context = bytes("test context");
+
+        // Generate keypair
+        (bool success, bytes memory result) = KEYPAIR_GENERATE.call(abi.encode(sigType, seed));
+        assertTrue(success, "Keypair generation failed");
+
+        (bytes memory publicKey, bytes memory privateKey) = abi.decode(result, (bytes, bytes));        
+
+        // Sign message
+        (bool successSign, bytes memory signResult) = SIGN.call(
+            abi.encode(sigType, privateKey, context, message)
+        );
+        assertTrue(successSign, "Signing failed");
+
+        // Get signature bytes - don't re-encode
+        bytes memory signature = signResult;
+
+        (bool successVerify, bytes memory verifyResult) = VERIFY.call(
+            abi.encode(
+                sigType,          // uint256
+                publicKey,        // bytes - just the raw public key
+                context,          // bytes
+                message,         // bytes 
+                signature        // bytes - just the raw signature
+            )
+        );
+        bool verified = abi.decode(verifyResult, (bool));
+        assertTrue(verified, "Signature verification failed");
+    }
+
+    function testSymmetricKeyGeneration() public {
+        uint256 sigType = 0; // Ed25519_Oasis
+        // Different seeds should generate different key pairs
+        bytes memory seed1 = hex"3031323334353637383930313233343536373839303132333435363738393031";
+        bytes memory seed2 = hex"3031323334353637383930313233343536373839303132333435363738393032";
+        // Generate two key pairs
+        (bool success1, bytes memory result1) = KEYPAIR_GENERATE.call(abi.encode(sigType, seed1));
+        assertTrue(success1, "Keypair generation failed");
+        (bytes memory publicKey1, bytes memory privateKey1) = abi.decode(result1, (bytes, bytes));
+
+        (bool success2, bytes memory result2) = KEYPAIR_GENERATE.call(abi.encode(sigType, seed2));
+        assertTrue(success2, "Keypair generation failed");
+        (bytes memory publicKey2, bytes memory privateKey2) = abi.decode(result2, (bytes, bytes));
+
+        // Derive symmetric keys
+        (bool success3, bytes memory symmetricKey1) = X25519_DERIVE.call(abi.encode(publicKey1, privateKey2));
+        assertTrue(success3, "Derive symmetric key failed");
+
+        (bool success4, bytes memory symmetricKey2) = X25519_DERIVE.call(abi.encode(publicKey2, privateKey1));
+        assertTrue(success4, "Derive symmetric key failed");
+
+        // Assert the symmetric keys are equal
+        assertEq(symmetricKey1, symmetricKey2, "Symmetric keys should be equal");
+    }
+    
+    function testSubcallCoreCallDataPublicKey() public {
+        // Test direct subcall to core.CallDataPublicKey
+        (bool success, bytes memory result) = SUBCALL.call(
+            abi.encode(
+                "core.CallDataPublicKey",
+                hex"f6" // null CBOR input
+            )
+        );
+        assertTrue(success, "Direct subcall failed");
+        console.logBytes(result);
+        // Decode result
+        (uint64 status, bytes memory data) = abi.decode(result, (uint64, bytes));        
+    }
+}

--- a/integrations/foundry/test/TestSapphireContracts.t.sol
+++ b/integrations/foundry/test/TestSapphireContracts.t.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
+import "lib/oasisprotocol-sapphire-foundry/BaseSapphireTest.sol";
+import "lib/oasisprotocol-sapphire-contracts/CalldataEncryption.sol";
+
+
+contract CalldataEncryptionTest is SapphireTest {
+    
+    function setUp() public override {
+        super.setUp(); // Call parent setUp first
+    }
+    
+    /*
+    Test encryption using Sapphire Contracts.  
+    */  
+    function testEncryptCallData() public {
+        bytes memory in_data = bytes("Hello, Sapphire!");
+
+        Sapphire.Curve25519PublicKey myPublic;
+        Sapphire.Curve25519SecretKey mySecret;
+
+        (myPublic, mySecret) = Sapphire.generateCurve25519KeyPair("");
+
+        bytes15 nonce = bytes15(Sapphire.randomBytes(15, ""));
+
+        Subcall.CallDataPublicKey memory cdpk;
+        uint256 epoch;
+
+        (epoch, cdpk) = Subcall.coreCallDataPublicKey();
+        bytes memory result = encryptCallData(
+            in_data,
+            myPublic,
+            mySecret,
+            nonce,
+            epoch,
+            cdpk.key
+        );
+        // DECODE is used for 
+        // testing decryption using hardcoded peer public key.
+        // It is not part of the Sapphire EVM.
+        (bool success, bytes memory decrypted) = DECODE.call(abi.encode(result));
+        assertEq(success, true);
+        assertEq(decrypted, in_data);
+    }
+    
+    /*
+    Fuzz tests for the CalldataEncryption contract.
+    Foundry automatically generates nonces for fuzz tests.
+    */  
+    function testEncryptCallDataFuzz(bytes15 nonce) public {
+        bytes memory in_data = bytes("Hello, Sapphire!");
+
+        Sapphire.Curve25519PublicKey myPublic;
+        Sapphire.Curve25519SecretKey mySecret;
+
+        (myPublic, mySecret) = Sapphire.generateCurve25519KeyPair("");
+
+        Subcall.CallDataPublicKey memory cdpk;
+        uint256 epoch;
+
+        (epoch, cdpk) = Subcall.coreCallDataPublicKey();
+        bytes memory result = encryptCallData(
+            in_data,
+            myPublic,
+            mySecret,
+            nonce,
+            epoch,
+            cdpk.key
+        );
+        // DECODE is used for 
+        // testing decryption using hardcoded peer key.
+        // It is not part of the Sapphire EVM.
+        (bool success, bytes memory decrypted) = DECODE.call(abi.encode(result));
+        assertEq(success, true);
+        assertEq(decrypted, in_data);
+    }
+}


### PR DESCRIPTION
This PR:
- Adds boilerplate Foundry contracts that simulate Sapphire precompiles and decryption
- Implements Foundry tests
- Contains Rust FFI bindings
- Added Makefile with build, test, clean options
- Readme with instructions

Enables local testing of Sapphire-compatible contracts without using forks. 