### PR TITLE
docs: Make Oasis Explorer link clickable

### DIFF
--- a/docs/network.mdx
+++ b/docs/network.mdx
@@ -73,7 +73,7 @@ dedicated RPC endpoints, consider the following providers (in alphabetic order):
 
 | Name (Provider)                               | Mainnet URL                                | Testnet URL                                | EIP-3091 compatible |
 |-----------------------------------------------|--------------------------------------------|--------------------------------------------|---------------------|
-| Oasis Explorer ([Oasis Protocol Foundation])  | `https://explorer.oasis.io/mainnet/sapphire` | `https://explorer.oasis.io/testnet/sapphire` | Yes                 |
+| Oasis Explorer ([Oasis Protocol Foundation])  | https://explorer.oasis.io/mainnet/sapphire | https://explorer.oasis.io/testnet/sapphire | Yes                 |
 | Oasis Scan ([Bit Cat])                        | [https://www.oasisscan.com/paratimes/000…279](https://www.oasisscan.com/paratimes/000000000000000000000000000000000000000000000000f80306c9858e7279) | [https://testnet.oasisscan.com/paratimes/000…f6c](https://testnet.oasisscan.com/paratimes/000000000000000000000000000000000000000000000000a6d1e3ebf60dff6c) | No |
 
 [Bit Cat]: https://www.bitcat365.com/


### PR DESCRIPTION
Making the links to Sapphire Oasis Explorer clickable for a better user experience.