### PR TITLE
docs/develop: Fix npm package link for sapphire-paratime in concept.mdx

### DIFF
--- a/docs/develop/concept.mdx
+++ b/docs/develop/concept.mdx
@@ -32,6 +32,8 @@ signed**, otherwise `msg.sender` will be zeroed. On the other hand, set the
 the user's wallet for calls that do not need to be signed. The JS library will
 do this for you.
 
+[@oasisprotocol/sapphire-paratime]: https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime
+
 :::note
 
 Inside the smart contract code, there is no way of knowing whether the


### PR DESCRIPTION
A small fix for linking the `sapphire-paratime` npm package properly.