### PR TITLE
Enable Snap connections for Wagmi and Viem integrations

### DIFF
--- a/clients/js/src/provider.ts
+++ b/clients/js/src/provider.ts
@@ -140,7 +140,7 @@ interface SnapInfoT {
   blocked: boolean;
 }
 
-const SAPPHIRE_SNAP_PNPM_ID = 'npm:@oasisprotocol/sapphire-snap';
+const SAPPHIRE_SNAP_ID = 'npm:@oasisprotocol/sapphire-snap';
 
 export async function detectSapphireSnap(provider: EIP2696_EthereumProvider) {
   try {
@@ -148,7 +148,7 @@ export async function detectSapphireSnap(provider: EIP2696_EthereumProvider) {
       method: 'wallet_getSnaps',
     })) as Record<string, SnapInfoT>;
     for (const snap of Object.values(installedSnaps)) {
-      if (snap.id === SAPPHIRE_SNAP_PNPM_ID) {
+      if (snap.id === SAPPHIRE_SNAP_ID) {
         return snap.id;
       }
     }
@@ -246,7 +246,7 @@ export function makeSapphireRequestFn(
         provider,
       );
     }
-    
+
     const res = await provider.request({
       method,
       params: params ?? [],

--- a/clients/js/src/provider.ts
+++ b/clients/js/src/provider.ts
@@ -236,11 +236,6 @@ export function makeSapphireRequestFn(
       transactionData = params[0].data = cipher.encryptCall(params[0].data);
     }
 
-    const res = await provider.request({
-      method,
-      params: params ?? [],
-    });
-
     if (snapId !== undefined && transactionData !== undefined) {
       // Run in background so as to not delay results
       notifySapphireSnap(
@@ -251,6 +246,11 @@ export function makeSapphireRequestFn(
         provider,
       );
     }
+    
+    const res = await provider.request({
+      method,
+      params: params ?? [],
+    });
 
     // Decrypt responses which return encrypted data
     if (method === 'eth_call') {

--- a/clients/js/src/provider.ts
+++ b/clients/js/src/provider.ts
@@ -87,7 +87,7 @@ export function isWrappedEthereumProvider<P extends EIP2696_EthereumProvider>(
  */
 export function wrapEthereumProvider<P extends EIP2696_EthereumProvider>(
   upstream: P,
-  options?: SapphireWrapOptions,
+  options?: SapphireWrapConfig,
 ): P {
   if (isWrappedEthereumProvider(upstream)) {
     return upstream;

--- a/integrations/viem-v2/src/index.ts
+++ b/integrations/viem-v2/src/index.ts
@@ -3,6 +3,7 @@
 import {
 	KeyFetcher,
 	NETWORKS as SapphireNETWORKS,
+	type SapphireWrapConfig,
 	wrapEthereumProvider,
 } from "@oasisprotocol/sapphire-paratime";
 
@@ -69,7 +70,9 @@ export type SapphireHttpTransport = Transport<
  *
  * @returns Same as http()
  */
-export function sapphireHttpTransport<T extends Transport>(): T {
+export function sapphireHttpTransport<T extends Transport>(
+	options?: SapphireWrapConfig,
+): T {
 	const cachedProviders: Record<string, unknown> = {};
 	return ((params) => {
 		if (!params.chain) {
@@ -79,7 +82,7 @@ export function sapphireHttpTransport<T extends Transport>(): T {
 		}
 		const url = params.chain.rpcUrls.default.http[0];
 		if (!(url in cachedProviders)) {
-			const x = wrapEthereumProvider(http(url)(params));
+			const x = wrapEthereumProvider(http(url)(params), options);
 			Reflect.set(x, SAPPHIRE_WRAPPED_VIEM_TRANSPORT, true);
 			cachedProviders[url] = x;
 		}

--- a/integrations/wagmi-v2/src/index.ts
+++ b/integrations/wagmi-v2/src/index.ts
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { wrapEthereumProvider } from "@oasisprotocol/sapphire-paratime";
+import {
+	type SapphireWrapConfig,
+	wrapEthereumProvider,
+} from "@oasisprotocol/sapphire-paratime";
 import { type InjectedParameters, injected } from "@wagmi/core";
 import type { EIP1193Provider } from "viem";
 
@@ -29,7 +32,9 @@ const cachedProviders: Map<EIP1193Provider, EIP1193Provider> = new Map();
  *
  * @returns Same as injected()
  */
-export function injectedWithSapphire(): ReturnType<typeof injected> {
+export function injectedWithSapphire(
+	options?: SapphireWrapConfig,
+): ReturnType<typeof injected> {
 	return injected({
 		target: () => {
 			return {
@@ -45,6 +50,7 @@ export function injectedWithSapphire(): ReturnType<typeof injected> {
 								window.ethereum as unknown as Parameters<
 									typeof wrapEthereumProvider
 								>[0],
+								options,
 							) as EIP1193Provider;
 							cachedProviders.set(window.ethereum, wp);
 							return wp;


### PR DESCRIPTION
`wrapEthereumProvider` has params which are not accessible for Wagmi and Viem integrations. To allow Snap connections we need to pass wrap config.