### PR TITLE
Add SolDeer contracts upload to publish.yaml workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -65,3 +65,30 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
           NPM_TAG: ${{ steps.extract-tag.outputs.NPM_TAG }}
         working-directory: ${{ steps.extract-tag.outputs.NPM_PACKAGE }}
+  
+  publish-contracts-soldeer:
+    runs-on: ubuntu-latest
+    needs: publish
+    if: startsWith(github.ref_name, 'contracts/v')
+    steps:
+      - name: Extract version from tag
+        id: extract-tag-version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          echo "CONTRACTS_VERSION=$(echo $REF_NAME | grep -oP '(?<=v)[0-9]+\.[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Install soldeer
+        run: cargo install soldeer
+      - name: Set soldeer access token
+        env:
+          SOLDEER_AUTH_TOKEN: ${{ secrets.SOLDEER_TOKEN }}
+        run: |
+          echo "$SOLDEER_AUTH_TOKEN" > ~/.soldeer/.soldeer_login
+      - name: Publish to Soldeer
+        run: soldeer push @oasisprotocol-sapphire-contracts~$CONTRACTS_VERSION
+        working-directory: contracts/contracts

--- a/contracts/contracts/.soldeerignore
+++ b/contracts/contracts/.soldeerignore
@@ -1,0 +1,2 @@
+tests/.npmignore
+.soldeerignore


### PR DESCRIPTION
This PR adds ([issue](https://github.com/oasisprotocol/sapphire-paratime/issues/496)):

- contracts/contracts folder to SolDeer repository through publish.yaml workflow
- .soldeerignore file for .npmignore

TODO: We have to add the SOLDEER_ACCESS_TOKEN to github secrets.
