### PR TITLE
integrations: Publish `sapphire-hardhat` 2.22.2

### DIFF
--- a/integrations/hardhat/CHANGELOG.md
+++ b/integrations/hardhat/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is inspired by [Keep a Changelog].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 
+## 2.22.2 (2025-02)
+
+Publish stable V2 integration.
+
 ## 2.22.2-next.0 (2024-08)
 
 ### Fixed

--- a/integrations/hardhat/package.json
+++ b/integrations/hardhat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oasisprotocol/sapphire-hardhat",
   "license": "Apache-2.0",
-  "version": "2.22.2-next.1",
+  "version": "2.22.2",
   "description": "A Hardhat plugin for developing on the Sapphire ParaTime.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/hardhat",
   "repository": {


### PR DESCRIPTION
## Description

Close #505.

Note. We are including this set of changes: https://github.com/oasisprotocol/sapphire-paratime/pull/449, https://github.com/oasisprotocol/sapphire-paratime/pull/411, https://github.com/oasisprotocol/sapphire-paratime/pull/431 due to the non-branching publish process. Alternatively, we would cut at this [point](https://github.com/oasisprotocol/sapphire-paratime/releases/tag/integrations%2Fhardhat%2Fv2.22.2-next), and separately but also slightly more confusingly bump `package.json` that way.

## TODO

- [ ] Admin needs to tag post merge with `integrations/hardhat/v2.22.2`