### PR TITLE
clients/js: Bump JS client to 2.1.0

### DIFF
--- a/clients/js/CHANGELOG.md
+++ b/clients/js/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is inspired by [Keep a Changelog].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 
+## 2.1.0 (2025-02)
+
+### Added
+
+- Enabled Snap connection in Sapphire integrations
+
+### Fixed
+
+- Support Brave wallet default
+
 ## 2.0.1 (2024-09)
 
 https://github.com/oasisprotocol/sapphire-paratime/milestone/2?closed=1

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@oasisprotocol/sapphire-paratime",
   "license": "Apache-2.0",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "The Sapphire ParaTime Web3 integration library.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/clients/js",
   "repository": {


### PR DESCRIPTION
## Description

Release JS client.

## TODO

- [ ] tag merged commit with `clients/js/v2.1.0` similar to [clients/js/v2.0.1](https://github.com/oasisprotocol/sapphire-paratime/releases/tag/clients%2Fjs%2Fv2.0.1-next)