### PR TITLE
Fix sapphire_py whl file naming

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -120,7 +120,7 @@ jobs:
       - name: Install sapphirepy .whl file
         run: |
           pip3 install --user -r requirements.txt
-          pip3 install --user dist/sapphire.py-0.3.0-py3-none-any.whl
+          pip3 install --user dist/sapphire_py-0.3.0-py3-none-any.whl
 
       - name: Python client tests
         working-directory: clients/py
@@ -128,4 +128,4 @@ jobs:
           python3 -mpip install --user -r requirements.txt
           python3 -mpip install --user -r requirements.dev.txt
           python3 -munittest discover
-          pytest sapphirepy/tests/
+          python3 -m pytest sapphirepy/tests/


### PR DESCRIPTION
Setuptools was updated in actions/setup-python@v5, which means dot (.) and dash (-) symbols in lib name are automatically changed to underscore ( _ ). This PR fixes it in the ci-test py workflow.