### PR TITLE
contracts/auth/SiweAuth: Change _domain visibility to internal

### DIFF
--- a/contracts/contracts/auth/SiweAuth.sol
+++ b/contracts/contracts/auth/SiweAuth.sol
@@ -49,7 +49,7 @@ struct AuthToken {
  */
 contract SiweAuth is A13e {
     /// Domain which the dApp is associated with
-    string private _domain;
+    string internal _domain;
     /// Encryption key which the authentication tokens are encrypted with
     bytes32 private _authTokenEncKey;
     /// Default authentication token validity, if no expiration-time provided

--- a/contracts/contracts/tests/auth/SiweAuthTests.sol
+++ b/contracts/contracts/tests/auth/SiweAuthTests.sol
@@ -11,6 +11,12 @@ contract SiweAuthTests is SiweAuth {
         _owner = msg.sender;
     }
 
+    function setDomain(string memory inDomain) external {
+        if (msg.sender==_owner) {
+            _domain = inDomain;
+        }
+    }
+
     function testVerySecretMessage(bytes calldata token)
         external
         view

--- a/contracts/test/auth.ts
+++ b/contracts/test/auth.ts
@@ -179,4 +179,13 @@ describe('Auth', function () {
     await siweAuthTests.testRevokeAuthToken(ethers.keccak256(token5));
     await expect(siweAuthTests.testVerySecretMessage(token5)).to.be.reverted;
   });
+
+  it('Should change domain', async function () {
+    const siweAuthTests = await deploy('localhost');
+    expect(await siweAuthTests.domain()).to.be.equal('localhost');
+
+    const tx = await siweAuthTests.setDomain('localhost2', { gasLimit: 50000 });
+    await tx.wait();
+    expect(await siweAuthTests.domain()).to.be.equal('localhost2');
+  });
 });


### PR DESCRIPTION
I stumbled on this when deploying demo-rofl-chatbot contract on Testnet and as a test I set the initial domain to `localhost`. When I wanted to simply change it to `playground.oasis.io`, I realized it can't be done, because `_domain` is `private` in the super contract.

[Preview](https://deploy-preview-529--oasisprotocol-sapphire-paratime.netlify.app/build/sapphire/develop/authentication#siwe-domain)