### PR TITLE
Ignore integrations Foundry docs and add soldeer token folder

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -65,6 +65,10 @@ jobs:
         working-directory: ./integrations
         run: |
           for i in */ ; do
+            if [ "$i" == "foundry/" ]; then
+              continue
+            fi
+
             pushd $i
             pnpm build # Required for typedoc
             if [ "$i" == "hardhat/" ]; then

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -88,7 +88,7 @@ jobs:
         env:
           SOLDEER_AUTH_TOKEN: ${{ secrets.SOLDEER_TOKEN }}
         run: |
-          echo "$SOLDEER_AUTH_TOKEN" > ~/.soldeer/.soldeer_login
+          mkdir -p ~/.soldeer && echo "$SOLDEER_AUTH_TOKEN" > ~/.soldeer/.soldeer_login
       - name: Publish to Soldeer
         run: soldeer push @oasisprotocol-sapphire-contracts~$CONTRACTS_VERSION
         working-directory: contracts/contracts


### PR DESCRIPTION
This PR:
- Adds soldeer token folder in publish.yaml
- Removes integrations/Foundry folder from js-docs loop.