### PR TITLE
Bump web3py to 7.x

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -121,7 +121,7 @@ jobs:
       - name: Install sapphirepy .whl file
         run: |
           pip3 install --user -r requirements.txt
-          pip3 install --user dist/sapphire_py-0.3.0-py3-none-any.whl
+          pip3 install --user dist/*.whl
 
       - name: Python client tests
         working-directory: clients/py

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - clients/js/v[0-9]+.[0-9]+.[0-9]+*
+      - clients/py/v[0-9]+.[0-9]+.[0-9]+*
       - contracts/v[0-9]+.[0-9]+.[0-9]+*
       - integrations/ethers-v6/v[0-9]+.[0-9]+.[0-9]+*
       - integrations/hardhat/v[0-9]+.[0-9]+.[0-9]+*
@@ -92,3 +93,46 @@ jobs:
       - name: Publish to Soldeer
         run: soldeer push @oasisprotocol-sapphire-contracts~$CONTRACTS_VERSION
         working-directory: contracts/contracts
+
+  publish-py:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, 'clients/py/v')
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      
+      - name: Extract version from tag
+        id: extract-tag-version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          echo "SAPPHIREPY_VERSION=$(echo $REF_NAME | grep -oP '(?<=v)[0-9]+\.[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+      
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+          pip install -r requirements.txt
+          pip install -r requirements.dev.txt
+        working-directory: clients/py
+      
+      - name: Update version in setup.py
+        run: |
+          sed -i "s/version=\"[0-9]\+\.[0-9]\+\.[0-9]\+\"/version=\"${{ steps.extract-tag-version.outputs.SAPPHIREPY_VERSION }}\"/" setup.py
+        working-directory: clients/py
+      
+      - name: Build package
+        run: |
+          make build
+        working-directory: clients/py
+      
+      - name: Publish to PyPI
+        env:
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload --username __token__ dist/* --verbose # __token__ username specifies the usage of the API token
+        working-directory: clients/py

--- a/clients/py/README.md
+++ b/clients/py/README.md
@@ -8,18 +8,43 @@ pip3 install --user -r requirements.dev.txt
 make
 ```
 
+## Changelog
+
+https://github.com/oasisprotocol/sapphire-paratime/tree/main/clients/py/CHANGELOG.md
+
 ## Usage
 
 ```python
-from web3 import Web3
+from web3 import Web3, AsyncWeb3
+from web3.middleware import SignAndSendRawMiddlewareBuilder
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+
 from sapphirepy import sapphire
 
-# Setup your Web3 provider with a signing account.
 w3 = Web3(Web3.HTTPProvider(sapphire.NETWORKS['sapphire-localnet']))
-w3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))
+async_w3 = AsyncWeb3(
+    AsyncWeb3.AsyncHTTPProvider(
+        sapphire.NETWORKS['sapphire-localnet']
+    )
+)
+
+# Optional: Setup your Web3 provider with a signing account.
+# This account is used for signing transactions.
+account: LocalAccount = (
+    Account.from_key(  # pylint: disable=no-value-for-parameter
+        private_key="<your_private_key_here>"
+    )
+)
+w3.middleware_onion.add(SignAndSendRawMiddlewareBuilder.build(account))
 
 # Finally, wrap the provider to add Sapphire end-to-end encryption.
-w3 = sapphire.wrap(w3)
+# Note: Account parameter in the wrap() function is used for signing view
+# calls and can be different from the account used for singing transactions.
+w3 = sapphire.wrap(w3, account) # Can provide custom "account" parameter
+# Wrapper middleware also works with AsyncWeb3
+async_w3 = sapphire.wrap(async_w3, account)
+
 # Optionally, query Oasis Web3 Gateway for the gas price.
 # from web3.gas_strategies.rpc import rpc_gas_price_strategy
 # w3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
@@ -28,6 +53,7 @@ w3 = sapphire.wrap(w3)
 The Sapphire middleware for Web3.py ensures all transactions, gas estimates and
 view calls are end-to-end encrypted between your application and the smart
 contract.
+
 
 ## License
 

--- a/clients/py/requirements.txt
+++ b/clients/py/requirements.txt
@@ -1,3 +1,3 @@
 cbor2
 pynacl
-web3==6.*
+web3==7.*

--- a/clients/py/sapphirepy/sapphire.py
+++ b/clients/py/sapphirepy/sapphire.py
@@ -1,20 +1,34 @@
+import asyncio
 from binascii import unhexlify, hexlify
-from typing import (
-    Any,
-    Callable,
-    cast,
-    Optional,
-    TypedDict,
-)
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, cast, Optional, TypedDict, Union
 
+from toolz import (  # type: ignore
+    curry,
+)
 import cbor2
-from web3 import Web3
-from web3.types import RPCEndpoint, RPCResponse, TxParams, Middleware
+from web3 import (  # noqa: F401
+    AsyncWeb3,
+    Web3,
+)
+from web3.datastructures import (
+    AttributeDict
+)
+from web3.types import (  # noqa: F401
+    AsyncMakeRequestFn,
+    MakeRequestFn,
+    RPCEndpoint,
+    RPCResponse
+)
+from web3.middleware.base import (
+    Web3MiddlewareBuilder,
+)
 from eth_typing import HexStr
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
 
 from .envelope import TransactionCipher
+
 
 NETWORKS = {
     "sapphire": "https://sapphire.oasis.io",
@@ -49,9 +63,10 @@ class CalldataPublicKeyManager:
         self._keys = []
 
     def _trim_and_sort(self, newest_epoch: int):
-        self._keys = sorted([v for v in self._keys
-                             if v['epoch'] >= newest_epoch - EPOCH_LIMIT],
-                            key=lambda o: o['epoch'])[-EPOCH_LIMIT:]
+        self._keys = sorted(
+            [v for v in self._keys if v["epoch"] >= newest_epoch - EPOCH_LIMIT],
+            key=lambda o: o["epoch"],
+        )[-EPOCH_LIMIT:]
 
     @property
     def newest(self):
@@ -61,64 +76,65 @@ class CalldataPublicKeyManager:
 
     def add(self, pk: CalldataPublicKey):
         if self._keys:
-            if self.newest['epoch'] < pk['epoch']:
+            if self.newest["epoch"] < pk["epoch"]:
                 self._keys.append(pk)
-            self._trim_and_sort(pk['epoch'])
+            self._trim_and_sort(pk["epoch"])
         else:
             self._keys.append(pk)
 
 
-def _should_intercept(method: RPCEndpoint, params: tuple[TxParams]):
+def _should_intercept(method: RPCEndpoint, params: Any):
     if not ENCRYPT_DEPLOYS:
-        if method in ('eth_sendTransaction', 'eth_estimateGas'):
+        if method in ("eth_sendTransaction", "eth_estimateGas"):
             # When 'to' flag is missing, we assume it's a deployment
-            if not params[0].get('to', None):
+            if not params[0].get("to", None):
                 return False
-    return method in ('eth_estimateGas', 'eth_sendTransaction', 'eth_call')
+    return method in ("eth_estimateGas", "eth_sendTransaction", "eth_call")
 
 
-def _encrypt_tx_params(pk: CalldataPublicKey,
-                       params: tuple[TxParams],
-                       method,
-                       web3: Web3,
-                       account: Optional[LocalAccount]=None) -> TransactionCipher:
-    c = TransactionCipher(peer_pubkey=pk['key'], peer_epoch=pk['epoch'])
-    data = params[0]['data']
+def _encrypt_tx_params(
+    pk: CalldataPublicKey,
+    params: Any,
+    account: Optional[LocalAccount] = None,
+    signed_call_data: Optional[AttributeDict] = None,
+) -> TransactionCipher:
+    c = TransactionCipher(peer_pubkey=pk["key"], peer_epoch=pk["epoch"])
+    data = params[0]["data"]
     if isinstance(data, bytes):
         data_bytes = data
     elif isinstance(data, str):
-        if len(data) < 2 or data[:2] != '0x':
-            raise ValueError('Data is not hex encoded!', data)
+        if len(data) < 2 or data[:2] != "0x":
+            raise ValueError("Data is not hex encoded!", data)
         data_bytes = unhexlify(data[2:])
     else:
         raise TypeError("Invalid 'data' type", type(data))
     encrypted_data = c.encrypt(data_bytes)
 
-    if method == 'eth_call' and params[0]['from'] and account:
-        data_pack = _new_signed_call_data_pack(c.make_envelope(data_bytes),
-                                               data_bytes,
-                                               params,
-                                               web3,
-                                               account)
-        params[0]['data'] = cbor2.dumps(data_pack, canonical=True)
+    if signed_call_data and account:
+        data_pack = _new_signed_call_data_pack(
+            c.make_envelope(data_bytes), data_bytes, params, account, signed_call_data
+        )
+        params[0]["data"] = cbor2.dumps(data_pack, canonical=True)
     else:
-        params[0]['data'] = HexStr('0x' + hexlify(encrypted_data).decode('ascii'))
+        params[0]["data"] = HexStr("0x" + hexlify(encrypted_data).decode("ascii"))
     return c
 
 
-def _new_signed_call_data_pack(encrypted_data: dict,
-                               data_bytes: bytes,
-                               params: tuple[TxParams],
-                               web3: Web3,
-                               account: LocalAccount) -> dict:
+def _new_signed_call_data_pack(
+    encrypted_data: dict,
+    data_bytes: bytes,
+    params: Any,
+    account: LocalAccount,
+    signed_call_data: AttributeDict,
+) -> dict:
     # Update params with default values, these get used outside the scope of this function
-    params[0]['gas'] = params[0].get('gas', DEFAULT_GAS_LIMIT)
-    params[0]['gasPrice'] = params[0].get('gasPrice', web3.to_wei(DEFAULT_GAS_PRICE, 'wei'))
+    params[0]["gas"] = int(params[0].get("gas", DEFAULT_GAS_LIMIT))
+    params[0]["gasPrice"] = signed_call_data.get("gas_price")
 
     domain_data = {
         "name": "oasis-runtime-sdk/evm: signed query",
         "version": "1.0.0",
-        "chainId": web3.eth.chain_id,
+        "chainId": signed_call_data.get("chain_id"),
         # "verifyingContract": "",
         # "salt": "",
     }
@@ -144,23 +160,26 @@ def _new_signed_call_data_pack(encrypted_data: dict,
             {"name": "blockRange", "type": "uint64"},
         ],
     }
-    nonce = web3.eth.get_transaction_count(web3.to_checksum_address(params[0]['from']))
-    block_number = web3.eth.block_number
-    block_hash = web3.eth.get_block(block_number-1)['hash'].hex()
+    nonce = signed_call_data.get("nonce")
+    block_number = signed_call_data.get("block_number")
+
+    block_hash = signed_call_data.get("block_hash")
+    if block_hash and block_hash.startswith("0x"):
+        block_hash = block_hash[2:]
+
     msg_data = {
-        "from": params[0].get('from'),
-        "to": params[0].get('to'),
-        "value": params[0].get('value', 0),
-        "gasLimit": params[0].get('gas', DEFAULT_GAS_LIMIT),
-        "gasPrice": params[0].get('gasPrice', DEFAULT_GAS_PRICE),
+        "from": params[0].get("from"),
+        "to": params[0].get("to"),
+        "value": params[0].get("value", 0),
+        "gasLimit": params[0].get("gas", DEFAULT_GAS_LIMIT),
+        "gasPrice": params[0].get("gasPrice", DEFAULT_GAS_PRICE),
         "data": data_bytes,
-        "leash":
-            {
-                "nonce": nonce,
-                "blockNumber": block_number - 1,
-                "blockHash": unhexlify(block_hash[2:]),
-                "blockRange": DEFAULT_BLOCK_RANGE,
-            }
+        "leash": {
+            "nonce": nonce,
+            "blockNumber": cast(int, block_number) - 1,
+            "blockHash": unhexlify(cast(HexStr, block_hash)),
+            "blockRange": DEFAULT_BLOCK_RANGE,
+        },
     }
 
     full_message = {
@@ -175,32 +194,46 @@ def _new_signed_call_data_pack(encrypted_data: dict,
 
     leash = {
         "nonce": nonce,
-        "block_number": block_number - 1,
-        "block_hash": unhexlify(block_hash[2:]),
+        "block_number": cast(int, block_number) - 1,
+        "block_hash": unhexlify(cast(HexStr, block_hash)),
         "block_range": DEFAULT_BLOCK_RANGE,
     }
 
-    data_pack= {
-        'data': encrypted_data,
-        'leash': leash,
-        'signature': bytes(signed_msg['signature']),
+    data_pack = {
+        "data": encrypted_data,
+        "leash": leash,
+        "signature": bytes(signed_msg["signature"]),
     }
+    params[0]["gas"] = hex(params[0]["gas"])
+    params[0]["gasPrice"] = hex(params[0]["gasPrice"])
     return data_pack
 
 
-def construct_sapphire_middleware(
-        account: Optional[LocalAccount] = None
-) -> Middleware:
+class ConstructSapphireMiddlewareBuilder(Web3MiddlewareBuilder):
     """
     Construct a Sapphire middleware for Web3.py.
     :param account: Used to encrypt signed queries.
     :return: A Sapphire middleware function.
     """
 
-    def sapphire_middleware(
-            make_request: Callable[[RPCEndpoint, Any], Any], w3: "Web3"
-    ) -> Callable[[RPCEndpoint, Any], RPCResponse]:
+    sapphire_account = None
+
+    @staticmethod
+    @curry
+    def build(
+        account: LocalAccount,
+        w3: Union[Web3, AsyncWeb3],
+    ) -> "ConstructSapphireMiddlewareBuilder":
+        # pylint: disable=no-value-for-parameter,arguments-differ
+        middleware = ConstructSapphireMiddlewareBuilder(w3)
+        middleware.sapphire_account = account
+        return middleware
+
+    def wrap_make_request(self, make_request: MakeRequestFn) -> MakeRequestFn:
         """
+        Synchronous wrapper around async_wrap_make_request.
+        Creates a new event loop to run the async middleware.
+        
         Transparently encrypt the calldata for:
 
          - eth_estimateGas
@@ -218,60 +251,137 @@ def construct_sapphire_middleware(
 
         Pre-signed transactions can't be encrypted if submitted via this instance.
         """
-        manager = CalldataPublicKeyManager()
+
+        # Create an async version of the make_request function
+        async def async_make_request(method: RPCEndpoint, params: Any) -> RPCResponse:
+            return make_request(method, params)
+
+        async def main(method, params):
+            async_middleware = await self.async_wrap_make_request(async_make_request)
+            return await async_middleware(method, params)
 
         def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
+            try:
+                asyncio.get_running_loop()  # Triggers RuntimeError if no running event loop
+                # Create a separate thread so we can block before returning
+                with ThreadPoolExecutor(1) as pool:
+                    result = pool.submit(lambda: asyncio.run(main(method, params))).result()
+            except RuntimeError:
+                result = asyncio.run(main(method, params))
+            return result
+            # return loop.run_until_complete(main(method, params))
+
+        return middleware
+
+    async def async_wrap_make_request(
+        self, make_request: AsyncMakeRequestFn
+    ) -> AsyncMakeRequestFn:
+        """
+        Async version of wrap_make_request that handles the same encryption logic
+        for eth_estimateGas, eth_sendTransaction, and eth_call
+        """
+        manager = CalldataPublicKeyManager()
+
+        async def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
             if _should_intercept(method, params):
                 do_fetch = True
                 pk = manager.newest
                 while do_fetch:
                     if not pk:
                         # If no calldata public key exists, fetch one
-                        cdpk = cast(RPCResponse, make_request(RPCEndpoint('oasis_callDataPublicKey'), []))
-                        pk = cast(Optional[CalldataPublicKey], cdpk.get('result', None))
+                        cdpk = cast(
+                            RPCResponse,
+                            await make_request(
+                                RPCEndpoint("oasis_callDataPublicKey"), []
+                            ),
+                        )
+                        pk = cast(Optional[CalldataPublicKey], cdpk.get("result", None))
                         if pk:
                             manager.add(pk)
                     if not pk:
-                        raise RuntimeError('Could not retrieve callDataPublicKey!')
+                        raise RuntimeError("Could not retrieve callDataPublicKey!")
                     do_fetch = False
 
-                    c = _encrypt_tx_params(pk, params, method, w3, account)
+                    if method == "eth_call" and params[0]["from"] and self.sapphire_account:
+                        # Get block number - use inline if to handle async vs sync
+                        block_number = (
+                            await self._w3.eth.block_number
+                            if isinstance(self._w3, AsyncWeb3)
+                            else self._w3.eth.block_number
+                        )
+                        # Get chain ID - inline if
+                        chain_id = (
+                            await self._w3.eth.chain_id
+                            if isinstance(self._w3, AsyncWeb3)
+                            else self._w3.eth.chain_id
+                        )
+                        # Get transaction count - inline if
+                        nonce = (
+                            await self._w3.eth.get_transaction_count(
+                                self._w3.to_checksum_address(params[0]["from"])
+                            )
+                            if isinstance(self._w3, AsyncWeb3)
+                            else self._w3.eth.get_transaction_count(
+                                self._w3.to_checksum_address(params[0]["from"])
+                            )
+                        )
+                        # Get block and extract hash - inline if
+                        block_hash = (
+                            (await self._w3.eth.get_block(block_number - 1))["hash"].hex()
+                            if isinstance(self._w3, AsyncWeb3)
+                            else self._w3.eth.get_block(block_number - 1)["hash"].hex()
+                        )
+                        signed_call_data = AttributeDict({
+                            "chain_id": chain_id,
+                            "nonce": nonce,
+                            "block_number": block_number,
+                            "block_hash": block_hash,
+                            "gas_price": self._w3.to_wei(
+                                params[0].get("gasPrice", DEFAULT_GAS_PRICE), "wei"
+                            ),
+                        })
+                        c = _encrypt_tx_params(pk, params, self.sapphire_account, signed_call_data)
+                    else:
+                        c = _encrypt_tx_params(pk, params, self.sapphire_account)
 
                     # We may encounter three errors here:
                     #  'core: invalid call format: epoch too far in the past'
                     #  'core: invalid call format: Tag verification failed'
                     #  'core: invalid call format: epoch in the future'
                     # We can only do something meaningful with the first!
-                    result = cast(RPCResponse, make_request(method, params))
-                    if result.get('error', None) is not None:
-                        error = result['error']
-                        if not isinstance(error, str) and error['code'] == -32000:
-                            if error['message'] == 'core: invalid call format: epoch too far in the past':
+                    result = cast(RPCResponse, await make_request(method, params))
+                    if result.get("error", None) is not None:
+                        error = result["error"]
+                        if not isinstance(error, str) and error["code"] == -32000:
+                            if (
+                                error["message"]
+                                == "core: invalid call format: epoch too far in the past"
+                            ):
                                 # force the re-fetch, and encrypt with new key
                                 do_fetch = True
                                 pk = None
                                 continue
 
                 # Only eth_call is decrypted
-                if method == 'eth_call' and result.get('result', '0x') != '0x':
-                    decrypted = c.decrypt(unhexlify(result['result'][2:]))
-                    result['result'] = HexStr('0x' + hexlify(decrypted).decode('ascii'))
+                if method == "eth_call" and result.get("result", "0x") != "0x":
+                    decrypted = c.decrypt(unhexlify(result["result"][2:]))
+                    result["result"] = HexStr("0x" + hexlify(decrypted).decode("ascii"))
 
                 return result
-            return make_request(method, params)
+            return await make_request(method, params)
 
         return middleware
 
-    return sapphire_middleware
 
-
-def wrap(w3: Web3, account: Optional[LocalAccount] = None):
+def wrap(w3: Union[Web3, AsyncWeb3], account: Optional[LocalAccount] = None):
     """
     Adds the Sapphire transaction encryption middleware to a Web3.py provider.
 
     Note: the provider must be wrapped *after* any signing middleware has been
           added, otherwise pre-signed transactions will not be encrypted.
     """
-    if 'sapphire' not in w3.middleware_onion:
-        w3.middleware_onion.add(construct_sapphire_middleware(account), "sapphire")
+    if "sapphire" not in w3.middleware_onion:
+        w3.middleware_onion.add(
+            ConstructSapphireMiddlewareBuilder.build(account), "sapphire"  # pylint: disable=no-value-for-parameter
+        )
     return w3

--- a/clients/py/sapphirepy/tests/test_async_e2e.py
+++ b/clients/py/sapphirepy/tests/test_async_e2e.py
@@ -1,0 +1,253 @@
+import unittest
+import asyncio
+import time
+from typing import Type, Union
+
+from web3 import Web3, AsyncWeb3
+from web3.exceptions import ContractLogicError, ContractCustomError
+from web3.contract.contract import Contract
+from web3.middleware import SignAndSendRawMiddlewareBuilder
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+from eth_utils import function_signature_to_4byte_selector
+
+from sapphirepy import sapphire
+
+from .test_e2e import compiled_test_contract
+
+
+class AsyncTestEndToEnd(unittest.IsolatedAsyncioTestCase):
+    """Async tests for Sapphire middleware with AsyncWeb3."""
+
+    contract: Union[Contract, Type[Contract]]
+    w3: AsyncWeb3
+
+    # Also store sync instances for performance comparison
+    sync_greeter: Union[Contract, Type[Contract]]
+    sync_w3: Web3
+
+    async def asyncSetUp(self):
+        """Set up both async and sync Web3 instances for testing."""
+        # Use the same key for both instances
+        account: LocalAccount = (
+            Account.from_key(  # pylint: disable=no-value-for-parameter
+                private_key="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+            )
+        )
+
+        # Set up async Web3
+        w3_async = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider("http://localhost:8545"))
+        w3_async.middleware_onion.add(
+            SignAndSendRawMiddlewareBuilder.build(account)  # pylint: disable=no-value-for-parameter
+        )
+        self.w3_async_no_signer = AsyncWeb3(
+            AsyncWeb3.AsyncHTTPProvider("http://localhost:8545")
+        )
+        self.w3_async = sapphire.wrap(w3_async, account)
+        self.w3_async.eth.default_account = account.address
+
+        # Deploy the contract using async Web3
+        iface = compiled_test_contract()
+        contract = self.w3_async.eth.contract(abi=iface["abi"], bytecode=iface["bin"])
+        tx_hash = await contract.constructor().transact(
+            {"gasPrice": await self.w3_async.eth.gas_price}
+        )
+        tx_receipt = await self.w3_async.eth.wait_for_transaction_receipt(tx_hash)
+        contract_address = tx_receipt["contractAddress"]
+
+        # Create contract instances for both async and sync Web3
+        self.async_greeter = self.w3_async.eth.contract(
+            address=contract_address, abi=iface["abi"]
+        )
+        self.async_greeter_no_signer = self.w3_async_no_signer.eth.contract(
+            address=contract_address, abi=iface["abi"]
+        )
+
+    async def asyncTearDown(self):
+        """Clean up async resources."""
+        if hasattr(self, "w3_async"):
+            await self.w3_async.provider.disconnect()
+        if hasattr(self, "w3_async_no_signer"):
+            await self.w3_async_no_signer.provider.disconnect()
+
+    # Async versions of the tests in test_e2e.py
+    async def test_viewcall_revert_custom(self):
+        with self.assertRaises(ContractCustomError) as cm:
+            await self.async_greeter.functions.revertWithCustomError().call()
+
+        error_signature = "MyCustomError(string)"
+        selector = function_signature_to_4byte_selector(error_signature)
+        error_data = self.w3_async.codec.encode(["string"], ["thisIsCustom"])
+        data = selector + error_data
+
+        self.assertEqual(cm.exception.args[0], "0x" + data.hex())
+
+    async def test_viewcall_revert_reason(self):
+        with self.assertRaises(ContractLogicError) as cm:
+            await self.async_greeter.functions.revertWithReason().call()
+        self.assertEqual(cm.exception.message, "execution reverted: reasonGoesHere")
+
+    async def test_viewcall(self):
+        result = await self.async_greeter.functions.greet().call()
+        self.assertEqual(result, "Hello")
+
+    async def test_viewcall_only_owner(self):
+        result = await self.async_greeter.functions.greetOnlyOwner().call()
+        self.assertEqual(result, "Hello")
+
+    async def test_viewcall_only_owner_no_signer(self):
+        with self.assertRaises(ContractLogicError) as cm:
+            await self.async_greeter_no_signer.functions.greetOnlyOwner().call()
+        self.assertEqual(
+            cm.exception.message,
+            "execution reverted: Only owner can call this function",
+        )
+
+    async def test_transaction(self):
+        x = await self.async_greeter.functions.blah().transact(
+            {"gasPrice": await self.w3_async.eth.gas_price}
+        )
+        y = await self.w3_async.eth.wait_for_transaction_receipt(x)
+        z = self.async_greeter.events.Greeting().process_receipt(y)
+        self.assertEqual(z[0].args["g"], "Hello")
+
+
+class TestPerformanceComparison(unittest.IsolatedAsyncioTestCase):
+    """Performance comparison between sync and async Web3."""
+
+    async def asyncSetUp(self):
+        # Set up accounts
+        self.account = Account.from_key(  # pylint: disable=no-value-for-parameter
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+        )
+
+        # Set up providers
+        self.sync_w3 = Web3(Web3.HTTPProvider("http://localhost:8545"))
+        self.sync_w3.middleware_onion.add(
+            SignAndSendRawMiddlewareBuilder.build(self.account)  # pylint: disable=no-value-for-parameter
+        )
+        self.sync_w3 = sapphire.wrap(self.sync_w3, self.account)
+        self.sync_w3.eth.default_account = self.account.address
+
+        self.async_w3 = AsyncWeb3(
+            AsyncWeb3.AsyncHTTPProvider("http://localhost:8545")
+        )
+        # self.async_w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider('https://testnet.sapphire.oasis.io'))
+        self.async_w3.middleware_onion.add(
+            SignAndSendRawMiddlewareBuilder.build(self.account)  # pylint: disable=no-value-for-parameter
+        )
+        self.async_w3 = sapphire.wrap(self.async_w3, self.account)
+        self.async_w3.eth.default_account = self.account.address
+
+        # Deploy contract for contract call tests
+        iface = compiled_test_contract()
+        contract = self.async_w3.eth.contract(abi=iface["abi"], bytecode=iface["bin"])
+        tx_hash = await contract.constructor().transact(
+            {"gasPrice": await self.async_w3.eth.gas_price}
+        )
+        tx_receipt = await self.async_w3.eth.wait_for_transaction_receipt(tx_hash)
+        contract_address = tx_receipt["contractAddress"]
+
+        self.sync_contract = self.sync_w3.eth.contract(
+            address=contract_address, abi=iface["abi"]
+        )
+        self.async_contract = self.async_w3.eth.contract(
+            address=contract_address, abi=iface["abi"]
+        )
+
+    async def asyncTearDown(self):
+        """Clean up async resources."""
+        if hasattr(self, "async_w3"):
+            await self.async_w3.provider.disconnect()
+
+    async def test_performance(self):
+        """Compare performance between sync and async operations."""
+        batch_sizes = [1, 2, 5]
+
+        print("\nPerformance Comparison: Sync vs Async Web3")
+        print("------------------------------------------")
+
+        for batch_size in batch_sizes:
+            # RPC call performance (block number)
+            sync_time = await self._measure_sync_batch(batch_size)
+            async_time = await self._measure_async_batch(batch_size)
+
+            speedup = sync_time / async_time if async_time > 0 else float("inf")
+
+            print(f"\nBatch Size: {batch_size} requests")
+            print(f"  Sync RPC Time:  {sync_time:.4f} seconds")
+            print(f"  Async RPC Time: {async_time:.4f} seconds")
+            print(f"  Speedup:        {speedup:.2f}x")
+
+            # For larger batches, async should be noticeably faster
+            # if batch_size >= 10:
+            #     self.assertGreater(speedup, 1.0,
+            #                       f"Expected async to be faster for batch size {batch_size}")
+
+        # Contract call performance
+        await self._compare_contract_calls()
+        await self.async_w3.provider.disconnect()
+
+    async def _measure_sync_batch(self, num_requests: int) -> float:
+        """Measure time to execute a batch of sync block number requests."""
+        start_time = time.time()
+
+        for _ in range(num_requests):
+            self.sync_contract.functions.greet().call()
+            time.sleep(0.1)
+
+        end_time = time.time()
+        return end_time - start_time
+
+    async def _measure_async_batch(self, num_requests: int) -> float:
+        """Measure time to execute a batch of async block number requests concurrently."""
+        start_time = time.time()
+
+        tasks = []
+        for _ in range(num_requests):
+            tasks.append(
+                asyncio.gather(
+                    self.async_contract.functions.greet().call(), asyncio.sleep(0.1)
+                )
+            )
+
+        await asyncio.gather(*tasks)
+
+        end_time = time.time()
+        return end_time - start_time
+
+    async def _compare_contract_calls(self):
+        """Compare contract call performance between sync and async."""
+        print("\nContract Call Performance:")
+
+        # Measure sync contract calls
+        start_time = time.time()
+        for _ in range(100):
+            self.sync_contract.functions.greet().call()
+            time.sleep(0.1)
+        sync_time = time.time() - start_time
+
+        # Measure async contract calls
+        start_time = time.time()
+        tasks = []
+        for _ in range(100):
+            # tasks.append(self.async_contract.functions.greet().call())
+            tasks.append(
+                asyncio.gather(
+                    self.async_contract.functions.greet().call(), asyncio.sleep(0.1)
+                )
+            )
+        await asyncio.gather(*tasks)
+        async_time = time.time() - start_time
+
+        speedup = sync_time / async_time if async_time > 0 else float("inf")
+
+        print(f"  Sync Contract Calls:  {sync_time:.4f} seconds")
+        print(f"  Async Contract Calls: {async_time:.4f} seconds")
+        print(f"  Speedup:              {speedup:.2f}x")
+
+        self.assertGreater(speedup, 1.0, "Expected async contract calls to be faster")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/py/sapphirepy/tests/test_e2e.py
+++ b/clients/py/sapphirepy/tests/test_e2e.py
@@ -6,102 +6,115 @@ from typing import Type, Union
 from web3 import Web3
 from web3.exceptions import ContractLogicError, ContractCustomError
 from web3.contract.contract import Contract
-from web3.middleware import construct_sign_and_send_raw_middleware
+from web3.middleware import SignAndSendRawMiddlewareBuilder
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
+from eth_utils import function_signature_to_4byte_selector
 
 from sapphirepy import sapphire
 
-TESTDATA = os.path.join(os.path.dirname(__file__), 'testdata')
-GREETER_ABI = os.path.join(TESTDATA, 'Greeter.abi')
-GREETER_BIN = os.path.join(TESTDATA, 'Greeter.bin')
-GREETER_SOL = os.path.join(TESTDATA, 'Greeter.sol')
+TESTDATA = os.path.join(os.path.dirname(__file__), "testdata")
+GREETER_ABI = os.path.join(TESTDATA, "Greeter.abi")
+GREETER_BIN = os.path.join(TESTDATA, "Greeter.bin")
+GREETER_SOL = os.path.join(TESTDATA, "Greeter.sol")
+
 
 def compiled_test_contract():
     if not os.path.exists(GREETER_ABI):
         # pylint: disable=import-outside-toplevel
-        import solcx   # type: ignore
+        import solcx  # type: ignore
 
-        with open(GREETER_SOL, 'r', encoding='utf-8') as handle:
-            solcx.install_solc(version='0.8.9')
-            solcx.set_solc_version('0.8.9')
+        with open(GREETER_SOL, "r", encoding="utf-8") as handle:
+            solcx.install_solc(version="0.8.9")
+            solcx.set_solc_version("0.8.9")
             compiled_sol = solcx.compile_source(
-                handle.read(),
-                output_values=['abi', 'bin']
+                handle.read(), output_values=["abi", "bin"]
             )
             _, contract_interface = compiled_sol.popitem()
-        with open(GREETER_ABI, 'w', encoding='utf-8') as handle:
-            json.dump(contract_interface['abi'], handle)
-        with open(GREETER_BIN, 'w', encoding='utf-8') as handle:
-            json.dump(contract_interface['bin'], handle)
+        with open(GREETER_ABI, "w", encoding="utf-8") as handle:
+            json.dump(contract_interface["abi"], handle)
+        with open(GREETER_BIN, "w", encoding="utf-8") as handle:
+            json.dump(contract_interface["bin"], handle)
         return {
-            'abi': contract_interface['abi'],
-            'bin': contract_interface['bin'],
+            "abi": contract_interface["abi"],
+            "bin": contract_interface["bin"],
         }
-    with open(GREETER_ABI, 'rb') as abi_handle:
-        with open(GREETER_BIN, 'rb') as bin_handle:
-            return {
-                'abi': json.load(abi_handle),
-                'bin': json.load(bin_handle)
-            }
+    with open(GREETER_ABI, "rb") as abi_handle:
+        with open(GREETER_BIN, "rb") as bin_handle:
+            return {"abi": json.load(abi_handle), "bin": json.load(bin_handle)}
+
 
 class TestEndToEnd(unittest.TestCase):
-    greeter:Union[Contract,Type[Contract]]
+    greeter: Union[Contract, Type[Contract]]
     w3: Web3
 
     def setUp(self):
-        account: LocalAccount = Account.from_key("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")  # pylint: disable=no-value-for-parameter
+        account: LocalAccount = Account.from_key(  # pylint: disable=no-value-for-parameter
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+        )
 
-
-        w3 = Web3(Web3.HTTPProvider('http://localhost:8545'))
+        w3 = Web3(Web3.HTTPProvider("http://localhost:8545"))
         # w3 = Web3(Web3.HTTPProvider('https://testnet.sapphire.oasis.io'))
-        w3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))
-        self.w3_no_signer = Web3(Web3.HTTPProvider('http://localhost:8545'))
-        self.w3 = w3 = sapphire.wrap(w3, account)
+        w3.middleware_onion.add(
+            SignAndSendRawMiddlewareBuilder.build(account)  # pylint: disable=no-value-for-parameter
+        )
+        self.w3_no_signer = Web3(Web3.HTTPProvider("http://localhost:8545"))
+        self.w3 = sapphire.wrap(w3, account)
 
-        w3.eth.default_account = account.address
+        self.w3.eth.default_account = account.address
 
         iface = compiled_test_contract()
 
-        contract = w3.eth.contract(abi=iface['abi'], bytecode=iface['bin'], )
-        tx_hash = contract.constructor().transact({'gasPrice': w3.eth.gas_price})
-        tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+        contract = self.w3.eth.contract(abi=iface["abi"], bytecode=iface["bin"])
+        tx_hash = contract.constructor().transact({"gasPrice": self.w3.eth.gas_price})
+        tx_receipt = self.w3.eth.wait_for_transaction_receipt(tx_hash)
 
-        self.greeter = w3.eth.contract(address=tx_receipt['contractAddress'], abi=iface['abi'])
-        self.greeter_no_signer = self.w3_no_signer.eth.contract(address=tx_receipt['contractAddress'], abi=iface['abi'])
+        self.greeter = self.w3.eth.contract(
+            address=tx_receipt["contractAddress"], abi=iface["abi"]
+        )
+        self.greeter_no_signer = self.w3_no_signer.eth.contract(
+            address=tx_receipt["contractAddress"], abi=iface["abi"]
+        )
 
     def test_viewcall_revert_custom(self):
         with self.assertRaises(ContractCustomError) as cm:
             self.greeter.functions.revertWithCustomError().call()
-        data = self.greeter.encode_abi(
-            fn_name="MyCustomError", args=["thisIsCustom"]
-        )
-        self.assertEqual(cm.exception.args[0], data)
+
+        error_signature = "MyCustomError(string)"
+        selector = function_signature_to_4byte_selector(error_signature)
+        error_data = self.w3.codec.encode(["string"], ["thisIsCustom"])
+        data = selector + error_data
+
+        self.assertEqual(cm.exception.args[0], f"0x{data.hex()}")
 
     def test_viewcall_revert_reason(self):
         with self.assertRaises(ContractLogicError) as cm:
             self.greeter.functions.revertWithReason().call()
-        self.assertEqual(cm.exception.message, 'execution reverted: reasonGoesHere')
+        self.assertEqual(cm.exception.message, "execution reverted: reasonGoesHere")
 
     def test_viewcall(self):
-        self.assertEqual(self.greeter.functions.greet().call(), 'Hello')
+        self.assertEqual(self.greeter.functions.greet().call(), "Hello")
 
     def test_viewcall_only_owner(self):
-        self.assertEqual(self.greeter.functions.greetOnlyOwner().call(), 'Hello')
+        self.assertEqual(self.greeter.functions.greetOnlyOwner().call(), "Hello")
 
     def test_viewcall_only_owner_no_signer(self):
         with self.assertRaises(ContractLogicError) as cm:
             self.greeter_no_signer.functions.greetOnlyOwner().call()
-        self.assertEqual(cm.exception.message, 'execution reverted: Only owner can call this function')
+        self.assertEqual(
+            cm.exception.message,
+            "execution reverted: Only owner can call this function",
+        )
 
     def test_transaction(self):
         w3 = self.w3
         greeter = self.greeter
 
-        x = self.greeter.functions.blah().transact({'gasPrice': w3.eth.gas_price})
+        x = self.greeter.functions.blah().transact({"gasPrice": w3.eth.gas_price})
         y = w3.eth.wait_for_transaction_receipt(x)
         z = greeter.events.Greeting().process_receipt(y)
-        self.assertEqual(z[0].args['g'], 'Hello')
+        self.assertEqual(z[0].args["g"], "Hello")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR updates web3.py version in sapphirepy from 6.x to 7.x.
Changes:
- sapphire.py Now uses 7.x class based middleware with changes to block_hash parsing (new hexbytes version).
- test_e2e.py updated

TODO:

- [x]  Add AsyncWeb3 middleware

In addition, this PR also updates the publish.yaml workflow with PyPI tag release.