### PR TITLE
feat: Add statement and resources for SIWE authentication

### DIFF
--- a/contracts/contracts/tests/auth/SiweAuthTests.sol
+++ b/contracts/contracts/tests/auth/SiweAuthTests.sol
@@ -48,6 +48,70 @@ contract SiweAuthTests is SiweAuth {
         return revokeAuthToken(token);
     }
 
+    /**
+     * @notice Test function to retrieve the statement from a token
+     * @param token The authentication token to extract the statement from
+     * @return The statement string from the SIWE message
+     */
+    function testGetStatement(bytes calldata token) 
+        external 
+        view 
+        returns (string memory) 
+    {
+        return getStatement(token);
+    }
+    
+    /**
+     * @notice Test function to retrieve all resources from a token
+     * @param token The authentication token to extract resources from
+     * @return Array of resource URIs the token grants access to
+     */
+    function testGetResources(bytes calldata token) 
+        external 
+        view 
+        returns (string[] memory) 
+    {
+        return getResources(token);
+    }
+    
+    /**
+     * @notice Test function that requires a specific statement
+     * @param token The authentication token
+     * @param expectedStatement The statement that is expected in the token
+     * @return A success message if the statement matches
+     */
+    function testStatementVerification(bytes calldata token, string calldata expectedStatement) 
+        external 
+        view 
+        returns (bool) 
+    {
+        string memory actualStatement = getStatement(token);
+        if (keccak256(bytes(actualStatement)) == keccak256(bytes(expectedStatement))) {
+            return true;
+        }
+        return false;
+    }
+   
+    /**
+     * @notice Test function to check if a token grants access to a specific resource
+     * @param token The authentication token to check
+     * @param resource The resource URI to check access for
+     * @return True if the token grants access to the specified resource
+     */
+    function testHasResourceAccess(bytes calldata token, string calldata resource) 
+        external 
+        view 
+        returns (bool) 
+    {
+        string[] memory tokenResources = getResources(token);
+        for (uint256 i = 0; i < tokenResources.length; i++) {
+            if (keccak256(bytes(tokenResources[i])) == keccak256(bytes(resource))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     function doNothing() external { // solhint-disable-line
         // Does nothing
     }

--- a/contracts/test/auth.ts
+++ b/contracts/test/auth.ts
@@ -26,15 +26,20 @@ describe('Auth', function () {
     domain: string,
     signerIdx: number,
     expiration?: Date,
+    statement?: string,
+    resources?: string[],
   ): Promise<string> {
     return new SiweMessage({
       domain,
       address: await (await ethers.provider.getSigner(signerIdx)).getAddress(),
-      statement: `I accept the ExampleOrg Terms of Service: http://${domain}/tos`,
+      statement:
+        statement ||
+        `I accept the ExampleOrg Terms of Service: http://${domain}/tos`,
       uri: `http://${domain}:5173`,
       version: '1',
       chainId: Number((await ethers.provider.getNetwork()).chainId),
       expirationTime: expiration ? expiration.toISOString() : undefined,
+      resources: resources || [],
     }).toMessage();
   }
 
@@ -187,5 +192,167 @@ describe('Auth', function () {
     const tx = await siweAuthTests.setDomain('localhost2', { gasLimit: 50000 });
     await tx.wait();
     expect(await siweAuthTests.domain()).to.be.equal('localhost2');
+  });
+
+  it('Should verify statement from token', async function () {
+    // Skip this test on non-sapphire chains.
+    if (
+      Number((await ethers.provider.getNetwork()).chainId) !=
+      NETWORKS.localnet.chainId
+    ) {
+      this.skip();
+    }
+
+    const siweAuthTests = await deploy('localhost');
+
+    // Create a custom statement
+    const customStatement =
+      'I agree to the terms and authorize this specific action';
+
+    // Get the signer
+    const accounts = config.networks.hardhat
+      .accounts as HardhatNetworkHDAccountsConfig;
+    const account = ethers.HDNodeWallet.fromMnemonic(
+      ethers.Mnemonic.fromPhrase(accounts.mnemonic),
+      accounts.path + '/0',
+    );
+
+    // Create the SIWE message with the custom statement
+    const siweStr = await siweMsg('localhost', 0, undefined, customStatement);
+
+    // Generate token
+    const token = await siweAuthTests.testLogin(
+      siweStr,
+      await erc191sign(siweStr, account),
+    );
+
+    // Verify the statement is correctly stored and retrieved
+    expect(await siweAuthTests.testGetStatement(token)).to.equal(
+      customStatement,
+    );
+
+    // Test statement verification function
+    expect(
+      await siweAuthTests.testStatementVerification(token, customStatement),
+    ).to.be.true;
+
+    // Test with incorrect statement
+    expect(
+      await siweAuthTests.testStatementVerification(token, 'Wrong statement'),
+    ).to.be.false;
+  });
+
+  it('Should check resource access permissions', async function () {
+    // Skip this test on non-sapphire chains.
+    if (
+      Number((await ethers.provider.getNetwork()).chainId) !=
+      NETWORKS.localnet.chainId
+    ) {
+      this.skip();
+    }
+
+    const siweAuthTests = await deploy('localhost');
+
+    // Define resources
+    const resources = [
+      'https://example.com/api/resource1',
+      'https://example.com/api/resource2',
+      'ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
+    ];
+
+    // Get the signer
+    const accounts = config.networks.hardhat
+      .accounts as HardhatNetworkHDAccountsConfig;
+    const account = ethers.HDNodeWallet.fromMnemonic(
+      ethers.Mnemonic.fromPhrase(accounts.mnemonic),
+      accounts.path + '/0',
+    );
+
+    // Create the SIWE message with resources
+    const siweStr = await siweMsg(
+      'localhost',
+      0,
+      undefined,
+      undefined,
+      resources,
+    );
+
+    // Generate token
+    const token = await siweAuthTests.testLogin(
+      siweStr,
+      await erc191sign(siweStr, account),
+    );
+
+    // Check if the token grants access to specific resources
+    expect(await siweAuthTests.testHasResourceAccess(token, resources[0])).to.be
+      .true;
+    expect(await siweAuthTests.testHasResourceAccess(token, resources[1])).to.be
+      .true;
+    expect(await siweAuthTests.testHasResourceAccess(token, resources[2])).to.be
+      .true;
+
+    // Check that token doesn't grant access to unauthorized resources
+    expect(
+      await siweAuthTests.testHasResourceAccess(
+        token,
+        'https://example.com/api/unauthorized',
+      ),
+    ).to.be.false;
+  });
+
+  it('Should handle both statement and resources in the same token', async function () {
+    // Skip this test on non-sapphire chains.
+    if (
+      Number((await ethers.provider.getNetwork()).chainId) !=
+      NETWORKS.localnet.chainId
+    ) {
+      this.skip();
+    }
+
+    const siweAuthTests = await deploy('localhost');
+
+    // Define resources and statement
+    const resources = [
+      'https://example.com/api/profile',
+      'https://example.com/api/data',
+    ];
+    const statement =
+      'I authorize this application to access my profile and data';
+
+    // Get the signer
+    const accounts = config.networks.hardhat
+      .accounts as HardhatNetworkHDAccountsConfig;
+    const account = ethers.HDNodeWallet.fromMnemonic(
+      ethers.Mnemonic.fromPhrase(accounts.mnemonic),
+      accounts.path + '/0',
+    );
+
+    // Create the SIWE message with both statement and resources
+    const siweStr = await siweMsg(
+      'localhost',
+      0,
+      undefined,
+      statement,
+      resources,
+    );
+
+    // Generate token
+    const token = await siweAuthTests.testLogin(
+      siweStr,
+      await erc191sign(siweStr, account),
+    );
+
+    // Verify statement
+    expect(await siweAuthTests.testGetStatement(token)).to.equal(statement);
+    expect(await siweAuthTests.testStatementVerification(token, statement)).to
+      .be.true;
+
+    // Verify resource access
+    const tokenResources = [...(await siweAuthTests.testGetResources(token))];
+    expect(tokenResources).to.have.members(resources);
+    expect(await siweAuthTests.testHasResourceAccess(token, resources[0])).to.be
+      .true;
+    expect(await siweAuthTests.testHasResourceAccess(token, resources[1])).to.be
+      .true;
   });
 });


### PR DESCRIPTION
### Enhancements to `SiweAuth` contract:

* Added `statement` and `resources` fields to the `AuthToken` structure 
* Implemented functions to retrieve the statement and resources from an authentication token, and a helper function to decode and validate tokens 

### Test functions and cases:

* Added test functions to `SiweAuthTests` for retrieving statements and resources
* Updated test cases to verify the new functionality, including tests for statement verification, resource access 