### PR TITLE
Ziga mr/fix/foundry pin time crate v0.3.36

### DIFF
--- a/clients/py/requirements.txt
+++ b/clients/py/requirements.txt
@@ -1,3 +1,3 @@
 cbor2
 pynacl
-web3==6.*
+web3==7.*

--- a/clients/py/sapphirepy/sapphire.py
+++ b/clients/py/sapphirepy/sapphire.py
@@ -1,15 +1,24 @@
 from binascii import unhexlify, hexlify
-from typing import (
-    Any,
-    Callable,
-    cast,
-    Optional,
-    TypedDict,
+from typing import Any, cast, Optional, TypedDict, Union
+from toolz import (  # type: ignore
+    curry,
 )
-
 import cbor2
-from web3 import Web3
-from web3.types import RPCEndpoint, RPCResponse, TxParams, Middleware
+from web3 import (  # noqa: F401
+    AsyncWeb3,
+    Web3,
+)
+from web3.types import (  # noqa: F401
+    AsyncMakeRequestFn,
+    MakeRequestFn,
+    RPCEndpoint,
+    RPCResponse,
+    BlockData,
+    Coroutine,
+)
+from web3.middleware.base import (
+    Web3MiddlewareBuilder,
+)
 from eth_typing import HexStr
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
@@ -49,9 +58,10 @@ class CalldataPublicKeyManager:
         self._keys = []
 
     def _trim_and_sort(self, newest_epoch: int):
-        self._keys = sorted([v for v in self._keys
-                             if v['epoch'] >= newest_epoch - EPOCH_LIMIT],
-                            key=lambda o: o['epoch'])[-EPOCH_LIMIT:]
+        self._keys = sorted(
+            [v for v in self._keys if v["epoch"] >= newest_epoch - EPOCH_LIMIT],
+            key=lambda o: o["epoch"],
+        )[-EPOCH_LIMIT:]
 
     @property
     def newest(self):
@@ -61,64 +71,67 @@ class CalldataPublicKeyManager:
 
     def add(self, pk: CalldataPublicKey):
         if self._keys:
-            if self.newest['epoch'] < pk['epoch']:
+            if self.newest["epoch"] < pk["epoch"]:
                 self._keys.append(pk)
-            self._trim_and_sort(pk['epoch'])
+            self._trim_and_sort(pk["epoch"])
         else:
             self._keys.append(pk)
 
 
-def _should_intercept(method: RPCEndpoint, params: tuple[TxParams]):
+def _should_intercept(method: RPCEndpoint, params: Any):
     if not ENCRYPT_DEPLOYS:
-        if method in ('eth_sendTransaction', 'eth_estimateGas'):
+        if method in ("eth_sendTransaction", "eth_estimateGas"):
             # When 'to' flag is missing, we assume it's a deployment
-            if not params[0].get('to', None):
+            if not params[0].get("to", None):
                 return False
-    return method in ('eth_estimateGas', 'eth_sendTransaction', 'eth_call')
+    return method in ("eth_estimateGas", "eth_sendTransaction", "eth_call")
 
 
-def _encrypt_tx_params(pk: CalldataPublicKey,
-                       params: tuple[TxParams],
-                       method,
-                       web3: Web3,
-                       account: Optional[LocalAccount]=None) -> TransactionCipher:
-    c = TransactionCipher(peer_pubkey=pk['key'], peer_epoch=pk['epoch'])
-    data = params[0]['data']
+def _encrypt_tx_params(
+    pk: CalldataPublicKey,
+    params: Any,
+    account: Optional[LocalAccount] = None,
+    signed_call_data: Optional[dict] = None,
+) -> TransactionCipher:
+    c = TransactionCipher(peer_pubkey=pk["key"], peer_epoch=pk["epoch"])
+    data = params[0]["data"]
     if isinstance(data, bytes):
         data_bytes = data
     elif isinstance(data, str):
-        if len(data) < 2 or data[:2] != '0x':
-            raise ValueError('Data is not hex encoded!', data)
+        if len(data) < 2 or data[:2] != "0x":
+            raise ValueError("Data is not hex encoded!", data)
         data_bytes = unhexlify(data[2:])
     else:
         raise TypeError("Invalid 'data' type", type(data))
     encrypted_data = c.encrypt(data_bytes)
 
-    if method == 'eth_call' and params[0]['from'] and account:
-        data_pack = _new_signed_call_data_pack(c.make_envelope(data_bytes),
-                                               data_bytes,
-                                               params,
-                                               web3,
-                                               account)
-        params[0]['data'] = cbor2.dumps(data_pack, canonical=True)
+    if signed_call_data and account:
+        data_pack = _new_signed_call_data_pack(
+            c.make_envelope(data_bytes), data_bytes, params, account, signed_call_data
+        )
+        params[0]["data"] = cbor2.dumps(data_pack, canonical=True)
     else:
-        params[0]['data'] = HexStr('0x' + hexlify(encrypted_data).decode('ascii'))
+        params[0]["data"] = HexStr("0x" + hexlify(encrypted_data).decode("ascii"))
     return c
 
 
-def _new_signed_call_data_pack(encrypted_data: dict,
-                               data_bytes: bytes,
-                               params: tuple[TxParams],
-                               web3: Web3,
-                               account: LocalAccount) -> dict:
+def _new_signed_call_data_pack(
+    encrypted_data: dict,
+    data_bytes: bytes,
+    params: Any,
+    account: LocalAccount,
+    signed_call_data: dict,
+) -> dict:
     # Update params with default values, these get used outside the scope of this function
-    params[0]['gas'] = params[0].get('gas', DEFAULT_GAS_LIMIT)
-    params[0]['gasPrice'] = params[0].get('gasPrice', web3.to_wei(DEFAULT_GAS_PRICE, 'wei'))
+    params[0]["gas"] = int(params[0].get("gas", DEFAULT_GAS_LIMIT))
+    params[0]["gasPrice"] = signed_call_data[
+        "gas_price"
+    ]  # web3.to_wei(params[0].get('gasPrice', DEFAULT_GAS_PRICE), 'wei')
 
     domain_data = {
         "name": "oasis-runtime-sdk/evm: signed query",
         "version": "1.0.0",
-        "chainId": web3.eth.chain_id,
+        "chainId": signed_call_data["chain_id"],
         # "verifyingContract": "",
         # "salt": "",
     }
@@ -144,23 +157,30 @@ def _new_signed_call_data_pack(encrypted_data: dict,
             {"name": "blockRange", "type": "uint64"},
         ],
     }
-    nonce = web3.eth.get_transaction_count(web3.to_checksum_address(params[0]['from']))
-    block_number = web3.eth.block_number
-    block_hash = web3.eth.get_block(block_number-1)['hash'].hex()
+    nonce = signed_call_data[
+        "nonce"
+    ]  # web3.eth.get_transaction_count(web3.to_checksum_address(params[0]['from']))
+    block_number = signed_call_data["block_number"]  # web3.eth.block_number
+
+    block_hash = signed_call_data[
+        "block_hash"
+    ]  # web3.eth.get_block(block_number - 1)['hash'].hex()
+    if block_hash.startswith("0x"):
+        block_hash = block_hash[2:]
+
     msg_data = {
-        "from": params[0].get('from'),
-        "to": params[0].get('to'),
-        "value": params[0].get('value', 0),
-        "gasLimit": params[0].get('gas', DEFAULT_GAS_LIMIT),
-        "gasPrice": params[0].get('gasPrice', DEFAULT_GAS_PRICE),
+        "from": params[0].get("from"),
+        "to": params[0].get("to"),
+        "value": params[0].get("value", 0),
+        "gasLimit": params[0].get("gas", DEFAULT_GAS_LIMIT),
+        "gasPrice": params[0].get("gasPrice", DEFAULT_GAS_PRICE),
         "data": data_bytes,
-        "leash":
-            {
-                "nonce": nonce,
-                "blockNumber": block_number - 1,
-                "blockHash": unhexlify(block_hash[2:]),
-                "blockRange": DEFAULT_BLOCK_RANGE,
-            }
+        "leash": {
+            "nonce": nonce,
+            "blockNumber": block_number - 1,
+            "blockHash": unhexlify(block_hash),
+            "blockRange": DEFAULT_BLOCK_RANGE,
+        },
     }
 
     full_message = {
@@ -176,30 +196,41 @@ def _new_signed_call_data_pack(encrypted_data: dict,
     leash = {
         "nonce": nonce,
         "block_number": block_number - 1,
-        "block_hash": unhexlify(block_hash[2:]),
+        "block_hash": unhexlify(block_hash),
         "block_range": DEFAULT_BLOCK_RANGE,
     }
 
-    data_pack= {
-        'data': encrypted_data,
-        'leash': leash,
-        'signature': bytes(signed_msg['signature']),
+    data_pack = {
+        "data": encrypted_data,
+        "leash": leash,
+        "signature": bytes(signed_msg["signature"]),
     }
+    params[0]["gas"] = hex(params[0]["gas"])
+    params[0]["gasPrice"] = hex(params[0]["gasPrice"])
     return data_pack
 
 
-def construct_sapphire_middleware(
-        account: Optional[LocalAccount] = None
-) -> Middleware:
+class ConstructSapphireMiddlewareBuilder(Web3MiddlewareBuilder):
     """
     Construct a Sapphire middleware for Web3.py.
     :param account: Used to encrypt signed queries.
     :return: A Sapphire middleware function.
     """
 
-    def sapphire_middleware(
-            make_request: Callable[[RPCEndpoint, Any], Any], w3: "Web3"
-    ) -> Callable[[RPCEndpoint, Any], RPCResponse]:
+    sapphire_account = None
+
+    @staticmethod
+    @curry
+    def build(
+        account: LocalAccount,
+        w3: Union["Web3", "AsyncWeb3"],
+    ) -> "ConstructSapphireMiddlewareBuilder":
+        # pylint: disable=no-value-for-parameter,arguments-differ
+        middleware = ConstructSapphireMiddlewareBuilder(w3)
+        middleware.sapphire_account = account
+        return middleware
+
+    def wrap_make_request(self, make_request: "MakeRequestFn") -> "MakeRequestFn":
         """
         Transparently encrypt the calldata for:
 
@@ -220,22 +251,48 @@ def construct_sapphire_middleware(
         """
         manager = CalldataPublicKeyManager()
 
-        def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
+        def middleware(method: "RPCEndpoint", params: Any) -> "RPCResponse":
             if _should_intercept(method, params):
                 do_fetch = True
                 pk = manager.newest
                 while do_fetch:
                     if not pk:
                         # If no calldata public key exists, fetch one
-                        cdpk = cast(RPCResponse, make_request(RPCEndpoint('oasis_callDataPublicKey'), []))
-                        pk = cast(Optional[CalldataPublicKey], cdpk.get('result', None))
+                        cdpk = cast(
+                            RPCResponse,
+                            make_request(RPCEndpoint("oasis_callDataPublicKey"), []),
+                        )
+                        pk = cast(Optional[CalldataPublicKey], cdpk.get("result", None))
                         if pk:
                             manager.add(pk)
                     if not pk:
-                        raise RuntimeError('Could not retrieve callDataPublicKey!')
+                        raise RuntimeError("Could not retrieve callDataPublicKey!")
                     do_fetch = False
 
-                    c = _encrypt_tx_params(pk, params, method, w3, account)
+                    if (
+                        method == "eth_call"
+                        and params[0]["from"]
+                        and self.sapphire_account
+                    ):
+                        block_number = cast(int, self._w3.eth.block_number)
+                        signed_call_data = {
+                            "chain_id": self._w3.eth.chain_id,
+                            "nonce": self._w3.eth.get_transaction_count(
+                                self._w3.to_checksum_address(params[0]["from"])
+                            ),
+                            "block_number": block_number,
+                            "block_hash": cast(
+                                BlockData, self._w3.eth.get_block(block_number - 1)
+                            )["hash"].hex(),
+                            "gas_price": self._w3.to_wei(
+                                params[0].get("gasPrice", DEFAULT_GAS_PRICE), "wei"
+                            ),
+                        }
+                        c = _encrypt_tx_params(
+                            pk, params, self.sapphire_account, signed_call_data
+                        )
+                    else:
+                        c = _encrypt_tx_params(pk, params, self.sapphire_account)
 
                     # We may encounter three errors here:
                     #  'core: invalid call format: epoch too far in the past'
@@ -243,35 +300,126 @@ def construct_sapphire_middleware(
                     #  'core: invalid call format: epoch in the future'
                     # We can only do something meaningful with the first!
                     result = cast(RPCResponse, make_request(method, params))
-                    if result.get('error', None) is not None:
-                        error = result['error']
-                        if not isinstance(error, str) and error['code'] == -32000:
-                            if error['message'] == 'core: invalid call format: epoch too far in the past':
+                    if result.get("error", None) is not None:
+                        error = result["error"]
+                        if not isinstance(error, str) and error["code"] == -32000:
+                            if (
+                                error["message"]
+                                == "core: invalid call format: epoch too far in the past"
+                            ):
                                 # force the re-fetch, and encrypt with new key
                                 do_fetch = True
                                 pk = None
                                 continue
 
                 # Only eth_call is decrypted
-                if method == 'eth_call' and result.get('result', '0x') != '0x':
-                    decrypted = c.decrypt(unhexlify(result['result'][2:]))
-                    result['result'] = HexStr('0x' + hexlify(decrypted).decode('ascii'))
+                if method == "eth_call" and result.get("result", "0x") != "0x":
+                    decrypted = c.decrypt(unhexlify(result["result"][2:]))
+                    result["result"] = HexStr("0x" + hexlify(decrypted).decode("ascii"))
 
                 return result
             return make_request(method, params)
 
         return middleware
 
-    return sapphire_middleware
+    async def async_wrap_make_request(
+        self, make_request: "AsyncMakeRequestFn"
+    ) -> "AsyncMakeRequestFn":
+        """
+        Async version of wrap_make_request that handles the same encryption logic
+        for eth_estimateGas, eth_sendTransaction, and eth_call
+        """
+        manager = CalldataPublicKeyManager()
+
+        async def middleware(method: "RPCEndpoint", params: Any) -> "RPCResponse":
+            if _should_intercept(method, params):
+                do_fetch = True
+                pk = manager.newest
+                while do_fetch:
+                    if not pk:
+                        # If no calldata public key exists, fetch one
+                        cdpk = cast(
+                            RPCResponse,
+                            await make_request(
+                                RPCEndpoint("oasis_callDataPublicKey"), []
+                            ),
+                        )
+                        pk = cast(Optional[CalldataPublicKey], cdpk.get("result", None))
+                        if pk:
+                            manager.add(pk)
+                    if not pk:
+                        raise RuntimeError("Could not retrieve callDataPublicKey!")
+                    do_fetch = False
+
+                    if (
+                        method == "eth_call"
+                        and params[0]["from"]
+                        and self.sapphire_account
+                    ):
+                        block_number = await cast(
+                            Coroutine[Any, Any, int], self._w3.eth.block_number
+                        )
+                        signed_call_data = {
+                            "chain_id": await cast(
+                                Coroutine[Any, Any, int], self._w3.eth.chain_id
+                            ),
+                            "nonce": await cast(
+                                Coroutine[Any, Any, int],
+                                self._w3.eth.get_transaction_count(
+                                    self._w3.to_checksum_address(params[0]["from"])
+                                ),
+                            ),
+                            "block_number": block_number,
+                            "block_hash": (
+                                await cast(
+                                    Coroutine[Any, Any, BlockData],
+                                    self._w3.eth.get_block(block_number - 1),
+                                )
+                            )["hash"].hex(),
+                            "gas_price": self._w3.to_wei(
+                                params[0].get("gasPrice", DEFAULT_GAS_PRICE), "wei"
+                            ),
+                        }
+                        c = _encrypt_tx_params(
+                            pk, params, self.sapphire_account, signed_call_data
+                        )
+                    else:
+                        c = _encrypt_tx_params(pk, params, self.sapphire_account)
+
+                    # Handle the same three potential errors as sync version
+                    result = cast(RPCResponse, await make_request(method, params))
+                    if result.get("error", None) is not None:
+                        error = result["error"]
+                        if not isinstance(error, str) and error["code"] == -32000:
+                            if (
+                                error["message"]
+                                == "core: invalid call format: epoch too far in the past"
+                            ):
+                                # force the re-fetch, and encrypt with new key
+                                do_fetch = True
+                                pk = None
+                                continue
+
+                # Only eth_call is decrypted
+                if method == "eth_call" and result.get("result", "0x") != "0x":
+                    decrypted = c.decrypt(unhexlify(result["result"][2:]))
+                    result["result"] = HexStr("0x" + hexlify(decrypted).decode("ascii"))
+
+                return result
+            return await make_request(method, params)
+
+        return middleware
 
 
-def wrap(w3: Web3, account: Optional[LocalAccount] = None):
+def wrap(w3: Union[Web3, AsyncWeb3], account: Optional[LocalAccount] = None):
     """
     Adds the Sapphire transaction encryption middleware to a Web3.py provider.
 
     Note: the provider must be wrapped *after* any signing middleware has been
           added, otherwise pre-signed transactions will not be encrypted.
     """
-    if 'sapphire' not in w3.middleware_onion:
-        w3.middleware_onion.add(construct_sapphire_middleware(account), "sapphire")
+    if "sapphire" not in w3.middleware_onion:
+        w3.middleware_onion.add(
+            ConstructSapphireMiddlewareBuilder.build(account), "sapphire"  # pylint: disable=no-value-for-parameter
+        )
     return w3

--- a/clients/py/sapphirepy/tests/test_async_e2e.py
+++ b/clients/py/sapphirepy/tests/test_async_e2e.py
@@ -1,0 +1,253 @@
+import unittest
+import asyncio
+import time
+from typing import Type, Union
+
+from web3 import Web3, AsyncWeb3
+from web3.exceptions import ContractLogicError, ContractCustomError
+from web3.contract.contract import Contract
+from web3.middleware import SignAndSendRawMiddlewareBuilder
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+from eth_utils import function_signature_to_4byte_selector
+
+from sapphirepy import sapphire
+
+from .test_e2e import compiled_test_contract
+
+
+class AsyncTestEndToEnd(unittest.IsolatedAsyncioTestCase):
+    """Async tests for Sapphire middleware with AsyncWeb3."""
+
+    contract: Union[Contract, Type[Contract]]
+    w3: AsyncWeb3
+
+    # Also store sync instances for performance comparison
+    sync_greeter: Union[Contract, Type[Contract]]
+    sync_w3: Web3
+
+    async def asyncSetUp(self):
+        """Set up both async and sync Web3 instances for testing."""
+        # Use the same key for both instances
+        account: LocalAccount = (
+            Account.from_key(  # pylint: disable=no-value-for-parameter
+                private_key="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+            )
+        )
+
+        # Set up async Web3
+        w3_async = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider("http://localhost:8545"))
+        w3_async.middleware_onion.add(
+            SignAndSendRawMiddlewareBuilder.build(account)  # pylint: disable=no-value-for-parameter
+        )
+        self.w3_async_no_signer = AsyncWeb3(
+            AsyncWeb3.AsyncHTTPProvider("http://localhost:8545")
+        )
+        self.w3_async = sapphire.wrap(w3_async, account)
+        self.w3_async.eth.default_account = account.address
+
+        # Deploy the contract using async Web3
+        iface = compiled_test_contract()
+        contract = self.w3_async.eth.contract(abi=iface["abi"], bytecode=iface["bin"])
+        tx_hash = await contract.constructor().transact(
+            {"gasPrice": await self.w3_async.eth.gas_price}
+        )
+        tx_receipt = await self.w3_async.eth.wait_for_transaction_receipt(tx_hash)
+        contract_address = tx_receipt["contractAddress"]
+
+        # Create contract instances for both async and sync Web3
+        self.async_greeter = self.w3_async.eth.contract(
+            address=contract_address, abi=iface["abi"]
+        )
+        self.async_greeter_no_signer = self.w3_async_no_signer.eth.contract(
+            address=contract_address, abi=iface["abi"]
+        )
+
+    async def asyncTearDown(self):
+        """Clean up async resources."""
+        if hasattr(self, "w3_async"):
+            await self.w3_async.provider.disconnect()
+        if hasattr(self, "w3_async_no_signer"):
+            await self.w3_async_no_signer.provider.disconnect()
+
+    # Async versions of the tests in test_e2e.py
+    async def test_viewcall_revert_custom(self):
+        with self.assertRaises(ContractCustomError) as cm:
+            await self.async_greeter.functions.revertWithCustomError().call()
+
+        error_signature = "MyCustomError(string)"
+        selector = function_signature_to_4byte_selector(error_signature)
+        error_data = self.w3_async.codec.encode(["string"], ["thisIsCustom"])
+        data = selector + error_data
+
+        self.assertEqual(cm.exception.args[0], "0x" + data.hex())
+
+    async def test_viewcall_revert_reason(self):
+        with self.assertRaises(ContractLogicError) as cm:
+            await self.async_greeter.functions.revertWithReason().call()
+        self.assertEqual(cm.exception.message, "execution reverted: reasonGoesHere")
+
+    async def test_viewcall(self):
+        result = await self.async_greeter.functions.greet().call()
+        self.assertEqual(result, "Hello")
+
+    async def test_viewcall_only_owner(self):
+        result = await self.async_greeter.functions.greetOnlyOwner().call()
+        self.assertEqual(result, "Hello")
+
+    async def test_viewcall_only_owner_no_signer(self):
+        with self.assertRaises(ContractLogicError) as cm:
+            await self.async_greeter_no_signer.functions.greetOnlyOwner().call()
+        self.assertEqual(
+            cm.exception.message,
+            "execution reverted: Only owner can call this function",
+        )
+
+    async def test_transaction(self):
+        x = await self.async_greeter.functions.blah().transact(
+            {"gasPrice": await self.w3_async.eth.gas_price}
+        )
+        y = await self.w3_async.eth.wait_for_transaction_receipt(x)
+        z = self.async_greeter.events.Greeting().process_receipt(y)
+        self.assertEqual(z[0].args["g"], "Hello")
+
+
+class TestPerformanceComparison(unittest.IsolatedAsyncioTestCase):
+    """Performance comparison between sync and async Web3."""
+
+    async def asyncSetUp(self):
+        # Set up accounts
+        self.account = Account.from_key(  # pylint: disable=no-value-for-parameter
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+        )
+
+        # Set up providers
+        self.sync_w3 = Web3(Web3.HTTPProvider("http://localhost:8545"))
+        self.sync_w3.middleware_onion.add(
+            SignAndSendRawMiddlewareBuilder.build(self.account)  # pylint: disable=no-value-for-parameter
+        )
+        self.sync_w3 = sapphire.wrap(self.sync_w3, self.account)
+        self.sync_w3.eth.default_account = self.account.address
+
+        self.async_w3 = AsyncWeb3(
+            AsyncWeb3.AsyncHTTPProvider("http://localhost:8545")
+        )
+        # self.async_w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider('https://testnet.sapphire.oasis.io'))
+        self.async_w3.middleware_onion.add(
+            SignAndSendRawMiddlewareBuilder.build(self.account)  # pylint: disable=no-value-for-parameter
+        )
+        self.async_w3 = sapphire.wrap(self.async_w3, self.account)
+        self.async_w3.eth.default_account = self.account.address
+
+        # Deploy contract for contract call tests
+        iface = compiled_test_contract()
+        contract = self.async_w3.eth.contract(abi=iface["abi"], bytecode=iface["bin"])
+        tx_hash = await contract.constructor().transact(
+            {"gasPrice": await self.async_w3.eth.gas_price}
+        )
+        tx_receipt = await self.async_w3.eth.wait_for_transaction_receipt(tx_hash)
+        contract_address = tx_receipt["contractAddress"]
+
+        self.sync_contract = self.sync_w3.eth.contract(
+            address=contract_address, abi=iface["abi"]
+        )
+        self.async_contract = self.async_w3.eth.contract(
+            address=contract_address, abi=iface["abi"]
+        )
+
+    async def asyncTearDown(self):
+        """Clean up async resources."""
+        if hasattr(self, "async_w3"):
+            await self.async_w3.provider.disconnect()
+
+    async def test_performance(self):
+        """Compare performance between sync and async operations."""
+        batch_sizes = [1, 2, 5]
+
+        print("\nPerformance Comparison: Sync vs Async Web3")
+        print("------------------------------------------")
+
+        for batch_size in batch_sizes:
+            # RPC call performance (block number)
+            sync_time = await self._measure_sync_batch(batch_size)
+            async_time = await self._measure_async_batch(batch_size)
+
+            speedup = sync_time / async_time if async_time > 0 else float("inf")
+
+            print(f"\nBatch Size: {batch_size} requests")
+            print(f"  Sync RPC Time:  {sync_time:.4f} seconds")
+            print(f"  Async RPC Time: {async_time:.4f} seconds")
+            print(f"  Speedup:        {speedup:.2f}x")
+
+            # For larger batches, async should be noticeably faster
+            # if batch_size >= 10:
+            #     self.assertGreater(speedup, 1.0,
+            #                       f"Expected async to be faster for batch size {batch_size}")
+
+        # Contract call performance
+        await self._compare_contract_calls()
+        await self.async_w3.provider.disconnect()
+
+    async def _measure_sync_batch(self, num_requests: int) -> float:
+        """Measure time to execute a batch of sync block number requests."""
+        start_time = time.time()
+
+        for _ in range(num_requests):
+            self.sync_contract.functions.greet().call()
+            time.sleep(0.1)
+
+        end_time = time.time()
+        return end_time - start_time
+
+    async def _measure_async_batch(self, num_requests: int) -> float:
+        """Measure time to execute a batch of async block number requests concurrently."""
+        start_time = time.time()
+
+        tasks = []
+        for _ in range(num_requests):
+            tasks.append(
+                asyncio.gather(
+                    self.async_contract.functions.greet().call(), asyncio.sleep(0.1)
+                )
+            )
+
+        await asyncio.gather(*tasks)
+
+        end_time = time.time()
+        return end_time - start_time
+
+    async def _compare_contract_calls(self):
+        """Compare contract call performance between sync and async."""
+        print("\nContract Call Performance:")
+
+        # Measure sync contract calls
+        start_time = time.time()
+        for _ in range(100):
+            self.sync_contract.functions.greet().call()
+            time.sleep(0.1)
+        sync_time = time.time() - start_time
+
+        # Measure async contract calls
+        start_time = time.time()
+        tasks = []
+        for _ in range(100):
+            # tasks.append(self.async_contract.functions.greet().call())
+            tasks.append(
+                asyncio.gather(
+                    self.async_contract.functions.greet().call(), asyncio.sleep(0.1)
+                )
+            )
+        await asyncio.gather(*tasks)
+        async_time = time.time() - start_time
+
+        speedup = sync_time / async_time if async_time > 0 else float("inf")
+
+        print(f"  Sync Contract Calls:  {sync_time:.4f} seconds")
+        print(f"  Async Contract Calls: {async_time:.4f} seconds")
+        print(f"  Speedup:              {speedup:.2f}x")
+
+        self.assertGreater(speedup, 1.0, "Expected async contract calls to be faster")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/py/sapphirepy/tests/test_e2e.py
+++ b/clients/py/sapphirepy/tests/test_e2e.py
@@ -85,7 +85,7 @@ class TestEndToEnd(unittest.TestCase):
         error_data = self.w3.codec.encode(["string"], ["thisIsCustom"])
         data = selector + error_data
 
-        self.assertEqual(cm.exception.args[0], "0x" + data.hex())
+        self.assertEqual(cm.exception.args[0], f"0x{data.hex()}")
 
     def test_viewcall_revert_reason(self):
         with self.assertRaises(ContractLogicError) as cm:

--- a/clients/py/sapphirepy/tests/test_e2e.py
+++ b/clients/py/sapphirepy/tests/test_e2e.py
@@ -6,102 +6,115 @@ from typing import Type, Union
 from web3 import Web3
 from web3.exceptions import ContractLogicError, ContractCustomError
 from web3.contract.contract import Contract
-from web3.middleware import construct_sign_and_send_raw_middleware
+from web3.middleware import SignAndSendRawMiddlewareBuilder
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
+from eth_utils import function_signature_to_4byte_selector
 
 from sapphirepy import sapphire
 
-TESTDATA = os.path.join(os.path.dirname(__file__), 'testdata')
-GREETER_ABI = os.path.join(TESTDATA, 'Greeter.abi')
-GREETER_BIN = os.path.join(TESTDATA, 'Greeter.bin')
-GREETER_SOL = os.path.join(TESTDATA, 'Greeter.sol')
+TESTDATA = os.path.join(os.path.dirname(__file__), "testdata")
+GREETER_ABI = os.path.join(TESTDATA, "Greeter.abi")
+GREETER_BIN = os.path.join(TESTDATA, "Greeter.bin")
+GREETER_SOL = os.path.join(TESTDATA, "Greeter.sol")
+
 
 def compiled_test_contract():
     if not os.path.exists(GREETER_ABI):
         # pylint: disable=import-outside-toplevel
-        import solcx   # type: ignore
+        import solcx  # type: ignore
 
-        with open(GREETER_SOL, 'r', encoding='utf-8') as handle:
-            solcx.install_solc(version='0.8.9')
-            solcx.set_solc_version('0.8.9')
+        with open(GREETER_SOL, "r", encoding="utf-8") as handle:
+            solcx.install_solc(version="0.8.9")
+            solcx.set_solc_version("0.8.9")
             compiled_sol = solcx.compile_source(
-                handle.read(),
-                output_values=['abi', 'bin']
+                handle.read(), output_values=["abi", "bin"]
             )
             _, contract_interface = compiled_sol.popitem()
-        with open(GREETER_ABI, 'w', encoding='utf-8') as handle:
-            json.dump(contract_interface['abi'], handle)
-        with open(GREETER_BIN, 'w', encoding='utf-8') as handle:
-            json.dump(contract_interface['bin'], handle)
+        with open(GREETER_ABI, "w", encoding="utf-8") as handle:
+            json.dump(contract_interface["abi"], handle)
+        with open(GREETER_BIN, "w", encoding="utf-8") as handle:
+            json.dump(contract_interface["bin"], handle)
         return {
-            'abi': contract_interface['abi'],
-            'bin': contract_interface['bin'],
+            "abi": contract_interface["abi"],
+            "bin": contract_interface["bin"],
         }
-    with open(GREETER_ABI, 'rb') as abi_handle:
-        with open(GREETER_BIN, 'rb') as bin_handle:
-            return {
-                'abi': json.load(abi_handle),
-                'bin': json.load(bin_handle)
-            }
+    with open(GREETER_ABI, "rb") as abi_handle:
+        with open(GREETER_BIN, "rb") as bin_handle:
+            return {"abi": json.load(abi_handle), "bin": json.load(bin_handle)}
+
 
 class TestEndToEnd(unittest.TestCase):
-    greeter:Union[Contract,Type[Contract]]
+    greeter: Union[Contract, Type[Contract]]
     w3: Web3
 
     def setUp(self):
-        account: LocalAccount = Account.from_key("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")  # pylint: disable=no-value-for-parameter
+        account: LocalAccount = Account.from_key(  # pylint: disable=no-value-for-parameter
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+        )
 
-
-        w3 = Web3(Web3.HTTPProvider('http://localhost:8545'))
+        w3 = Web3(Web3.HTTPProvider("http://localhost:8545"))
         # w3 = Web3(Web3.HTTPProvider('https://testnet.sapphire.oasis.io'))
-        w3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))
-        self.w3_no_signer = Web3(Web3.HTTPProvider('http://localhost:8545'))
-        self.w3 = w3 = sapphire.wrap(w3, account)
+        w3.middleware_onion.add(
+            SignAndSendRawMiddlewareBuilder.build(account)  # pylint: disable=no-value-for-parameter
+        )
+        self.w3_no_signer = Web3(Web3.HTTPProvider("http://localhost:8545"))
+        self.w3 = sapphire.wrap(w3, account)
 
-        w3.eth.default_account = account.address
+        self.w3.eth.default_account = account.address
 
         iface = compiled_test_contract()
 
-        contract = w3.eth.contract(abi=iface['abi'], bytecode=iface['bin'], )
-        tx_hash = contract.constructor().transact({'gasPrice': w3.eth.gas_price})
-        tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+        contract = self.w3.eth.contract(abi=iface["abi"], bytecode=iface["bin"])
+        tx_hash = contract.constructor().transact({"gasPrice": self.w3.eth.gas_price})
+        tx_receipt = self.w3.eth.wait_for_transaction_receipt(tx_hash)
 
-        self.greeter = w3.eth.contract(address=tx_receipt['contractAddress'], abi=iface['abi'])
-        self.greeter_no_signer = self.w3_no_signer.eth.contract(address=tx_receipt['contractAddress'], abi=iface['abi'])
+        self.greeter = self.w3.eth.contract(
+            address=tx_receipt["contractAddress"], abi=iface["abi"]
+        )
+        self.greeter_no_signer = self.w3_no_signer.eth.contract(
+            address=tx_receipt["contractAddress"], abi=iface["abi"]
+        )
 
     def test_viewcall_revert_custom(self):
         with self.assertRaises(ContractCustomError) as cm:
             self.greeter.functions.revertWithCustomError().call()
-        data = self.greeter.encode_abi(
-            fn_name="MyCustomError", args=["thisIsCustom"]
-        )
-        self.assertEqual(cm.exception.args[0], data)
+
+        error_signature = "MyCustomError(string)"
+        selector = function_signature_to_4byte_selector(error_signature)
+        error_data = self.w3.codec.encode(["string"], ["thisIsCustom"])
+        data = selector + error_data
+
+        self.assertEqual(cm.exception.args[0], "0x" + data.hex())
 
     def test_viewcall_revert_reason(self):
         with self.assertRaises(ContractLogicError) as cm:
             self.greeter.functions.revertWithReason().call()
-        self.assertEqual(cm.exception.message, 'execution reverted: reasonGoesHere')
+        self.assertEqual(cm.exception.message, "execution reverted: reasonGoesHere")
 
     def test_viewcall(self):
-        self.assertEqual(self.greeter.functions.greet().call(), 'Hello')
+        self.assertEqual(self.greeter.functions.greet().call(), "Hello")
 
     def test_viewcall_only_owner(self):
-        self.assertEqual(self.greeter.functions.greetOnlyOwner().call(), 'Hello')
+        self.assertEqual(self.greeter.functions.greetOnlyOwner().call(), "Hello")
 
     def test_viewcall_only_owner_no_signer(self):
         with self.assertRaises(ContractLogicError) as cm:
             self.greeter_no_signer.functions.greetOnlyOwner().call()
-        self.assertEqual(cm.exception.message, 'execution reverted: Only owner can call this function')
+        self.assertEqual(
+            cm.exception.message,
+            "execution reverted: Only owner can call this function",
+        )
 
     def test_transaction(self):
         w3 = self.w3
         greeter = self.greeter
 
-        x = self.greeter.functions.blah().transact({'gasPrice': w3.eth.gas_price})
+        x = self.greeter.functions.blah().transact({"gasPrice": w3.eth.gas_price})
         y = w3.eth.wait_for_transaction_receipt(x)
         z = greeter.events.Greeting().process_receipt(y)
-        self.assertEqual(z[0].args['g'], 'Hello')
+        self.assertEqual(z[0].args["g"], "Hello")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/integrations/foundry/lib/oasisprotocol-sapphire-foundry/precompiles/Cargo.toml
+++ b/integrations/foundry/lib/oasisprotocol-sapphire-foundry/precompiles/Cargo.toml
@@ -74,9 +74,12 @@ rand = "0.8"
 ed25519-dalek = "2.1.1"
 oasis-core-keymanager = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v25.0" }
 oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v25.0" }
-oasis-runtime-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", package = "oasis-runtime-sdk", branch = "main" }
+oasis-runtime-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", tag="runtime-sdk/v0.12.0" }
 evm = { git = "https://github.com/oasisprotocol/evm", tag = "v0.39.1-oasis" }
 oasis_cbor = { version = "0.5.1", package = "oasis-cbor" }
+
+[patch.crates-io]
+time = { git = "https://github.com/time-rs/time", tag = "v0.3.36" }
 
 [build]
 rustflags = ["-C", "target-feature=+aes,+ssse3"]


### PR DESCRIPTION
This PR addresses build failures caused by recent updates to the [time](https://crates.io/crates/time) crate (v0.3.41) and its dependency deranged (v0.4.1). 

- Recent releases of the `time` crate (after v0.3.36) pull in `deranged` v0.4.1
- This newer version of `deranged` introduces changes to trait implementations that cause type inference errors
- The specific error occurs in runtime/src/common/sgx/ias.rs with ambiguous trait implementations

Fix:
- Patched the time crate to use v0.3.36 from GitHub (released April 11, 2024)