### PR TITLE
Fix: Pin time crate to v0.3.36 to resolve type inference regressions

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -17,6 +17,9 @@ on:
       - stable/*
       - rc/*
 
+env:
+  CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+
 jobs:
 
   lint-rust:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -16,6 +16,7 @@ env:
   OASIS_UNSAFE_SKIP_AVR_VERIFY: "1"
   OASIS_UNSAFE_KM_POLICY_KEYS: "1"
   OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES: "1"
+  CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
 jobs:
   test-rust:
@@ -139,17 +140,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Install libclang-dev
-        run: sudo apt-get update && sudo apt-get install -y libclang-dev
+
+      - name: Install libclang-dev, cmake
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev cmake
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           profile: minimal
-      - name: Install CMake
-        uses: lukka/get-cmake@latest
 
       - name: Install dependencies
         run: make build
@@ -166,20 +168,22 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Install libclang-dev
-        run: sudo apt-get update && sudo apt-get install -y libclang-dev
+
+      - name: Install libclang-dev, cmake
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev cmake
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           profile: minimal
-      - name: Install CMake
-        uses: lukka/get-cmake@latest
-      
+
       - name: Install dependencies
         run: make build
-      
+        
       - name: Run tests
         run: forge test
+        

--- a/integrations/foundry/lib/oasisprotocol-sapphire-foundry/precompiles/Cargo.toml
+++ b/integrations/foundry/lib/oasisprotocol-sapphire-foundry/precompiles/Cargo.toml
@@ -74,9 +74,15 @@ rand = "0.8"
 ed25519-dalek = "2.1.1"
 oasis-core-keymanager = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v25.0" }
 oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v25.0" }
-oasis-runtime-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", package = "oasis-runtime-sdk", branch = "main" }
+oasis-runtime-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", tag="runtime-sdk/v0.13.0" }
 evm = { git = "https://github.com/oasisprotocol/evm", tag = "v0.39.1-oasis" }
 oasis_cbor = { version = "0.5.1", package = "oasis-cbor" }
+
+# Temp fix, pin time (and deranged) to earlier version
+# TODO: Remove patch once stable oasis-core version is released
+# https://github.com/oasisprotocol/oasis-core/pull/6125
+[patch.crates-io] 
+time = { git = "https://github.com/time-rs/time", tag = "v0.3.36" }
 
 [build]
 rustflags = ["-C", "target-feature=+aes,+ssse3"]


### PR DESCRIPTION
This PR addresses build failures caused by recent updates to the time crate (v0.3.41) and its dependency deranged (v0.4.1).

- Recent releases of the time crate (after v0.3.36) pull in deranged v0.4.1
- This newer version of deranged introduces changes to trait implementations that cause type inference errors
- The specific error occurs in runtime/src/common/sgx/ias.rs with ambiguous trait implementations

Fix:
- Patched the time crate to use v0.3.36 from GitHub (released April 11, 2024)
- Update Foundry cmake version in ci-test.yaml

