### PR TITLE
clients/js: Make NETWORKS compatible with wallet_addEthereumChain

### DIFF
--- a/clients/js/src/networks.ts
+++ b/clients/js/src/networks.ts
@@ -22,22 +22,52 @@ export const SAPPHIRE_LOCALNET_HTTP_PROXY_HOST = globalThis.process?.env
   : 'localhost';
 
 const localnetParams = {
+  chainName: 'Oasis Sapphire Localnet',
   chainId: 0x5afd,
   defaultGateway: `http://${SAPPHIRE_LOCALNET_HTTP_PROXY_HOST}:${SAPPHIRE_LOCALNET_HTTP_PROXY_PORT}`,
+  rpcUrls: [
+    `http://${SAPPHIRE_LOCALNET_HTTP_PROXY_HOST}:${SAPPHIRE_LOCALNET_HTTP_PROXY_PORT}`,
+  ],
+  nativeCurrency: {
+    name: 'Oasis TEST',
+    symbol: 'TEST',
+    decimals: 18,
+  },
+  blockExplorerUrls: ['http://localhost:8548/localnet/sapphire'],
   runtimeId:
     '0x8000000000000000000000000000000000000000000000000000000000000000',
 };
 
 const mainnetParams = {
+  chainName: 'Oasis Sapphire',
   chainId: 0x5afe,
   defaultGateway: 'https://sapphire.oasis.io/',
+  rpcUrls: ['https://sapphire.oasis.io/'],
+  nativeCurrency: {
+    name: 'Oasis ROSE',
+    symbol: 'ROSE',
+    decimals: 18,
+  },
+  blockExplorerUrls: ['https://explorer.oasis.io/mainnet/sapphire'],
+  iconUrls: ['https://assets.oasis.io/logotypes/metamask-oasis-sapphire.png'],
   runtimeId:
     '0x000000000000000000000000000000000000000000000000f80306c9858e7279',
 };
 
 const testnetParams = {
+  chainName: 'Oasis Sapphire Testnet',
   chainId: 0x5aff,
   defaultGateway: 'https://testnet.sapphire.oasis.io/',
+  rpcUrls: ['https://testnet.sapphire.oasis.io/'],
+  nativeCurrency: {
+    name: 'Oasis TEST',
+    symbol: 'TEST',
+    decimals: 18,
+  },
+  blockExplorerUrls: ['https://explorer.oasis.io/testnet/sapphire'],
+  iconUrls: [
+    'https://assets.oasis.io/logotypes/metamask-oasis-sapphire-testnet.png',
+  ],
   runtimeId:
     '0x000000000000000000000000000000000000000000000000a6d1e3ebf60dff6c',
 };


### PR DESCRIPTION
We have the "Add Sapphire network to Metamask" in the growing number of places (docs, faucet, all the dApps). Since most of those apps explicitly or implicitly import `@oasisprotocol/sapphire-paratime`, let's unify the network details in a single place.

For now, I made it compatible with https://docs.metamask.io/wallet/reference/json-rpc-methods/wallet_addethereumchain/ so one can directly use it in the UI.

But there seems to be some other competing formats:
- ethers Network object: https://docs.ethers.org/v6/api/providers/#Network
- ethereum chains https://github.com/ethereum-lists/chains/blob/master/tools/schema/chainSchema.json