### PR TITLE
clients/py: Prepare 0.4.0 release

### DIFF
--- a/clients/py/CHANGELOG.md
+++ b/clients/py/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.4.0 (2025-04-03)
+
+### Fixed
+- Fixed Python client compatibility with web3.py version 7.x by:
+  - Adding async/await support for AsyncWeb3 client
+  - Adding proper type annotations for signed_call_data using AttributeDict
+  - Implementing async middleware for the Sapphire client
+
+### Changed
+- Changed web3.py version requirement to web3==7.*
+- No backwards compatibility, web3 version 6.x and lower will throw an error
+  when using sapphirepy wrapper
+
+## 0.3.0
+
+- Initial public release based on web3.py version 6

--- a/clients/py/setup.py
+++ b/clients/py/setup.py
@@ -28,6 +28,6 @@ setup(
     packages=find_packages(include=["sapphirepy"]),
     install_requires=REQUIREMENTS,
     url="https://github.com/oasisprotocol/sapphire-paratime",
-    version="0.3.0",
+    version="0.4.0",
     zip_safe=True,
 )


### PR DESCRIPTION
This PR:
- adds CHANGELOG.md to clients/py wrapper library
- updates version from 0.3.0 to 0.4.0 in clients/py/setup.py