### PR TITLE
Change package name to oasis-sapphire-py

### DIFF
--- a/clients/py/setup.py
+++ b/clients/py/setup.py
@@ -19,7 +19,7 @@ setup(
         "Typing :: Typed"
     ],
     description="Oasis Sapphire encryption middleware for Web3.py",
-    name="sapphire.py",
+    name="oasis-sapphire-py",
     license="Apache Software License 2.0",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Change package name (sapphire.py -> oasis-sapphire-py) to allow upload to [PyPI](https://pypi.org/project/oasis-sapphire-py/#description).

Issue: https://github.com/oasisprotocol/sapphire-paratime/issues/561

The import still works the same `import sapphirepy`.