### PR TITLE
Add checkout action to soldeer CI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -72,6 +72,7 @@ jobs:
     needs: publish
     if: startsWith(github.ref_name, 'contracts/v')
     steps:
+      - uses: actions/checkout@v4
       - name: Extract version from tag
         id: extract-tag-version
         env:
@@ -85,13 +86,15 @@ jobs:
           toolchain: stable
       - name: Install soldeer
         run: cargo install soldeer
-      - name: Set soldeer access token
+      - name: Login to Soldeer
         env:
-          SOLDEER_AUTH_TOKEN: ${{ secrets.SOLDEER_TOKEN }}
-        run: |
-          mkdir -p ~/.soldeer && echo "$SOLDEER_AUTH_TOKEN" > ~/.soldeer/.soldeer_login
+          SOLDEER_EMAIL: ${{ secrets.SOLDEER_EMAIL }}
+          SOLDEER_PASSWORD: ${{ secrets.SOLDEER_PASSWORD }}
+        run: soldeer login --email "$SOLDEER_EMAIL" --password "$SOLDEER_PASSWORD"
       - name: Publish to Soldeer
-        run: soldeer push @oasisprotocol-sapphire-contracts~$CONTRACTS_VERSION
+        run: |
+          echo "Publishing version: ${{ steps.extract-tag-version.outputs.CONTRACTS_VERSION }}"
+          soldeer push @oasis-sapphire-contracts~${{ steps.extract-tag-version.outputs.CONTRACTS_VERSION }}
         working-directory: contracts/contracts
 
   publish-py:


### PR DESCRIPTION
This PR fixes: 
- `publish-contracts-soldeer` job error in publish.yaml. 
- Token expiration issue

Missing `actions/checkout@v4` resulted in combined working directory paths (/home/runner/work/**sapphire-paratime/sapphire-paratime**/contracts/contracts)

Soldeer API token expires after 1 month which makes it unsuitable as a github secret. The soldeer CI/CD has been updated to use email/password combination.

Fix: Added `actions/checkout@v4` to `publish-contracts-soldeer`.

Fixes https://github.com/oasisprotocol/sapphire-paratime/issues/561