### PR TITLE
Update dappwright dependency and enhance e2e tests for wallet account switching

### DIFF
--- a/examples/wagmi-v2/package.json
+++ b/examples/wagmi-v2/package.json
@@ -19,7 +19,7 @@
 		"@oasisprotocol/sapphire-wagmi-v2": "workspace:^",
 		"@playwright/test": "^1.48.2",
 		"@tanstack/react-query": "5.0.5",
-		"@tenkeylabs/dappwright": "^2.8.6",
+		"@tenkeylabs/dappwright": "^2.10.0",
 		"abitype": "^1.0.2",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",


### PR DESCRIPTION
This pull request includes updates to the `examples/wagmi-v2` project to improve the test suite and update dependencies. The most important changes include updating the `@tenkeylabs/dappwright` dependency and enhancing the end-to-end test script to handle page navigation and account switching more robustly.

Dependency updates:

* [`examples/wagmi-v2/package.json`](diffhunk://#diff-f7d8de0ffe97f6e81f56d48f2a99b5cc11f198833d91ec1eab9b98f75ec0a3b9L22-R22): Updated `@tenkeylabs/dappwright` dependency from version `^2.8.6` to `^2.10.0` which includes the fix for account selection by name
* Fixed MetaMask version to 12.10.4 to address issues with enabling testing networks during CI setup. See [TenKeyLabs/dappwright#426](https://github.com/TenKeyLabs/dappwright/issues/426) for details.

Enhancements to end-to-end tests:

* [`examples/wagmi-v2/test/e2e.spec.ts`](diffhunk://#diff-578b624e962f99f2e8735a93941a56c29263a50a33bf6a445c271d3e236de2aaL30-R94): Changed account selection from numeric index to account name (`wallet.switchAccount("Alice")`), based on the fix in [Dappwright PR #440](https://github.com/TenKeyLabs/dappwright/pull/440). This change resolves the issue where account switching would get stuck on the account selection screen.
* [`examples/wagmi-v2/test/e2e.spec.ts`](diffhunk://#diff-578b624e962f99f2e8735a93941a56c29263a50a33bf6a445c271d3e236de2aaL30-R94): Added logic to store the current URL and handle potential page closures by reopening and navigating back to the application URL if necessary. This ensures the test continues even if the page is closed during the process.