### PR TITLE
integrations/wagmi-v2: Prepare 2.1.0 release

### DIFF
--- a/integrations/wagmi-v2/CHANGELOG.md
+++ b/integrations/wagmi-v2/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is inspired by [Keep a Changelog].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 
+## 2.1.0 (2025-04)
+
+### Added
+
+- EIP-6963 support
+
 ## 2.0.0-next.1 (2024-08)
 
 ### Fixed

--- a/integrations/wagmi-v2/package.json
+++ b/integrations/wagmi-v2/package.json
@@ -2,7 +2,7 @@
 	"type": "module",
 	"name": "@oasisprotocol/sapphire-wagmi-v2",
 	"license": "Apache-2.0",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "Wagmi & Viem support for the Oasis Sapphire ParaTime.",
 	"homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/wagmi-v2",
 	"repository": {


### PR DESCRIPTION
Fixes #563 

Merge after https://github.com/oasisprotocol/internal/issues/64 is fixed.

May also wait for https://github.com/oasisprotocol/sapphire-paratime/pull/565 or make a 2.1.1 bugfix release afterwards.