### PR TITLE
Remove --no-commit flag

### DIFF
--- a/examples/foundry/Makefile
+++ b/examples/foundry/Makefile
@@ -2,7 +2,7 @@
 all: build test
 
 build:
-	forge install foundry-rs/forge-std --no-commit --no-git
+	forge install foundry-rs/forge-std --no-git
 	cd lib/oasisprotocol-sapphire-foundry/precompiles && cargo +nightly build --release
 
 test:

--- a/integrations/foundry/Makefile
+++ b/integrations/foundry/Makefile
@@ -2,7 +2,7 @@
 all: build test
 
 build:
-	forge install foundry-rs/forge-std --no-commit --no-git
+	forge install foundry-rs/forge-std --no-git
 	cd lib/oasisprotocol-sapphire-foundry/precompiles && cargo +nightly build --release
 
 test:


### PR DESCRIPTION
This PR fixes following issue:

- `--no-commit` flag was updated to `--commit` in new foundry version, so we can remove it from the CI