### PR TITLE
Update eth_getStorageAt docs with whitelisted storage slots

### DIFF
--- a/docs/develop/deployment.md
+++ b/docs/develop/deployment.md
@@ -44,11 +44,16 @@ contracts easier.
 
 While the underlying proxy implementations in EIP-1822 work perfectly in
 facilitating smart contract upgrades, the tools typically used to manage these
-proxies may not function as expected on Oasis Sapphire.
-For example, the [openzeppelin-upgrades] library, which relies on the EIP-1967
-standard, uses [eth_getStorageAt] to access contract storage. This function
-does not work in a confidential environment which forbids direct storage
-access.
+proxies may still face limitations on Oasis Sapphire.
+
+As of now, only the following well-known EIP-1967 slots are readable via
+`eth_getStorageAt`, enabling compatibility with most proxy tooling:
+
+- Proxy implementation address
+- Beacon proxy implementation
+- Admin slot
+
+Access to all other storage remains restricted in the confidential environment.
 
 Additionally, Sapphire natively protects against replay and currently does not
 allow an empty chain ID à la pre [EIP-155] transactions.

--- a/docs/ethereum.mdx
+++ b/docs/ethereum.mdx
@@ -34,7 +34,15 @@ but with the further restriction that not even full nodes can read the values.
 Public or access-controlled values are provided instead through explicit
 getters.
 
-Calling `eth_getStorageAt()` will return zero.
+Calling `eth_getStorageAt()` will return zero for all storage slots, **except**
+for the following well-known [EIP-1967] proxy-related slots, which remain
+readable to support compatibility with standard tooling:
+
+- `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc` — Proxy implementation address
+- `0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50` — Beacon proxy implementation
+- `0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103` — Admin slot
+
+[EIP-1967]: https://eips.ethereum.org/EIPS/eip-1967
 
 ## End-to-End Encrypted Transactions and Calls
 


### PR DESCRIPTION
Merge once Sapphire with https://github.com/oasisprotocol/oasis-sdk/pull/2215 is live.