### PR TITLE
docs: Ignore tests/auth from solidity docs

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,4 +1,4 @@
 [doc]
 out = "sol/sapphire-contracts"
 title = "Sapphire Contracts Lib"
-ignore = ["contracts/tests/*"]
+ignore = ["contracts/tests/*", "contracts/tests/auth/*"]


### PR DESCRIPTION
Just ignoring `contracts/tests/*` is not sufficient. You need to put any subfolders in it too e.g. `contracts/tests/auth/*`. Double asterisk is not supported yet by foundry.