### PR TITLE
Try to fail foundry due to wrong EVM version

### DIFF
--- a/examples/foundry/src/Counter.sol
+++ b/examples/foundry/src/Counter.sol
@@ -17,4 +17,8 @@ contract Counter is SapphireDecryptor {
     function withdraw() external {
         payable(msg.sender).transfer(address(this).balance);
     }
+
+    function thisCompilesToPush0AndShouldDetectWrongEvmVersion() public pure returns (bool) {
+        return false; // This will compile to PUSH0 in new unsupported EVM versions
+    }
 }


### PR DESCRIPTION
https://github.com/oasisprotocol/sapphire-paratime/blob/052e6df2acc6fa1e08529b4f79900a4918b9f4a4/examples/foundry/foundry.toml#L1-L7 

doesn't specify evm version (https://github.com/oasisprotocol/demo-rofl-chatbot/pull/17), and

https://github.com/oasisprotocol/sapphire-paratime/blob/052e6df2acc6fa1e08529b4f79900a4918b9f4a4/.github/workflows/contracts-test.yaml#L66

seems to use a latest stable version of foundry, so this should fail