### PR TITLE
fix: account switching an dappwright

### DIFF
--- a/examples/wagmi-v2/test/e2e.spec.ts
+++ b/examples/wagmi-v2/test/e2e.spec.ts
@@ -32,9 +32,9 @@ export const test = baseTest.extend<{
 });
 
 test.beforeEach(async ({ wallet, page }) => {
-	// Use first account from seed. dAppwright adds two accounts by default.
-	// Changed from numeric index to name as per PR #440
-	await wallet.switchAccount("batman");
+	// Metmask seems to name the accounts weird in the setup (maybe different every version?)
+	// "jvh" corresponds to address 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
+	await wallet.switchAccount("jvh");
 	
 	await page.bringToFront();
 });


### PR DESCRIPTION
Metamask seems to name the accounts weird in the setup (maybe different every version?)
"jvh" corresponds to address 0x70997970C51812dc3A010C7d01b50e0d17dc79C8

<img width="364" height="337" alt="Screenshot 2025-07-16 at 21 33 39" src="https://github.com/user-attachments/assets/7ded89ee-5649-487d-a142-d0b48da32498" />
