### PR TITLE
docs: Add tutorial on encrypted events and examples for Sapphire

### DIFF
--- a/docs/develop/concept.mdx
+++ b/docs/develop/concept.mdx
@@ -101,6 +101,12 @@ do instead is fork that contract and remove the offending emissions.
 
 :::
 
+:::tip Encrypted events
+
+To keep event payloads confidential while retaining indexability and triggers, see [Encrypted Events](./encrypted-events.mdx).
+
+:::
+
 ## See also
 
 <DocCard item={findSidebarItem('/build/sapphire/ethereum')} />

--- a/docs/develop/encrypted-events.mdx
+++ b/docs/develop/encrypted-events.mdx
@@ -1,0 +1,335 @@
+---
+title: Encrypted Events
+description: Emit confidential event data on Sapphire that only specific users can read, while keeping logs indexable.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import DocCard from '@theme/DocCard';
+import { findSidebarItem } from '@site/src/sidebarUtils';
+
+On standard blockchains, all event data is public. Oasis Sapphire's
+confidential EVM allows you to encrypt an event's **payload**, keeping
+sensitive data private while the event topics remain public for indexing and
+off-chain triggers. This unlocks powerful new use cases for dApps that need to
+log private information.
+
+In this chapter, you'll learn **three** patterns for encrypting event data:
+
+1. **[Passing a Symmetric Key](#pattern-1-passing-a-symmetric-key):** A client
+   passes a secret key directly to the contract in an encrypted transaction.
+2. **[Deriving a Symmetric Key (ECDH)](#pattern-2-deriving-a-symmetric-key-ecdh):**
+   The contract and client use Elliptic Curve Diffie-Hellman (ECDH) to derive
+   a shared secret key.
+3. **[On‑chain Key Generation (ROFL‑friendly)](#pattern-3-on-chain-key-generation-rofl-friendly):**
+   The contract generates a symmetric key on-chain and exposes a guarded
+   public function intended for ROFL-based consumers.
+
+We'll cover the on-chain smart contract logic and the off-chain decryption
+process. A full working example is available inside the
+**[Sapphire Examples][encrypted-events-example]** folder.
+
+## How it Works: Basic Concept
+
+To emit the encrypted event you need to **define an event**,
+**generate a nonce**, **encrypt the text** with
+additional authenticated data (AAD), and finally **emit the ciphertext**.
+How you obtain the key is covered in the specific pattern subsection below.
+
+### The `Encrypted` Event
+
+Define a standard event signature in your contract. This structure is shared by
+all patterns.
+
+```solidity
+// In your contract
+event Encrypted(address indexed sender, bytes32 nonce, bytes ciphertext);
+```
+
+- `sender`: The address that initiated the encryption. Indexing it helps in
+  filtering events.
+- `nonce`: A unique number used once per encryption with a given key. **Never
+  reuse a key/nonce pair!**
+- `ciphertext`: The encrypted data payload.
+
+### On-Chain Encryption
+
+Sapphire provides a precompile for encryption. The basic flow inside a contract
+function is:
+
+1. **Get a Nonce:** Generate a fresh, random nonce for each encryption with
+   [`Sapphire.randomBytes`]. Passing a domain separator is good practice.
+
+   ```solidity
+   // A 32-byte nonce for Deoxys-II, which uses the first 15 bytes
+   bytes32 nonce = bytes32(Sapphire.randomBytes(32, bytes("my-dapp-nonce")));
+   ```
+
+2. **Encrypt the Data:** Use [`Sapphire.encrypt`] with a key, the nonce, your
+   text (plaintext), and additional authenticated data.
+
+   ```solidity
+   // Keep names identical to the library
+   bytes memory ad = "additional data";
+   bytes memory encrypted = Sapphire.encrypt(key, nonce, text, ad);
+   ```
+
+3. **Emit the Event:**
+
+   ```solidity
+   emit Encrypted(msg.sender, nonce, encrypted);
+   ```
+
+### Off-Chain Decryption
+
+To read the secret text, an off-chain client with the correct key listens for
+`Encrypted` events and decrypts the `ciphertext`.
+
+```typescript
+import { AEAD, NonceSize } from '@oasisprotocol/deoxysii';
+import { ethers } from 'ethers';
+
+// You need:
+// - key: A Uint8Array(32) symmetric key
+// - nonceFromEvent: The 'nonce' field from the event log
+// - ciphertextFromEvent: The 'ciphertext' field from the event log
+// - ad: AAD bytes if used on-chain (a.k.a. "authenticated data")
+
+const aead = new AEAD(key);
+
+const plaintext = aead.decrypt(
+  // IMPORTANT: Deoxys-II uses a 15-byte nonce.
+  // We slice the first 15 bytes from the 32-byte value stored on-chain.
+  ethers.getBytes(nonceFromEvent).slice(0, NonceSize),
+  ethers.getBytes(ciphertextFromEvent),
+  ad,
+);
+
+console.log('Decrypted message:', ethers.toUtf8String(plaintext));
+```
+
+## Pattern 1: Passing a Symmetric Key
+
+This is the simplest approach. The client generates a 32‑byte symmetric key and
+passes it to the smart contract as an argument inside the encrypted
+transaction.
+
+### TypeScript: generate a `bytes32` key
+
+<Tabs>
+  <TabItem value="ethers" label="Ethers" default>
+
+```ts
+import { ethers } from 'ethers';
+
+const key = ethers.randomBytes(32); // Uint8Array
+const keyHex = ethers.hexlify(key) as `0x${string}`; // for contract calls
+
+// Pass keyHex directly to a Solidity function taking `bytes32 key`.
+// Use the `key` (Uint8Array) for off-chain decryption.
+```
+
+  </TabItem>
+  <TabItem value="node" label="Node.js">
+
+```ts
+import { ethers } from 'ethers';
+import { randomBytes } from 'crypto';
+
+const key = randomBytes(32); // Buffer, compatible with Uint8Array
+const keyHex = ethers.hexlify(key) as `0x${string}`; // for contract calls
+
+// Pass keyHex directly to a Solidity function taking `bytes32 key`.
+// Use the `key` (Buffer) for off-chain decryption.
+```
+
+  </TabItem>
+</Tabs>
+
+### Contract Implementation
+
+The function takes the key and the text, encrypts, and emits the event.
+
+```solidity title="EncryptedEvents.sol"
+import { Sapphire } from "@oasisprotocol/sapphire-contracts/contracts/Sapphire.sol";
+
+contract EncryptedEvents {
+    event Encrypted(address indexed sender, bytes32 nonce, bytes ciphertext);
+
+    function emitEncrypted(bytes32 key, bytes calldata text) external {
+        bytes32 nonce = bytes32(Sapphire.randomBytes(32, bytes("my-dapp-nonce")));
+        bytes memory ad = bytes(""); // optional AAD
+        bytes memory encrypted = Sapphire.encrypt(key, nonce, text, ad);
+        emit Encrypted(msg.sender, nonce, encrypted);
+    }
+}
+```
+
+The off-chain client is responsible for managing this key and using it for
+decryption as shown above.
+
+## Pattern 2: Deriving a Symmetric Key (ECDH)
+
+In this more advanced pattern, you don't send a key with every transaction.
+Instead, the contract holds a long‑lived Curve25519 secret key (in
+confidential state), and a shared secret is **derived on‑chain** from the
+caller’s public key using X25519 (ECDH).
+
+### Contract Implementation (ECDH)
+
+1. **Generate a Keypair:** In the constructor, generate a Curve25519 keypair and
+   store the secret key in confidential state. The public key can be exposed
+   for clients.
+
+   ```solidity title="EncryptedEventsECDH.sol"
+   contract EncryptedEventsECDH {
+       Sapphire.Curve25519SecretKey private _contractSk;
+       Sapphire.Curve25519PublicKey public contractPk;
+
+       constructor() {
+           (Sapphire.Curve25519PublicKey pk, Sapphire.Curve25519SecretKey sk) =
+               Sapphire.generateCurve25519KeyPair(bytes(""));
+           contractPk = pk;
+           _contractSk = sk;
+       }
+       // ...
+   }
+   ```
+
+2. **Derive and Encrypt:** The emit function now takes the caller's public key,
+   derives the shared key, encrypts the text, and emits the event.
+
+   ```solidity title="EncryptedEventsECDH.sol"
+   function emitEncryptedECDH(
+       Sapphire.Curve25519PublicKey callerPublicKey,
+       bytes calldata text
+   ) external {
+       // Derive the shared symmetric key
+       bytes32 key = Sapphire.deriveSymmetricKey(callerPublicKey, _contractSk);
+
+       // Encrypt and emit as before
+       bytes32 nonce = bytes32(Sapphire.randomBytes(32, bytes("my-dapp-nonce")));
+       bytes memory ad = bytes(""); // optional AAD
+       bytes memory encrypted = Sapphire.encrypt(key, nonce, text, ad);
+       emit Encrypted(msg.sender, nonce, encrypted);
+   }
+   ```
+
+### Off-Chain Key Derivation
+
+The client derives the shared key from its **secret** and the contract’s
+**public** key.
+
+```typescript
+import { mraeDeoxysii } from '@oasisprotocol/client-rt';
+import { AEAD } from '@oasisprotocol/deoxysii';
+import { ethers } from 'ethers';
+
+// contractPkHex: 0x-prefixed Curve25519 public key (bytes32) fetched on-chain
+// callerSkBytes: Uint8Array(32) caller's Curve25519 secret key
+const sharedKey = mraeDeoxysii.deriveSymmetricKey(
+  ethers.getBytes(contractPkHex),
+  callerSkBytes,
+);
+
+const aead = new AEAD(sharedKey);
+// ... decrypt with aead.decrypt() as shown earlier.
+```
+
+### Recommended: Bind Ciphertext with AAD
+
+**Additional Authenticated Data (AAD)** binds a ciphertext to its context. If
+the bytes don’t match during decryption, it fails. Provide the **same bytes**
+to [`Sapphire.encrypt`] on-chain (as `ad`) and to `AEAD.decrypt` off-chain (as
+`adBytes`).
+
+#### Option A: Sender‑Bound AAD
+
+Bind to `msg.sender` (useful for user-specific data).
+
+- **On-Chain AAD:** `bytes memory ad = abi.encodePacked(msg.sender);`
+- **Off-Chain AAD:** Get the `sender` from the event log and convert to bytes.
+
+  ```typescript
+  const adBytes = ethers.getBytes(senderAddress); // 20 bytes
+  ```
+
+#### Option B: Context‑Bound AAD
+
+Bind to the (chain, contract). This is relayer‑agnostic.
+
+- **On-Chain AAD:** `bytes memory ad = abi.encodePacked(block.chainid, address(this));`
+- **Off-Chain AAD:** Reconstruct the same packed bytes.
+
+  ```typescript
+  const { chainId } = await provider.getNetwork();
+  const adBytes = ethers.getBytes(
+    ethers.solidityPacked(['uint256', 'address'], [chainId, contractAddress]),
+  );
+  ```
+
+## Pattern 3: On-chain Key Generation (ROFL-friendly)
+
+For **ROFL** containers and similar trusted off-chain compute, you may prefer
+to **generate the symmetric key on-chain** and expose a **guarded** public
+function that encrypts and emits events. The ROFL worker fetches events and
+uses its corresponding secret material to decrypt.
+
+<DocCard item={findSidebarItem('/build/rofl/')} />
+
+### Contract Sketch
+
+```solidity title="EncryptedEventsROFL.sol"
+import {Sapphire} from "@oasisprotocol/sapphire-contracts/contracts/Sapphire.sol";
+
+contract EncryptedEventsROFL {
+    event Encrypted(address indexed sender, bytes32 nonce, bytes ciphertext);
+
+    // IMPORTANT: This is a sketch. Do **not** deploy this contract as-is.
+    // Replace this with a real ROFL/OPL authorization scheme (e.g., allowlist,
+    // appd/attestation checks, marketplace‑managed identities, etc.).
+    address public roflApp; // set to your ROFL app's address in your deployment flow
+
+    modifier onlyROFL() {
+        require(msg.sender == roflApp, "only ROFL app");
+        _;
+    }
+
+    function emitWithOnchainKey(bytes calldata text) external onlyROFL {
+        // 1) Generate a fresh symmetric key on-chain (per call or per session)
+        bytes32 key = bytes32(Sapphire.randomBytes(32, bytes("rofl:onchain:key")));
+
+        // 2) Encrypt with optional context-binding AAD
+        bytes32 nonce = bytes32(Sapphire.randomBytes(32, bytes("rofl:nonce")));
+        bytes memory ad = abi.encodePacked(block.chainid, address(this));
+        bytes memory encrypted = Sapphire.encrypt(key, nonce, text, ad);
+
+        // 3) Emit
+        emit Encrypted(msg.sender, nonce, encrypted);
+
+        // Optionally: persist or wrap `key` for ROFL retrieval using your chosen scheme.
+        // Do NOT emit or log secrets in production.
+    }
+}
+```
+
+## Important Notes
+
+- **Carefully store the secret key**: Keep the key **inside** the
+  contract/state or wrap it for ROFL; never emit it.
+- **Replay attacks**: Always use [AAD](#recommended-bind-ciphertext-with-aad)
+  to bind ciphertexts to contract/chain or sender.
+- **ROFL key derivation**: If you're deriving event encryption keys inside
+  ROFL, ensure the derivation mirrors your on-chain logic.
+
+:::example Encrypted Events
+
+See the **[Encrypted Events Demo][encrypted-events-example]** example folder
+for end-to-end Hardhat tasks to deploy, emit, and decrypt events using the
+patterns above, plus tests and a step-by-step tutorial.
+
+:::
+
+[`Sapphire.encrypt`]: https://api.docs.oasis.io/sol/sapphire-contracts/contracts/Sapphire.sol/library.Sapphire.html#encrypt-1
+[`Sapphire.randomBytes`]: https://api.docs.oasis.io/sol/sapphire-contracts/contracts/Sapphire.sol/library.Sapphire.html#randombytes
+[encrypted-events-example]: https://github.com/oasisprotocol/sapphire-paratime/tree/main/examples/encrypted-events

--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -4,6 +4,17 @@ description: Examples built with Sapphire
 
 # Examples
 
+## Encrypted Events
+
+<table>
+  <tr>
+    <td> **[Encrypted Events][encrypted-events-example]** </td>
+    <td>
+      A minimal example of emitting confidential events on Oasis Sapphire.
+    </td>
+  </tr>
+</table>
+
 ## Randomness
 
 <table>
@@ -31,7 +42,7 @@ description: Examples built with Sapphire
 <table>
   <tr>
     <td> **[SIWE authentication][siwe-example]** </td>
-    <td> An dApp witch uses Sign in with Ethereum (SIWE) for authentication. </td>
+    <td> A dApp which uses Sign in with Ethereum (SIWE) for authentication. </td>
   </tr>
 </table>
 
@@ -53,4 +64,5 @@ Find more examples, including the unofficial ones, on [playground.oasis.io].
 [voTEE.oasis.io]: https://votee.oasis.io
 [siwe-example]: https://github.com/oasisprotocol/demo-starter
 [onchain-signer]: https://github.com/oasisprotocol/sapphire-paratime/tree/main/examples/onchain-signer
+[encrypted-events-example]: https://github.com/oasisprotocol/sapphire-paratime/tree/main/examples/encrypted-events
 [playground.oasis.io]: https://playground.oasis.io

--- a/examples/encrypted-events/.env.example
+++ b/examples/encrypted-events/.env.example
@@ -1,0 +1,2 @@
+# Copy to `.env` and insert your own 0x-prefixed private key
+PRIVATE_KEY="0xYOUR_PRIVATE_KEY_HERE"

--- a/examples/encrypted-events/.gitignore
+++ b/examples/encrypted-events/.gitignore
@@ -1,0 +1,17 @@
+node_modules
+.env
+
+# Hardhat files
+/cache
+/artifacts
+
+# TypeChain files
+/typechain
+/typechain-types
+
+# solidity-coverage files
+/coverage
+/coverage.json
+
+# Hardhat Ignition default folder for deployments against a local node
+ignition/deployments/chain-31337

--- a/examples/encrypted-events/Makefile
+++ b/examples/encrypted-events/Makefile
@@ -1,0 +1,17 @@
+NPM ?= pnpm
+
+all: build test
+
+build:
+	$(NPM) $@
+
+test: build
+	$(NPM) $@
+
+clean:
+	rm -rf artifacts cache typechain typechain-types
+
+distclean: clean
+	rm -rf node_modules
+
+.PHONY: all build test clean distclean

--- a/examples/encrypted-events/README.md
+++ b/examples/encrypted-events/README.md
@@ -1,0 +1,222 @@
+# Encrypted Events Demo (Oasis Sapphire)
+
+Minimal, production‑ready patterns for emitting **confidential** events on
+Sapphire and decrypting them off‑chain.
+
+- **Event:** `event Encrypted(address indexed sender, bytes32 nonce, bytes ciphertext);`
+- **AEAD:** Deoxys‑II (`NonceSize = 15`); we store a 32‑byte nonce on‑chain
+  and use only the first 15 bytes for decryption.
+- **Two flows**
+  - **A — Key in tx (default):** pass a 32‑byte symmetric key in an
+    **encrypted** tx.
+  - **B — On‑chain ECDH:** derive the symmetric key via X25519 between
+    caller and contract.
+
+## Requirements
+
+- Node 18+
+- Docker (for Localnet)
+- Git
+
+## 1) Start Sapphire Localnet
+
+```bash
+docker run -it -p8544-8548:8544-8548 ghcr.io/oasisprotocol/sapphire-localnet
+# On Apple Silicon, add: --platform linux/x86_64  (if the image lacks arm64)
+```
+
+## 2) Install Dependencies
+
+This example is part of the `sapphire-paratime` monorepo. From this
+directory (`examples/encrypted-events`), run:
+
+```bash
+pnpm install
+cp .env.example .env   # paste a 0x‑prefixed private key
+
+pnpm build
+# (Optional) Better typings for overloads:
+pnpm run build:types    # runs hardhat compile + typechain
+```
+
+## 3) Flow A — Key in the (encrypted) tx
+
+> Only on Sapphire. Passing a raw key in calldata is safe only on Sapphire
+> networks because the Sapphire wrappers encrypt tx/calls. Do not use this
+> pattern on non‑Sapphire chains.
+
+### On Localnet (deploy, emit, decrypt)
+
+```bash
+# Deploy
+npx hardhat deploy --network sapphire-localnet
+# copy printed address to $ADDR  (this is the CONTRACT address, not a tx hash)
+
+# Emit (prints the symmetric key). Select AAD if desired:
+#   --aadmode none|sender|context
+# Tip: provide --key to reuse the same key across emit & decrypt.
+npx hardhat emit --network sapphire-localnet \
+  --mode key --contract $ADDR \
+  --message "secret" [--key <HEX32>] [--aadmode sender|context]
+
+# Decrypt a past tx by hash (add --aadmode if you used it when emitting)
+# (In key mode, --contract is optional; pass it to disambiguate if the tx
+# has multiple logs.)
+npx hardhat decrypt --network sapphire-localnet \
+  --mode key [--contract $ADDR] \
+  --tx <TX_HASH> --key <PRINTED_OR_PROVIDED_KEY> [--aadmode sender|context]
+```
+
+### Live Listen (Testnet/Mainnet only)
+
+Live event listening requires RPC support for log filters/subscriptions, which
+**sapphire-localnet does not currently support**. To test `listen`, deploy on Testnet:
+
+```bash
+# Deploy on Testnet
+npx hardhat deploy --network sapphire-testnet
+# copy printed address to $ADDR
+
+# Live listen & decrypt (stays open until Ctrl‑C; add --aadmode if you used it)
+npx hardhat listen --network sapphire-testnet \
+  --mode key --contract $ADDR \
+  --key <HEX32> [--aadmode sender|context]
+```
+
+### Quickest test (two terminals, Testnet)
+
+Terminal A – listener
+
+```bash
+# First deploy on testnet and copy the address
+npx hardhat deploy --network sapphire-testnet
+export ADDR=<DEPLOYED_ADDRESS>
+export KEY=0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+npx hardhat listen --network sapphire-testnet \
+  --mode key --contract $ADDR --key $KEY
+```
+
+Terminal B – emitter
+
+```bash
+npx hardhat emit --network sapphire-testnet \
+  --mode key --contract $ADDR --message "secret" --key $KEY
+```
+
+**Expected:** Terminal A prints `Decrypted: secret`.
+
+**Tip:** `--contract` is **always** a contract address (0x…), not a tx hash.
+
+## 4) Flow B — On‑chain ECDH (X25519)
+
+### ECDH on Localnet (deploy, emit, decrypt)
+
+```bash
+# Deploy (prints the contract's Curve25519 public key)
+npx hardhat deploy-ecdh --network sapphire-localnet
+# copy printed address to $ADDR
+
+# Emit (generates an ephemeral caller keypair; DEMO prints the SECRET).
+# Select AAD if desired: --aadmode none|sender|context
+# Tip: provide --secret to reuse the same caller secret across emit & decrypt.
+npx hardhat emit --network sapphire-localnet \
+  --mode ecdh --contract $ADDR \
+  --message "secret" [--secret <HEX32>] [--aadmode sender|context]
+
+# Decrypt a past tx (ECDH — needs the contract to fetch its public key)
+npx hardhat decrypt --network sapphire-localnet \
+  --mode ecdh --contract $ADDR \
+  --tx <TX_HASH> --secret <HEX32> [--aadmode sender|context] [--hkdf]
+```
+
+### ECDH Live Listen (Testnet/Mainnet only)
+
+```bash
+# Deploy on Testnet first
+npx hardhat deploy-ecdh --network sapphire-testnet
+# copy printed address to $ADDR
+
+# Live listen & decrypt using the provided/printed caller SECRET
+# (add --aadmode if you used it)
+# Optional: --hkdf for per-message keys (requires a matching on-chain variant).
+npx hardhat listen --network sapphire-testnet \
+  --mode ecdh --contract $ADDR \
+  --secret <HEX32> [--aadmode sender|context] [--hkdf]
+```
+
+**IMPORTANT (ECDH):** Off‑chain, derive the AEAD key from the X25519 keys
+using the **official SDK helper**:
+
+```ts
+import { mraeDeoxysii } from '@oasisprotocol/client-rt';
+// contractPublic: Uint8Array(32), callerSecret: Uint8Array(32)
+const key = mraeDeoxysii.deriveSymmetricKey(contractPublic, callerSecret);
+const aead = new AEAD(key);
+```
+
+This mirrors Sapphire’s on‑chain derivation.
+
+## Tests
+
+Run against Localnet (the tests skip on non‑Sapphire networks):
+
+```bash
+pnpm test
+# or: npx hardhat test --network sapphire-localnet
+```
+
+## How it Works
+
+The core logic is:
+
+1. **Nonce**: `bytes32 n = bytes32(Sapphire.randomBytes(32, ...));`
+2. **Encrypt**: `bytes c = Sapphire.encrypt(key, n, message, aad);`
+3. **Emit**: `emit Encrypted(msg.sender, n, c);`
+4. **Decrypt**: Use `@oasisprotocol/deoxysii` off-chain.
+
+**Nonce size:** Deoxys‑II uses a **120‑bit (15 bytes)** nonce. We store 32
+bytes on chain and slice only the first 15 bytes for decryption.
+
+**Gas note:** If you emit a **non‑indexed** `bytes15 nonce` instead of
+`bytes32`, you save ~136 gas per event. We keep `bytes32` for simplicity and
+future derivations.
+
+## Best Practices & Tips
+
+- **AAD modes**: Bind ciphertext to context. AAD bytes must match exactly
+  between encryption and decryption.
+
+  - `sender`: `abi.encodePacked(msg.sender)`. Use the emitted `sender`
+    (20 bytes). Relayer-aware.
+  - `context`: `abi.encodePacked(block.chainid, address(this))`. Use
+    `solidityPacked(["uint256","address"], [chainId, contractAddr])`.
+    Relayer-agnostic.
+  - `none`: No authenticity binding (simplest).
+
+- **HKDF option:** For ECDH mode, if you pass `--hkdf`, the listener/decrypt
+  script will derive a per‑message key from `(ECDH shared key, nonce)`
+  using HKDF. Your **contract must encrypt with the same HKDF** or
+  decryption will fail. The demo contracts do **not** apply HKDF on-chain.
+
+- **Nonce personalization**: Use a domain separator for nonce generation to
+  prevent collisions, e.g., `Sapphire.randomBytes(32, bytes("MyDapp:nonce"))`.
+
+- **Index wisely**: Indexing `sender` is useful for filtering. Indexing a
+  random nonce is not.
+
+- **Security:**
+
+  - **Never reuse `(key, nonce)`**. Always use a fresh random nonce.
+  - **Do not log secrets** (keys or Curve25519 secret keys) in production.
+    This demo prints them for convenience.
+  - **Plaintext length leaks size**. If sensitive, pad to a fixed size
+    client‑side before encrypting.
+  - **Events are permanent.** Emit only what can remain confidential long-term.
+  - **Testnet is not production.** Confidentiality is not guaranteed.
+
+- **Listeners stay open** until you press **Ctrl‑C**.
+
+- **Ethers listeners**: Receive `(sender, nonce, ciphertext, event)`. You
+  can also read the indexed `sender` from `event.args.sender`.
+
+## License: Apache-2.0

--- a/examples/encrypted-events/contracts/EncryptedEvents.sol
+++ b/examples/encrypted-events/contracts/EncryptedEvents.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.24;
+
+import {Sapphire} from "@oasisprotocol/sapphire-contracts/contracts/Sapphire.sol";
+
+/**
+ * @title EncryptedEvents
+ * @notice Minimal example of emitting confidential events on Oasis Sapphire.
+ *
+ * Event includes the sender (indexed) for easier filtering and AAD binding.
+ */
+contract EncryptedEvents {
+    event Encrypted(address indexed sender, bytes32 nonce, bytes ciphertext);
+
+    // Number of random bytes used to construct the 32-byte nonce for Deoxys-II
+    uint256 private constant NONCE_SIZE_BYTES = 32;
+
+    // Domain separation tag for nonce generation
+    string private constant NONCE_PERS = "EncryptedEvents:nonce";
+
+    /// @notice Encrypts a message with a caller-provided symmetric key and emits it.
+    /// @dev Pass the key over an encrypted transaction (default when using the Sapphire Hardhat plugin).
+    function emitEncrypted(bytes32 key, bytes calldata message) external {
+        // Domain-separated randomness for nonce generation.
+        bytes32 nonce = bytes32(
+            Sapphire.randomBytes(NONCE_SIZE_BYTES, bytes(NONCE_PERS))
+        );
+        bytes memory cipher = Sapphire.encrypt(key, nonce, message, bytes(""));
+        emit Encrypted(msg.sender, nonce, cipher);
+    }
+
+    /// @notice Same as emitEncrypted, but binds encryption to msg.sender via AAD for authenticity.
+    function emitEncryptedWithAad(
+        bytes32 key,
+        bytes calldata message
+    ) external {
+        // Domain-separated randomness for nonce generation.
+        bytes32 nonce = bytes32(
+            Sapphire.randomBytes(NONCE_SIZE_BYTES, bytes(NONCE_PERS))
+        );
+
+        // AAD must exactly match off-chain bytes (20-byte address).
+        bytes memory aad = abi.encodePacked(msg.sender);
+        bytes memory cipher = Sapphire.encrypt(key, nonce, message, aad);
+        emit Encrypted(msg.sender, nonce, cipher);
+    }
+
+    /// @notice Same as emitEncrypted, but binds encryption to (chainId, contract) via AAD.
+    /// @dev This is relayer-agnostic since it does not depend on msg.sender.
+    function emitEncryptedWithContextAad(
+        bytes32 key,
+        bytes calldata message
+    ) external {
+        bytes32 nonce = bytes32(
+            Sapphire.randomBytes(NONCE_SIZE_BYTES, bytes(NONCE_PERS))
+        );
+
+        // AAD = solidityPacked(uint256 chainid, address this)
+        bytes memory aad = abi.encodePacked(block.chainid, address(this));
+        bytes memory cipher = Sapphire.encrypt(key, nonce, message, aad);
+        emit Encrypted(msg.sender, nonce, cipher);
+    }
+}

--- a/examples/encrypted-events/contracts/EncryptedEventsECDH.sol
+++ b/examples/encrypted-events/contracts/EncryptedEventsECDH.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.24;
+
+import {Sapphire} from "@oasisprotocol/sapphire-contracts/contracts/Sapphire.sol";
+
+/**
+ * @title EncryptedEventsECDH
+ * @notice Emits confidential events where the symmetric key is derived on-chain
+ *         using X25519 (Curve25519) ECDH between the caller and the contract.
+ *
+ * Flow:
+ *  - On deploy: contract generates a Curve25519 keypair and keeps the secret key in encrypted state.
+ *  - Off-chain: caller generates a Curve25519 keypair and sends their public key in the tx.
+ *  - On-chain:  key = Sapphire.deriveSymmetricKey(callerPublicKey, contractSecretKey)
+ *  - Encrypt + emit: same event shape as the simple example.
+ */
+contract EncryptedEventsECDH {
+    event Encrypted(address indexed sender, bytes32 nonce, bytes ciphertext);
+
+    // Number of random bytes used to construct the 32-byte nonce for Deoxys-II
+    uint256 private constant NONCE_SIZE_BYTES = 32;
+
+    // Domain separation tag for nonce generation
+    string private constant NONCE_PERS = "EncryptedEvents:nonce";
+
+    // Long‑lived ECDH secret key, stored in confidential Sapphire state.
+    Sapphire.Curve25519SecretKey private _contractSk;
+    // Public key exposed for clients to derive the shared key off‑chain.
+    Sapphire.Curve25519PublicKey public contractPk;
+
+    constructor() {
+        bytes memory empty = bytes("");
+        (
+            Sapphire.Curve25519PublicKey pk,
+            Sapphire.Curve25519SecretKey sk
+        ) = Sapphire.generateCurve25519KeyPair(empty);
+        contractPk = pk;
+        _contractSk = sk;
+    }
+
+    /// @notice Derives a symmetric key with the caller and emits an encrypted event.
+    /// @param callerPublicKey Curve25519 public key of the caller (32 bytes, typed).
+    /// @param message         Plaintext message (bytes) to encrypt and emit.
+    function emitEncryptedECDH(
+        Sapphire.Curve25519PublicKey callerPublicKey,
+        bytes calldata message
+    ) external {
+        // Derive a 32-byte symmetric key via X25519 (ECDH) with the caller.
+        bytes32 key = Sapphire.deriveSymmetricKey(callerPublicKey, _contractSk);
+
+        // Encrypt and emit (Deoxys-II uses first 15 bytes of the 32-byte nonce).
+        bytes32 nonce = bytes32(
+            Sapphire.randomBytes(NONCE_SIZE_BYTES, bytes(NONCE_PERS))
+        );
+        bytes memory cipher = Sapphire.encrypt(key, nonce, message, bytes(""));
+        emit Encrypted(msg.sender, nonce, cipher);
+    }
+
+    /// @notice Same as emitEncryptedECDH, but binds encryption to msg.sender via AAD.
+    function emitEncryptedECDHWithAad(
+        Sapphire.Curve25519PublicKey callerPublicKey,
+        bytes calldata message
+    ) external {
+        bytes32 key = Sapphire.deriveSymmetricKey(callerPublicKey, _contractSk);
+
+        bytes32 nonce = bytes32(
+            Sapphire.randomBytes(NONCE_SIZE_BYTES, bytes(NONCE_PERS))
+        );
+        bytes memory aad = abi.encodePacked(msg.sender);
+        bytes memory cipher = Sapphire.encrypt(key, nonce, message, aad);
+        emit Encrypted(msg.sender, nonce, cipher);
+    }
+
+    /// @notice Same as emitEncryptedECDH, but binds encryption to (chainId, contract) via AAD.
+    function emitEncryptedECDHWithContextAad(
+        Sapphire.Curve25519PublicKey callerPublicKey,
+        bytes calldata message
+    ) external {
+        bytes32 key = Sapphire.deriveSymmetricKey(callerPublicKey, _contractSk);
+
+        bytes32 nonce = bytes32(
+            Sapphire.randomBytes(NONCE_SIZE_BYTES, bytes(NONCE_PERS))
+        );
+        // AAD = solidityPacked(uint256 chainid, address this)
+        bytes memory aad = abi.encodePacked(block.chainid, address(this));
+        bytes memory cipher = Sapphire.encrypt(key, nonce, message, aad);
+        emit Encrypted(msg.sender, nonce, cipher);
+    }
+}

--- a/examples/encrypted-events/contracts/EncryptedEventsROFL.sol
+++ b/examples/encrypted-events/contracts/EncryptedEventsROFL.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.24;
+
+import {Sapphire} from "@oasisprotocol/sapphire-contracts/contracts/Sapphire.sol";
+
+/**
+ * @title EncryptedEventsROFL
+ * @notice Sketch for a ROFL-friendly encrypted-events flow.
+ *
+ * IMPORTANT: This is a sketch. Do **not** deploy this contract as-is.
+ */
+contract EncryptedEventsROFL {
+    event Encrypted(address indexed sender, bytes32 nonce, bytes ciphertext);
+
+    // Replace this with a real ROFL/OPL authorization scheme (e.g., allowlist,
+    // appd/attestation checks, marketplace-managed identities, etc.).
+    address public roflApp; // set to your ROFL app's address in your deployment flow
+
+    modifier onlyROFL() {
+        require(msg.sender == roflApp, "only ROFL app");
+        _;
+    }
+
+    function emitWithOnchainKey(bytes calldata text) external onlyROFL {
+        // 1) Generate a fresh symmetric key on-chain (per call or per session)
+        bytes32 key = bytes32(Sapphire.randomBytes(32, bytes("rofl:onchain:key")));
+
+        // 2) Encrypt with optional context-binding AAD
+        bytes32 nonce = bytes32(Sapphire.randomBytes(32, bytes("rofl:nonce")));
+        bytes memory ad = abi.encodePacked(block.chainid, address(this));
+        bytes memory encrypted = Sapphire.encrypt(key, nonce, text, ad);
+
+        // 3) Emit
+        emit Encrypted(msg.sender, nonce, encrypted);
+
+        // Optionally: persist or wrap `key` for ROFL retrieval using your chosen scheme.
+        // Do NOT emit or log secrets in production.
+    }
+}

--- a/examples/encrypted-events/hardhat.config.ts
+++ b/examples/encrypted-events/hardhat.config.ts
@@ -1,0 +1,59 @@
+import 'dotenv/config';
+import '@oasisprotocol/sapphire-hardhat';
+import '@nomicfoundation/hardhat-toolbox';
+import '@typechain/hardhat';
+import { HardhatUserConfig } from 'hardhat/config';
+
+// custom tasks
+import './tasks/deploy';
+import './tasks/deploy-ecdh';
+import './tasks/enc';
+
+const PRIVATE_KEY = process.env.PRIVATE_KEY ?? '';
+
+// Use the standard test mnemonic when no explicit private key is provided,
+// just like our other examples. This ensures we always have signers available
+// on remote HTTP networks (e.g., sapphire-localnet) in CI and local dev.
+const accounts = PRIVATE_KEY
+  ? [PRIVATE_KEY]
+  : {
+      mnemonic: 'test test test test test test test test test test test junk',
+      path: "m/44'/60'/0'/0",
+      initialIndex: 0,
+      count: 20,
+      passphrase: '',
+    };
+
+const config: HardhatUserConfig = {
+  solidity: {
+    version: '0.8.24',
+    settings: {
+      optimizer: { enabled: true, runs: 200 },
+      // Use Paris explicitly to avoid PUSH0 on chains that might not support Shanghai yet.
+      evmVersion: 'paris',
+    },
+  },
+  networks: {
+    'sapphire-localnet': {
+      url: 'http://localhost:8545',
+      chainId: 0x5afd,
+      accounts,
+    },
+    'sapphire-testnet': {
+      url: 'https://testnet.sapphire.oasis.io',
+      chainId: 0x5aff,
+      accounts,
+    },
+    sapphire: {
+      url: 'https://sapphire.oasis.io',
+      chainId: 0x5afe,
+      accounts,
+    },
+  },
+  typechain: {
+    outDir: 'typechain-types',
+    target: 'ethers-v6',
+  },
+};
+
+export default config;

--- a/examples/encrypted-events/package.json
+++ b/examples/encrypted-events/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "encrypted-events-demo",
+  "version": "1.0.0",
+  "description": "Demonstration of emitting and decrypting confidential events on Oasis Sapphire",
+  "scripts": {
+    "build": "hardhat compile",
+    "typechain": "hardhat typechain",
+    "build:types": "hardhat compile && hardhat typechain",
+    "test": "hardhat test --network sapphire-localnet"
+  },
+  "keywords": [
+    "oasis",
+    "sapphire",
+    "encrypted events",
+    "confidential"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@noble/curves": "^1.4.0",
+    "@nomicfoundation/hardhat-toolbox": "^5.0.0",
+    "@oasisprotocol/sapphire-hardhat": "^2.22.2",
+    "@typechain/ethers-v6": "^0.5.1",
+    "@typechain/hardhat": "^9.1.0",
+    "@types/chai": "^4.3.14",
+    "chai": "^4.3.7",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "@oasisprotocol/client-rt": "^1.3.0",
+    "@oasisprotocol/deoxysii": "^0.0.6",
+    "@oasisprotocol/sapphire-contracts": "^0.2.14",
+    "dotenv": "^16.4.0",
+    "hardhat": "^2.26.1"
+  }
+}

--- a/examples/encrypted-events/tasks/deploy-ecdh.ts
+++ b/examples/encrypted-events/tasks/deploy-ecdh.ts
@@ -1,0 +1,17 @@
+import { task } from 'hardhat/config';
+
+task(
+  'deploy-ecdh',
+  'Deploys the EncryptedEventsECDH contract and prints its Curve25519 public key',
+).setAction(async (_args, hre) => {
+  const { ethers } = hre;
+  const Contract = await ethers.getContractFactory('EncryptedEventsECDH');
+  const contract = await Contract.deploy();
+  await contract.waitForDeployment();
+
+  const addr = contract.target;
+  const pk: string = await contract.contractPk();
+
+  console.log('EncryptedEventsECDH deployed to:', addr);
+  console.log('Contract Curve25519 public key (hex):', pk);
+});

--- a/examples/encrypted-events/tasks/deploy.ts
+++ b/examples/encrypted-events/tasks/deploy.ts
@@ -1,0 +1,11 @@
+import { task } from 'hardhat/config';
+
+task('deploy', 'Deploys the EncryptedEvents contract').setAction(
+  async (_args, hre) => {
+    const { ethers } = hre;
+    const Contract = await ethers.getContractFactory('EncryptedEvents');
+    const contract = await Contract.deploy();
+    await contract.waitForDeployment();
+    console.log('EncryptedEvents deployed to:', contract.target);
+  },
+);

--- a/examples/encrypted-events/tasks/enc.ts
+++ b/examples/encrypted-events/tasks/enc.ts
@@ -1,0 +1,515 @@
+import { task } from 'hardhat/config';
+import type { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { AEAD, NonceSize } from '@oasisprotocol/deoxysii';
+import { x25519 } from '@noble/curves/ed25519';
+import { mraeDeoxysii } from '@oasisprotocol/client-rt';
+import { hkdfSync } from 'crypto';
+
+/**
+ * Event signature (both contracts):
+ *   event Encrypted(address indexed sender, bytes32 nonce, bytes ciphertext);
+ *
+ * Tasks:
+ *   EMIT (key):     npx hardhat emit --network <net> --mode key  --contract <ADDR> [--message "..."] [--key <HEX32>] [--aadmode none|sender|context]
+ *   EMIT (ecdh):    npx hardhat emit --network <net> --mode ecdh --contract <ADDR> [--message "..."] [--secret <HEX32>] [--aadmode none|sender|context]
+ *
+ *   LISTEN (key):   npx hardhat listen --network <net> --mode key  --contract <ADDR> --key <HEX32> [--aadmode none|sender|context]
+ *   LISTEN (ecdh):  npx hardhat listen --network <net> --mode ecdh --contract <ADDR> --secret <HEX32> [--aadmode none|sender|context] [--hkdf]
+ *
+ *   DECRYPT (key):  npx hardhat decrypt --network <net> --mode key  [--contract <ADDR>] --tx <TX_HASH> --key <HEX32> [--aadmode none|sender|context]
+ *   DECRYPT (ecdh): npx hardhat decrypt --network <net> --mode ecdh --contract <ADDR> --tx <TX_HASH> --secret <HEX32> [--aadmode none|sender|context] [--hkdf]
+ */
+
+type Mode = 'key' | 'ecdh';
+type AadMode = 'none' | 'sender' | 'context';
+
+function assertMode(mode: string): asserts mode is Mode {
+  if (!['key', 'ecdh'].includes(mode)) {
+    throw new Error("mode must be 'key' or 'ecdh'");
+  }
+}
+
+function assertAadMode(aadmode: string): asserts aadmode is AadMode {
+  if (!['none', 'sender', 'context'].includes(aadmode)) {
+    throw new Error("aadmode must be 'none', 'sender', or 'context'");
+  }
+}
+
+function isAddressLike(s: string | undefined): s is string {
+  return !!s && /^0x[0-9a-fA-F]{40}$/.test(s);
+}
+
+async function getAadBytes(
+  hre: HardhatRuntimeEnvironment,
+  aadmode: AadMode,
+  senderFromEvent: string | undefined,
+  contractAddr: string,
+): Promise<Uint8Array> {
+  const { ethers } = hre;
+  if (aadmode === 'sender') {
+    if (!senderFromEvent)
+      throw new Error('Internal: sender missing from event for aadmode=sender');
+    return ethers.getBytes(senderFromEvent);
+  }
+  if (aadmode === 'context') {
+    const net = await ethers.provider.getNetwork();
+    const packed = ethers.solidityPacked(
+      ['uint256', 'address'],
+      [net.chainId, contractAddr],
+    );
+    return ethers.getBytes(packed);
+  }
+  return new Uint8Array();
+}
+
+async function deriveEcdhKey(
+  hre: HardhatRuntimeEnvironment,
+  ecdhContractAddr: string,
+  callerSecretHex: string,
+): Promise<Uint8Array> {
+  const { ethers } = hre;
+  const ecdh = await ethers.getContractAt(
+    'EncryptedEventsECDH',
+    ecdhContractAddr,
+  );
+  const contractPkHex: string = await ecdh.contractPk();
+  return mraeDeoxysii.deriveSymmetricKey(
+    ethers.getBytes(contractPkHex),
+    ethers.getBytes(callerSecretHex),
+  );
+}
+
+function warnContractParamIfTxHash(contract: string | undefined) {
+  if (contract && !isAddressLike(contract)) {
+    console.warn(
+      'Warning: --contract should be a 0x-prefixed 20-byte address (not a tx hash). You provided:',
+      contract,
+    );
+  }
+}
+
+// EMIT
+task('emit', 'Emit an Encrypted event (key|ecdh)')
+  .addParam('mode', 'key | ecdh')
+  .addParam('contract', 'Contract address')
+  .addOptionalParam('message', 'Plaintext to encrypt (emit)', 'Hello Sapphire')
+  .addOptionalParam('key', 'Hex-encoded 32-byte symmetric key (key mode)')
+  .addOptionalParam(
+    'secret',
+    'Hex-encoded 32-byte caller Curve25519 secret (ecdh mode)',
+  )
+  .addOptionalParam('aadmode', 'none | sender | context', 'none')
+  .addFlag(
+    'hkdf',
+    'ECDH only: derive per-message key from (ECDH, nonce) off-chain (no effect on emit)',
+  )
+  .setAction(
+    async ({ mode, contract, message, key, secret, aadmode, hkdf }, hre) => {
+      const { ethers } = hre;
+
+      assertMode(mode);
+      assertAadMode(aadmode);
+      if (!isAddressLike(contract)) {
+        throw new Error(
+          '--contract is required and must be a checksummed address for emit',
+        );
+      }
+      warnContractParamIfTxHash(contract);
+
+      if (mode === 'key') {
+        const instance = await ethers.getContractAt(
+          'EncryptedEvents',
+          contract,
+        );
+        const keyHex =
+          (key as `0x${string}`) ??
+          (ethers.hexlify(ethers.randomBytes(32)) as `0x${string}`);
+        const data = ethers.hexlify(ethers.toUtf8Bytes(message));
+
+        let txr;
+        if (aadmode === 'sender') {
+          txr = await (instance as any).emitEncryptedWithAad(keyHex, data);
+        } else if (aadmode === 'context') {
+          txr = await (instance as any).emitEncryptedWithContextAad(
+            keyHex,
+            data,
+          );
+        } else {
+          txr = await instance.emitEncrypted(keyHex, data);
+        }
+
+        const receipt = await txr.wait();
+        console.log('Encrypted event emitted in tx:', receipt?.hash);
+        console.log('Symmetric key (hex):', keyHex);
+        if (aadmode !== 'none') {
+          console.log(`AAD mode used: ${aadmode}`);
+          if (aadmode === 'sender') {
+            console.warn(
+              'Note: AAD binds to msg.sender (emitted as the first event arg). Use that same value when decrypting.',
+            );
+          } else {
+            console.warn(
+              'Note: AAD binds to (chainId, contract). Ensure you compute the same bytes off-chain when decrypting.',
+            );
+          }
+        }
+        if (hkdf) {
+          console.warn(
+            '--hkdf has no effect on EMIT; encryption happens on-chain. Only use --hkdf when LISTEN/DECRYPT against a contract that also applies HKDF on-chain.',
+          );
+        }
+        return;
+      }
+
+      // ECDH mode
+      const instance = await ethers.getContractAt(
+        'EncryptedEventsECDH',
+        contract,
+      );
+      const callerSecretBytes = secret
+        ? ethers.getBytes(secret)
+        : ethers.randomBytes(32);
+      if (callerSecretBytes.length !== 32)
+        throw new Error('Caller secret must be 32 bytes');
+      const callerPublic = x25519.getPublicKey(callerSecretBytes);
+      const callerPkHex = ethers.hexlify(callerPublic) as `0x${string}`;
+      const data = ethers.hexlify(ethers.toUtf8Bytes(message));
+
+      let txr2;
+      if (aadmode === 'sender') {
+        txr2 = await (instance as any).emitEncryptedECDHWithAad(
+          callerPkHex,
+          data,
+        );
+      } else if (aadmode === 'context') {
+        txr2 = await (instance as any).emitEncryptedECDHWithContextAad(
+          callerPkHex,
+          data,
+        );
+      } else {
+        txr2 = await instance.emitEncryptedECDH(callerPkHex, data);
+      }
+      const receipt2 = await txr2.wait();
+
+      console.log('Encrypted event emitted in tx:', receipt2?.hash);
+      console.log('Caller Curve25519 public key (hex):', callerPkHex);
+      // DEMO ONLY – DO NOT log or print secrets in production systems.
+      console.warn('DEMO ONLY: Do not log secret keys in production!');
+      console.log(
+        'Caller Curve25519 SECRET key (hex):',
+        ethers.hexlify(callerSecretBytes),
+      );
+      if (aadmode !== 'none') {
+        console.log(`AAD mode used: ${aadmode}`);
+        if (aadmode === 'sender') {
+          console.warn(
+            'Note: AAD binds to msg.sender (and is emitted as the first event arg). Use that value off-chain for decryption.',
+          );
+        } else {
+          console.warn(
+            'Note: AAD binds to (chainId, contract). Ensure you compute the same bytes off-chain when decrypting.',
+          );
+        }
+      }
+      if (hkdf) {
+        console.warn(
+          '--hkdf has no effect on EMIT; encryption happens on-chain. Only use --hkdf when LISTEN/DECRYPT against a contract that also applies HKDF on-chain.',
+        );
+      }
+    },
+  );
+
+// LISTEN
+task('listen', 'Listen and decrypt Encrypted events (key|ecdh)')
+  .addParam('mode', 'key | ecdh')
+  .addParam('contract', 'Contract address')
+  .addOptionalParam('key', 'Hex-encoded 32-byte symmetric key (key mode)')
+  .addOptionalParam(
+    'secret',
+    'Hex-encoded 32-byte caller Curve25519 secret (ecdh mode)',
+  )
+  .addOptionalParam('aadmode', 'none | sender | context', 'none')
+  .addFlag(
+    'hkdf',
+    'ECDH only: derive per-message key from (ECDH, nonce) off-chain',
+  )
+  .setAction(async ({ mode, contract, key, secret, aadmode, hkdf }, hre) => {
+    const { ethers } = hre;
+
+    assertMode(mode);
+    assertAadMode(aadmode);
+    if (!isAddressLike(contract)) {
+      throw new Error(
+        '--contract is required and must be a checksummed address for listen',
+      );
+    }
+    warnContractParamIfTxHash(contract);
+
+    const net = await ethers.provider.getNetwork();
+    if (net.chainId === BigInt(0x5afd)) {
+      console.warn(
+        'Note: sapphire-localnet does not yet support event filters/subscriptions, so live `listen` cannot work there. ' +
+          'Use `emit` + `decrypt --tx <hash>` on localnet, or run `listen` on sapphire-testnet/mainnet.',
+      );
+      return;
+    }
+
+    if (mode === 'key') {
+      if (!key) throw new Error('--key is required in key mode for listen');
+      if (hkdf) console.warn('--hkdf is ignored in key mode.');
+      const instance = await ethers.getContractAt('EncryptedEvents', contract);
+
+      console.log('Listening for Encrypted events (Ctrl-C to quit)');
+      if (aadmode !== 'none') {
+        console.warn(`AAD mode: ${aadmode}.`);
+      }
+
+      const aead = new AEAD(ethers.getBytes(key)); // same key for all events
+      instance.on(instance.filters.Encrypted(), async (...args: unknown[]) => {
+        try {
+          let sender: string, nonce: string, ciphertext: string;
+          // Shape A: ethers v6 gives single payload/log with .args (WS/polling)
+          if (args.length === 1 && (args[0] as { args?: unknown[] })?.args) {
+            [sender, nonce, ciphertext] = (
+              args[0] as { args: [string, string, string] }
+            ).args;
+            // Shape B: ethers gives decoded params positionally
+          } else {
+            [sender, nonce, ciphertext] = args as [string, string, string];
+          }
+          const aadBytes = await getAadBytes(hre, aadmode, sender, contract);
+          const plaintext = aead.decrypt(
+            ethers.getBytes(nonce).slice(0, NonceSize),
+            ethers.getBytes(ciphertext),
+            aadBytes,
+          );
+          console.log('Decrypted:', new TextDecoder().decode(plaintext));
+        } catch (e) {
+          console.error('Failed to decrypt event:', e);
+        }
+      });
+
+      process.on('SIGINT', () => {
+        try {
+          instance.removeAllListeners();
+        } catch {}
+        process.exit(0);
+      });
+      await new Promise<void>(() => {
+        /* keep open */
+      });
+      return;
+    }
+
+    // ECDH listen
+    if (!secret)
+      throw new Error('--secret is required in ecdh mode for listen');
+
+    const instance2 = await ethers.getContractAt(
+      'EncryptedEventsECDH',
+      contract,
+    );
+
+    console.log('Listening (ECDH) for Encrypted events (Ctrl-C to quit)');
+    if (aadmode !== 'none') {
+      console.warn(`AAD mode: ${aadmode}.`);
+    }
+    if (hkdf) {
+      console.warn(
+        'Note: --hkdf derives a per-message key off-chain using nonce. Your contract must encrypt with the same HKDF for this to succeed.',
+      );
+    }
+
+    // Base ECDH key is constant for a given (contract, callerSecret)
+    const baseKey = await deriveEcdhKey(hre, contract, secret);
+
+    // If not using HKDF, reuse a single AEAD instance
+    const aeadStatic = hkdf ? undefined : new AEAD(baseKey);
+
+    instance2.on(instance2.filters.Encrypted(), async (...args: unknown[]) => {
+      try {
+        let sender: string, nonce: string, ciphertext: string;
+        // Shape A: ethers v6 gives single payload/log with .args (WS/polling)
+        if (args.length === 1 && (args[0] as { args?: unknown[] })?.args) {
+          [sender, nonce, ciphertext] = (
+            args[0] as { args: [string, string, string] }
+          ).args;
+          // Shape B: ethers gives decoded params positionally
+        } else {
+          [sender, nonce, ciphertext] = args as [string, string, string];
+        }
+        const aadBytes = await getAadBytes(hre, aadmode, sender, contract);
+        const n15 = ethers.getBytes(nonce).slice(0, NonceSize);
+
+        let aead: AEAD;
+        if (hkdf) {
+          const sessionKey = hkdfSync(
+            'sha256',
+            Buffer.from(baseKey),
+            Buffer.from(n15),
+            Buffer.from('sapphire:events'),
+            32,
+          );
+          aead = new AEAD(new Uint8Array(sessionKey));
+        } else {
+          aead = aeadStatic!;
+        }
+
+        const plaintext = aead.decrypt(
+          n15,
+          ethers.getBytes(ciphertext),
+          aadBytes,
+        );
+        console.log('Decrypted (ECDH):', new TextDecoder().decode(plaintext));
+      } catch (e) {
+        console.error('Failed to decrypt event:', e);
+      }
+    });
+
+    process.on('SIGINT', () => {
+      try {
+        instance2.removeAllListeners();
+      } catch {}
+      process.exit(0);
+    });
+    await new Promise<void>(() => {
+      /* keep open */
+    });
+  });
+
+// DECRYPT (past tx by hash)
+task('decrypt', 'Decrypt an Encrypted event from a past transaction (key|ecdh)')
+  .addParam('mode', 'key | ecdh')
+  .addParam('tx', 'Transaction hash containing the Encrypted event')
+  .addOptionalParam(
+    'contract',
+    'Contract address (optional for key mode; required for ecdh mode)',
+  )
+  .addOptionalParam('key', 'Hex-encoded 32-byte symmetric key (key mode)')
+  .addOptionalParam(
+    'secret',
+    'Hex-encoded 32-byte caller Curve25519 secret (ecdh mode)',
+  )
+  .addOptionalParam('aadmode', 'none | sender | context', 'none')
+  .addFlag(
+    'hkdf',
+    'ECDH only: derive per-message key from (ECDH, nonce) off-chain',
+  )
+  .setAction(
+    async ({ mode, tx, contract, key, secret, aadmode, hkdf }, hre) => {
+      const { ethers } = hre;
+
+      assertMode(mode);
+      assertAadMode(aadmode);
+      if (mode === 'ecdh' && !isAddressLike(contract)) {
+        throw new Error(
+          '--contract is required and must be a checksummed address for decrypt in ecdh mode',
+        );
+      }
+      if (contract) warnContractParamIfTxHash(contract);
+
+      const receipt = await ethers.provider.getTransactionReceipt(tx);
+      if (!receipt) throw new Error('Transaction not found or not mined');
+
+      // Minimal interface for parsing the Encrypted event
+      const iface = new ethers.Interface([
+        'event Encrypted(address indexed sender, bytes32 nonce, bytes ciphertext)',
+      ]);
+
+      const target = contract ? contract.toLowerCase() : undefined;
+
+      // Parse all matching Encrypted logs (optionally filter by contract)
+      const matches: Array<{ parsed: any; address: string }> = [];
+      for (const l of receipt.logs) {
+        try {
+          if (target && (l.address ?? '').toLowerCase() !== target) continue;
+          const p = iface.parseLog(l);
+          if (p && p.name === 'Encrypted') {
+            matches.push({
+              parsed: p,
+              address: (l.address ?? '').toLowerCase(),
+            });
+          }
+        } catch {
+          /* ignore non-matching logs */
+        }
+      }
+
+      if (matches.length === 0) {
+        if (target)
+          throw new Error(
+            'Encrypted event not found for the provided contract in this transaction',
+          );
+        throw new Error('Encrypted event not found in tx logs');
+      }
+      if (!target && matches.length > 1) {
+        console.warn(
+          'Warning: Multiple Encrypted events found in this tx across different contracts. Please re-run with --contract <ADDR> to disambiguate.',
+        );
+        throw new Error('Ambiguous: multiple Encrypted events');
+      }
+
+      const chosen = matches[0];
+      const sender: string = chosen.parsed.args[0];
+      const nonce: string = chosen.parsed.args[1];
+      const ciphertext: string = chosen.parsed.args[2];
+
+      if (mode === 'key') {
+        if (!key) throw new Error('--key is required in key mode for decrypt');
+        if (hkdf) console.warn('--hkdf is ignored in key mode.');
+        const aead = new AEAD(ethers.getBytes(key));
+        const aadBytes = await getAadBytes(
+          hre,
+          aadmode,
+          aadmode === 'sender' ? sender : undefined,
+          (contract ?? chosen.address) as string,
+        );
+        const plaintext = aead.decrypt(
+          ethers.getBytes(nonce).slice(0, NonceSize),
+          ethers.getBytes(ciphertext),
+          aadBytes,
+        );
+        console.log('Decrypted message:', new TextDecoder().decode(plaintext));
+        return;
+      }
+
+      // ecdh mode
+      if (!secret)
+        throw new Error('--secret is required in ecdh mode for decrypt');
+
+      const targetAddr = (contract ?? chosen.address) as string;
+      const baseKey = await deriveEcdhKey(hre, targetAddr, secret);
+
+      const aadBytes2 = await getAadBytes(
+        hre,
+        aadmode,
+        aadmode === 'sender' ? sender : undefined,
+        targetAddr,
+      );
+      const n15 = ethers.getBytes(nonce).slice(0, NonceSize);
+
+      let aead2: AEAD;
+      if (hkdf) {
+        const sessionKey = hkdfSync(
+          'sha256',
+          Buffer.from(baseKey),
+          Buffer.from(n15),
+          Buffer.from('sapphire:events'),
+          32,
+        );
+        aead2 = new AEAD(new Uint8Array(sessionKey));
+      } else {
+        aead2 = new AEAD(baseKey);
+      }
+
+      const plaintext2 = aead2.decrypt(
+        n15,
+        ethers.getBytes(ciphertext),
+        aadBytes2,
+      );
+      console.log(
+        'Decrypted message (ECDH):',
+        new TextDecoder().decode(plaintext2),
+      );
+    },
+  );

--- a/examples/encrypted-events/test/AAD.spec.ts
+++ b/examples/encrypted-events/test/AAD.spec.ts
@@ -1,0 +1,123 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { AEAD, NonceSize } from '@oasisprotocol/deoxysii';
+import { randomBytes } from 'crypto';
+import { x25519 } from '@noble/curves/ed25519';
+import { mraeDeoxysii } from '@oasisprotocol/client-rt';
+
+describe('AAD behavior', function () {
+  before(async function () {
+    const net = await ethers.provider.getNetwork();
+    const sapphire = new Set([0x5afe, 0x5aff, 0x5afd].map(BigInt));
+    if (!sapphire.has(net.chainId)) {
+      // Sapphire precompiles are not available on non‑Sapphire networks.
+      // eslint-disable-next-line no-restricted-syntax
+      (this as any).skip?.();
+    }
+  });
+
+  it('EncryptedEvents: decrypt fails without AAD and succeeds with correct AAD', async function () {
+    const Contract = await ethers.getContractFactory('EncryptedEvents');
+    const contract = await Contract.deploy();
+    await contract.waitForDeployment();
+
+    const keyBytes = randomBytes(32);
+    const keyHex = ethers.hexlify(keyBytes) as `0x${string}`;
+    const message = 'AAD bound message';
+
+    // Call AAD variant
+    const tx = await contract.emitEncryptedWithAad(
+      keyHex,
+      ethers.hexlify(ethers.toUtf8Bytes(message)),
+    );
+    const receipt = await tx.wait();
+
+    const parsed = receipt!.logs
+      .map((l: any) => contract.interface.parseLog(l))
+      .find((l: any) => l && l.name === 'Encrypted');
+    if (!parsed) throw new Error('Encrypted event not found');
+
+    const sender: string = parsed.args[0];
+    const nonce: string = parsed.args[1];
+    const ciphertext: string = parsed.args[2];
+
+    const aead = new AEAD(keyBytes);
+
+    // Wrong/no AAD should throw
+    expect(() =>
+      aead.decrypt(
+        ethers.getBytes(nonce).slice(0, NonceSize),
+        ethers.getBytes(ciphertext),
+        new Uint8Array(),
+      ),
+    ).to.throw();
+
+    // Correct AAD (20-byte address equal to emitted sender)
+    const aadBytes = ethers.getBytes(sender);
+
+    const plaintext = aead.decrypt(
+      ethers.getBytes(nonce).slice(0, NonceSize),
+      ethers.getBytes(ciphertext),
+      aadBytes,
+    );
+    expect(new TextDecoder().decode(plaintext)).to.equal(message);
+  });
+
+  it('EncryptedEventsECDH: decrypt fails without AAD and succeeds with correct AAD', async function () {
+    const Contract = await ethers.getContractFactory('EncryptedEventsECDH');
+    const contract = await Contract.deploy();
+    await contract.waitForDeployment();
+
+    // Caller keypair (off-chain)
+    const callerSk = ethers.randomBytes(32);
+    const callerPk = x25519.getPublicKey(callerSk);
+    const callerPkHex = ethers.hexlify(callerPk) as `0x${string}`;
+
+    const message = 'AAD bound ECDH message';
+
+    // Emit using AAD variant
+    const tx = await contract.emitEncryptedECDHWithAad(
+      callerPkHex,
+      ethers.hexlify(ethers.toUtf8Bytes(message)) as `0x${string}`,
+    );
+    const receipt = await tx.wait();
+
+    // Fetch contract's public key and derive symmetric key off-chain via client SDK
+    const contractPkHex: string = await contract.contractPk();
+    const key = mraeDeoxysii.deriveSymmetricKey(
+      ethers.getBytes(contractPkHex),
+      callerSk,
+    );
+
+    // Parse log
+    const parsed = receipt!.logs
+      .map((l: any) => contract.interface.parseLog(l))
+      .find((l: any) => l && l.name === 'Encrypted');
+    if (!parsed) throw new Error('Encrypted event not found');
+
+    const sender: string = parsed.args[0];
+    const nonce: string = parsed.args[1];
+    const ciphertext: string = parsed.args[2];
+
+    const aead = new AEAD(key);
+
+    // Wrong/no AAD should throw
+    expect(() =>
+      aead.decrypt(
+        ethers.getBytes(nonce).slice(0, NonceSize),
+        ethers.getBytes(ciphertext),
+        new Uint8Array(),
+      ),
+    ).to.throw();
+
+    // Correct AAD (emitted sender)
+    const aadBytes = ethers.getBytes(sender);
+
+    const plaintext = aead.decrypt(
+      ethers.getBytes(nonce).slice(0, NonceSize),
+      ethers.getBytes(ciphertext),
+      aadBytes,
+    );
+    expect(new TextDecoder().decode(plaintext)).to.equal(message);
+  });
+});

--- a/examples/encrypted-events/test/AADContext.spec.ts
+++ b/examples/encrypted-events/test/AADContext.spec.ts
@@ -1,0 +1,131 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { AEAD, NonceSize } from '@oasisprotocol/deoxysii';
+import { randomBytes } from 'crypto';
+import { x25519 } from '@noble/curves/ed25519';
+import { mraeDeoxysii } from '@oasisprotocol/client-rt';
+
+describe('Context-bound AAD behavior', function () {
+  before(async function () {
+    const net = await ethers.provider.getNetwork();
+    const sapphire = new Set([0x5afe, 0x5aff, 0x5afd].map(BigInt));
+    if (!sapphire.has(net.chainId)) {
+      // Sapphire precompiles are not available on non‑Sapphire networks.
+      // eslint-disable-next-line no-restricted-syntax
+      (this as any).skip?.();
+    }
+  });
+
+  it('EncryptedEvents: decrypt fails without AAD and succeeds with context AAD', async function () {
+    const Contract = await ethers.getContractFactory('EncryptedEvents');
+    const contract = await Contract.deploy();
+    await contract.waitForDeployment();
+
+    const keyBytes = randomBytes(32);
+    const keyHex = ethers.hexlify(keyBytes) as `0x${string}`;
+    const message = 'Context AAD bound message';
+
+    // Call context AAD variant
+    const tx = await contract.emitEncryptedWithContextAad(
+      keyHex,
+      ethers.hexlify(ethers.toUtf8Bytes(message)),
+    );
+    const receipt = await tx.wait();
+
+    const parsed = receipt!.logs
+      .map((l: any) => contract.interface.parseLog(l))
+      .find((l: any) => l && l.name === 'Encrypted');
+    if (!parsed) throw new Error('Encrypted event not found');
+
+    const nonce: string = parsed.args[1];
+    const ciphertext: string = parsed.args[2];
+
+    const aead = new AEAD(keyBytes);
+
+    // Wrong/no AAD should throw
+    expect(() =>
+      aead.decrypt(
+        ethers.getBytes(nonce).slice(0, NonceSize),
+        ethers.getBytes(ciphertext),
+        new Uint8Array(),
+      ),
+    ).to.throw();
+
+    // Correct AAD (chainId, contract)
+    const net = await ethers.provider.getNetwork();
+    const packed = ethers.solidityPacked(
+      ['uint256', 'address'],
+      [net.chainId, await contract.getAddress()],
+    );
+    const aadBytes = ethers.getBytes(packed);
+
+    const plaintext = aead.decrypt(
+      ethers.getBytes(nonce).slice(0, NonceSize),
+      ethers.getBytes(ciphertext),
+      aadBytes,
+    );
+    expect(new TextDecoder().decode(plaintext)).to.equal(message);
+  });
+
+  it('EncryptedEventsECDH: decrypt fails without AAD and succeeds with context AAD', async function () {
+    const Contract = await ethers.getContractFactory('EncryptedEventsECDH');
+    const contract = await Contract.deploy();
+    await contract.waitForDeployment();
+
+    // Caller keypair (off-chain)
+    const callerSk = ethers.randomBytes(32);
+    const callerPk = x25519.getPublicKey(callerSk);
+    const callerPkHex = ethers.hexlify(callerPk) as `0x${string}`;
+
+    const message = 'Context AAD bound ECDH message';
+
+    // Emit using context AAD variant
+    const tx = await contract.emitEncryptedECDHWithContextAad(
+      callerPkHex,
+      ethers.hexlify(ethers.toUtf8Bytes(message)) as `0x${string}`,
+    );
+    const receipt = await tx.wait();
+
+    // Derive symmetric key off-chain via client SDK
+    const contractPkHex: string = await contract.contractPk();
+    const key = mraeDeoxysii.deriveSymmetricKey(
+      ethers.getBytes(contractPkHex),
+      callerSk,
+    );
+
+    // Parse log
+    const parsed = receipt!.logs
+      .map((l: any) => contract.interface.parseLog(l))
+      .find((l: any) => l && l.name === 'Encrypted');
+    if (!parsed) throw new Error('Encrypted event not found');
+
+    const nonce: string = parsed.args[1];
+    const ciphertext: string = parsed.args[2];
+
+    const aead = new AEAD(key);
+
+    // Wrong/no AAD should throw
+    expect(() =>
+      aead.decrypt(
+        ethers.getBytes(nonce).slice(0, NonceSize),
+        ethers.getBytes(ciphertext),
+        new Uint8Array(),
+      ),
+    ).to.throw();
+
+    // Correct context AAD
+    const net = await ethers.provider.getNetwork();
+    const packed = ethers.solidityPacked(
+      ['uint256', 'address'],
+      [net.chainId, await contract.getAddress()],
+    );
+    const aadBytes = ethers.getBytes(packed);
+
+    const plaintext = aead.decrypt(
+      ethers.getBytes(nonce).slice(0, NonceSize),
+      ethers.getBytes(ciphertext),
+      aadBytes,
+    );
+    expect(new TextDecoder().decode(plaintext)).to.equal(message);
+  });
+});

--- a/examples/encrypted-events/test/EncryptedEvents.ts
+++ b/examples/encrypted-events/test/EncryptedEvents.ts
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { randomBytes } from 'crypto';
+import { AEAD, NonceSize } from '@oasisprotocol/deoxysii';
+
+describe('EncryptedEvents', function () {
+  it('decrypts emitted ciphertext back to the original plaintext', async function () {
+    const net = await ethers.provider.getNetwork();
+    const sapphireChainIds = new Set([0x5afe, 0x5aff, 0x5afd].map(BigInt));
+    if (!sapphireChainIds.has(net.chainId)) {
+      // Sapphire precompiles are not available on non-Sapphire networks (e.g., Hardhat local).
+      // Skip this test in that case.
+      // eslint-disable-next-line no-restricted-syntax
+      (this as any).skip?.();
+    }
+    const Contract = await ethers.getContractFactory('EncryptedEvents');
+    const contract = await Contract.deploy();
+    await contract.waitForDeployment();
+
+    const keyBytes = randomBytes(32);
+    const keyHex = ethers.hexlify(keyBytes) as `0x${string}`;
+    const message = 'Hello Sapphire';
+
+    const tx = await contract.emitEncrypted(
+      keyHex,
+      ethers.hexlify(ethers.toUtf8Bytes(message)),
+    );
+    const receipt = await tx.wait();
+
+    const parsed = receipt!.logs
+      .map((l) => contract.interface.parseLog(l))
+      .find((l) => l && l.name === 'Encrypted');
+    if (!parsed) throw new Error('Encrypted event not found');
+
+    // Encrypted(address sender, bytes32 nonce, bytes ciphertext)
+    const nonce: string = parsed.args[1];
+    const ciphertext: string = parsed.args[2];
+
+    const aead = new AEAD(keyBytes);
+    const plaintext = aead.decrypt(
+      ethers.getBytes(nonce).slice(0, NonceSize),
+      ethers.getBytes(ciphertext),
+      new Uint8Array(),
+    );
+
+    expect(new TextDecoder().decode(plaintext)).to.equal(message);
+  });
+});

--- a/examples/encrypted-events/test/EncryptedEventsECDH.ts
+++ b/examples/encrypted-events/test/EncryptedEventsECDH.ts
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { AEAD, NonceSize } from '@oasisprotocol/deoxysii';
+import { x25519 } from '@noble/curves/ed25519';
+import { mraeDeoxysii } from '@oasisprotocol/client-rt';
+
+describe('EncryptedEventsECDH', function () {
+  it('derives a shared key (X25519) and decrypts the emitted ciphertext', async function () {
+    const net = await ethers.provider.getNetwork();
+    const sapphireChainIds = new Set([0x5afe, 0x5aff, 0x5afd].map(BigInt));
+    if (!sapphireChainIds.has(net.chainId)) {
+      // Skip on non‑Sapphire networks where precompiles are unavailable.
+      // eslint-disable-next-line no-restricted-syntax
+      (this as any).skip?.();
+    }
+
+    const Contract = await ethers.getContractFactory('EncryptedEventsECDH');
+    const contract = await Contract.deploy();
+    await contract.waitForDeployment();
+
+    // 1) Off‑chain: caller keypair
+    const callerSk = ethers.randomBytes(32);
+    const callerPk = x25519.getPublicKey(callerSk);
+    const callerPkHex = ethers.hexlify(callerPk) as `0x${string}`;
+
+    // 2) On‑chain: emit encrypted
+    const message = 'Hello Sapphire ECDH';
+    const tx = await contract.emitEncryptedECDH(
+      callerPkHex,
+      ethers.hexlify(ethers.toUtf8Bytes(message)),
+    );
+    const receipt = await tx.wait();
+
+    // 3) Fetch contract public key and derive symmetric key off‑chain via SDK helper
+    const contractPkHex: string = await contract.contractPk();
+    const key = mraeDeoxysii.deriveSymmetricKey(
+      ethers.getBytes(contractPkHex),
+      callerSk,
+    );
+
+    // 4) Parse log and decrypt
+    const parsed = receipt!.logs
+      .map((l) => contract.interface.parseLog(l))
+      .find((l) => l && l.name === 'Encrypted');
+    if (!parsed) throw new Error('Encrypted event not found');
+
+    const nonce: string = parsed.args[1];
+    const ciphertext: string = parsed.args[2];
+
+    const aead = new AEAD(key);
+    const plaintext = aead.decrypt(
+      ethers.getBytes(nonce).slice(0, NonceSize),
+      ethers.getBytes(ciphertext),
+      new Uint8Array(), // no AAD in this test
+    );
+
+    expect(new TextDecoder().decode(plaintext)).to.equal(message);
+  });
+});

--- a/examples/encrypted-events/test/NonceSlice.spec.ts
+++ b/examples/encrypted-events/test/NonceSlice.spec.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { randomBytes } from 'crypto';
+import { AEAD, NonceSize } from '@oasisprotocol/deoxysii';
+
+describe('Nonce slicing behavior', function () {
+  it('fails to decrypt if the full 32-byte nonce is used instead of the first 15 bytes', async function () {
+    const net = await ethers.provider.getNetwork();
+    const sapphireChainIds = new Set([0x5afe, 0x5aff, 0x5afd].map(BigInt));
+    if (!sapphireChainIds.has(net.chainId)) {
+      // Skip on non‑Sapphire networks where precompiles are unavailable.
+      // eslint-disable-next-line no-restricted-syntax
+      (this as any).skip?.();
+    }
+
+    const Contract = await ethers.getContractFactory('EncryptedEvents');
+    const contract = await Contract.deploy();
+    await contract.waitForDeployment();
+
+    const keyBytes = randomBytes(32);
+    const keyHex = ethers.hexlify(keyBytes) as `0x${string}`;
+    const message = 'Slice your nonce!';
+
+    const tx = await contract.emitEncrypted(
+      keyHex,
+      ethers.hexlify(ethers.toUtf8Bytes(message)),
+    );
+    const receipt = await tx.wait();
+
+    const parsed = receipt!.logs
+      .map((l) => contract.interface.parseLog(l))
+      .find((l) => l && l.name === 'Encrypted');
+    if (!parsed) throw new Error('Encrypted event not found');
+
+    const nonceFull: string = parsed.args[1];
+    const ciphertext: string = parsed.args[2];
+
+    const aead = new AEAD(keyBytes);
+
+    // Using the correct 15-byte slice should work as a sanity check
+    const ok = aead.decrypt(
+      ethers.getBytes(nonceFull).slice(0, NonceSize),
+      ethers.getBytes(ciphertext),
+      new Uint8Array(),
+    );
+    expect(new TextDecoder().decode(ok)).to.equal(message);
+
+    // Using the full 32-byte nonce must fail
+    expect(() =>
+      aead.decrypt(
+        ethers.getBytes(nonceFull), // <-- no slice (WRONG)
+        ethers.getBytes(ciphertext),
+        new Uint8Array(),
+      ),
+    ).to.throw();
+  });
+});

--- a/examples/encrypted-events/tsconfig.json
+++ b/examples/encrypted-events/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,52 @@ importers:
         specifier: ^4.8.3
         version: 4.9.5
 
+  examples/encrypted-events:
+    dependencies:
+      '@oasisprotocol/client-rt':
+        specifier: ^1.3.0
+        version: 1.3.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@oasisprotocol/deoxysii':
+        specifier: ^0.0.6
+        version: 0.0.6
+      '@oasisprotocol/sapphire-contracts':
+        specifier: ^0.2.14
+        version: 0.2.14
+      dotenv:
+        specifier: ^16.4.0
+        version: 16.6.1
+      hardhat:
+        specifier: ^2.26.1
+        version: 2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
+    devDependencies:
+      '@noble/curves':
+        specifier: ^1.4.0
+        version: 1.9.0
+      '@nomicfoundation/hardhat-toolbox':
+        specifier: ^5.0.0
+        version: 5.0.0(c57650d770c281e6674bfc522685ca50)
+      '@oasisprotocol/sapphire-hardhat':
+        specifier: ^2.22.2
+        version: 2.22.2(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@typechain/ethers-v6':
+        specifier: ^0.5.1
+        version: 0.5.1(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)
+      '@typechain/hardhat':
+        specifier: ^9.1.0
+        version: 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3))(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))
+      '@types/chai':
+        specifier: ^4.3.14
+        version: 4.3.20
+      chai:
+        specifier: ^4.3.7
+        version: 4.5.0
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.2(@types/node@22.7.5)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.4.5
+        version: 5.8.3
+
   examples/hardhat:
     dependencies:
       '@nomicfoundation/hardhat-toolbox':
@@ -484,10 +530,10 @@ importers:
         version: 1.9.4
       '@playwright/test':
         specifier: ^1.56.1
-        version: 1.56.1
+        version: 1.57.0
       '@tenkeylabs/dappwright':
         specifier: ^2.12.0
-        version: 2.12.0(playwright-core@1.56.1)
+        version: 2.12.0(playwright-core@1.57.0)
       '@types/react':
         specifier: ^18.2.79
         version: 18.3.20
@@ -671,7 +717,7 @@ importers:
         version: 18.19.86
       '@walletconnect/ethereum-provider':
         specifier: ^2.23.0
-        version: 2.23.0(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+        version: 2.23.1(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@18.19.86)(typescript@5.8.3)
@@ -1890,6 +1936,11 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  '@ethereumjs/rlp@5.0.2':
+    resolution: {integrity: sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@ethereumjs/tx@3.3.2':
     resolution: {integrity: sha512-6AaJhwg4ucmwTvw/1qLaZUX5miWrwZ4nLOUsKyb/HtzS3BMw/CasKhdi1ims9mBKeK9sOJCH4qGKOBGyJCeeog==}
 
@@ -1903,6 +1954,10 @@ packages:
   '@ethereumjs/util@8.1.0':
     resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
     engines: {node: '>=14'}
+
+  '@ethereumjs/util@9.1.0':
+    resolution: {integrity: sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==}
+    engines: {node: '>=18'}
 
   '@ethersproject/abi@5.8.0':
     resolution: {integrity: sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==}
@@ -2387,32 +2442,64 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@nomicfoundation/edr-darwin-arm64@0.11.3':
+    resolution: {integrity: sha512-w0tksbdtSxz9nuzHKsfx4c2mwaD0+l5qKL2R290QdnN9gi9AV62p9DHkOgfBdyg6/a6ZlnQqnISi7C9avk/6VA==}
+    engines: {node: '>= 18'}
+
   '@nomicfoundation/edr-darwin-arm64@0.8.0':
     resolution: {integrity: sha512-sKTmOu/P5YYhxT0ThN2Pe3hmCE/5Ag6K/eYoiavjLWbR7HEb5ZwPu2rC3DpuUk1H+UKJqt7o4/xIgJxqw9wu6A==}
+    engines: {node: '>= 18'}
+
+  '@nomicfoundation/edr-darwin-x64@0.11.3':
+    resolution: {integrity: sha512-QR4jAFrPbOcrO7O2z2ESg+eUeIZPe2bPIlQYgiJ04ltbSGW27FblOzdd5+S3RoOD/dsZGKAvvy6dadBEl0NgoA==}
     engines: {node: '>= 18'}
 
   '@nomicfoundation/edr-darwin-x64@0.8.0':
     resolution: {integrity: sha512-8ymEtWw1xf1Id1cc42XIeE+9wyo3Dpn9OD/X8GiaMz9R70Ebmj2g+FrbETu8o6UM+aL28sBZQCiCzjlft2yWAg==}
     engines: {node: '>= 18'}
 
+  '@nomicfoundation/edr-linux-arm64-gnu@0.11.3':
+    resolution: {integrity: sha512-Ktjv89RZZiUmOFPspuSBVJ61mBZQ2+HuLmV67InNlh9TSUec/iDjGIwAn59dx0bF/LOSrM7qg5od3KKac4LJDQ==}
+    engines: {node: '>= 18'}
+
   '@nomicfoundation/edr-linux-arm64-gnu@0.8.0':
     resolution: {integrity: sha512-h/wWzS2EyQuycz+x/SjMRbyA+QMCCVmotRsgM1WycPARvVZWIVfwRRsKoXKdCftsb3S8NTprqBdJlOmsFyETFA==}
+    engines: {node: '>= 18'}
+
+  '@nomicfoundation/edr-linux-arm64-musl@0.11.3':
+    resolution: {integrity: sha512-B3sLJx1rL2E9pfdD4mApiwOZSrX0a/KQSBWdlq1uAhFKqkl00yZaY4LejgZndsJAa4iKGQJlGnw4HCGeVt0+jA==}
     engines: {node: '>= 18'}
 
   '@nomicfoundation/edr-linux-arm64-musl@0.8.0':
     resolution: {integrity: sha512-gnWxDgdkka0O9GpPX/gZT3REeKYV28Guyg13+Vj/bbLpmK1HmGh6Kx+fMhWv+Ht/wEmGDBGMCW1wdyT/CftJaQ==}
     engines: {node: '>= 18'}
 
+  '@nomicfoundation/edr-linux-x64-gnu@0.11.3':
+    resolution: {integrity: sha512-D/4cFKDXH6UYyKPu6J3Y8TzW11UzeQI0+wS9QcJzjlrrfKj0ENW7g9VihD1O2FvXkdkTjcCZYb6ai8MMTCsaVw==}
+    engines: {node: '>= 18'}
+
   '@nomicfoundation/edr-linux-x64-gnu@0.8.0':
     resolution: {integrity: sha512-DTMiAkgAx+nyxcxKyxFZk1HPakXXUCgrmei7r5G7kngiggiGp/AUuBBWFHi8xvl2y04GYhro5Wp+KprnLVoAPA==}
+    engines: {node: '>= 18'}
+
+  '@nomicfoundation/edr-linux-x64-musl@0.11.3':
+    resolution: {integrity: sha512-ergXuIb4nIvmf+TqyiDX5tsE49311DrBky6+jNLgsGDTBaN1GS3OFwFS8I6Ri/GGn6xOaT8sKu3q7/m+WdlFzg==}
     engines: {node: '>= 18'}
 
   '@nomicfoundation/edr-linux-x64-musl@0.8.0':
     resolution: {integrity: sha512-iTITWe0Zj8cNqS0xTblmxPbHVWwEtMiDC+Yxwr64d7QBn/1W0ilFQ16J8gB6RVVFU3GpfNyoeg3tUoMpSnrm6Q==}
     engines: {node: '>= 18'}
 
+  '@nomicfoundation/edr-win32-x64-msvc@0.11.3':
+    resolution: {integrity: sha512-snvEf+WB3OV0wj2A7kQ+ZQqBquMcrozSLXcdnMdEl7Tmn+KDCbmFKBt3Tk0X3qOU4RKQpLPnTxdM07TJNVtung==}
+    engines: {node: '>= 18'}
+
   '@nomicfoundation/edr-win32-x64-msvc@0.8.0':
     resolution: {integrity: sha512-mNRDyd/C3j7RMcwapifzv2K57sfA5xOw8g2U84ZDvgSrXVXLC99ZPxn9kmolb+dz8VMm9FONTZz9ESS6v8DTnA==}
+    engines: {node: '>= 18'}
+
+  '@nomicfoundation/edr@0.11.3':
+    resolution: {integrity: sha512-kqILRkAd455Sd6v8mfP3C1/0tCOynJWY+Ir+k/9Boocu2kObCrsFgG+ZWB7fSBVdd9cPVSNrnhWS+V+PEo637g==}
     engines: {node: '>= 18'}
 
   '@nomicfoundation/edr@0.8.0':
@@ -2642,11 +2729,28 @@ packages:
     peerDependencies:
       hardhat: ^2.0.4
 
+  '@oasisprotocol/client-rt@1.3.0':
+    resolution: {integrity: sha512-YMD0kg0LFk2P0d3VhNRN7OPuX7f5UwsoDhujRa52Q2OchufPrmG9Joss/LSXvPmG0r2pr8OY02mroWa2C6V4PA==}
+
   '@oasisprotocol/client@0.1.1-alpha.2':
     resolution: {integrity: sha512-iKFOjMvBWVs7eVSd+H/wWthuYeXXCcJZ0AxX4anLu+UQvmaXUzzbGwiM1YH3XkpJsYhrIDebU/L8WUr7C21LuA==}
 
+  '@oasisprotocol/client@1.3.0':
+    resolution: {integrity: sha512-eKavJ97/GmdwtFVZ0OqMj5CB/zOHkDJPUZx+mjUItUMurTFc3la0PMeRPkfeDmct9+2kvP+3HsR74JiOq8uW4w==}
+
   '@oasisprotocol/deoxysii@0.0.6':
     resolution: {integrity: sha512-TI51bIpChfsla9aRbjip6zvTbz6rpsqKgM7MqJvSfeFF6G5xLXQcbSC9u/1hOnOOazd7HaqA9NvaXQdeKCb3yw==}
+
+  '@oasisprotocol/sapphire-contracts@0.2.14':
+    resolution: {integrity: sha512-FYdJnHsnIBBME1Ggxc3pC1+NBa9HCaI/x4pDxSF2yBYbWvcFsd9M5+TJqP1BlZq6Z4D08v1+ahIcTzKF4YaGiw==}
+
+  '@oasisprotocol/sapphire-hardhat@2.22.2':
+    resolution: {integrity: sha512-43YYfsySrK/arbkurMd/AVOHpGwsZVvOrvQIS+TV8b56T0izLJuwe99Vou8U9GGiShBwFRuKl+J7pQWwvGWzPg==}
+    peerDependencies:
+      hardhat: 2.x
+
+  '@oasisprotocol/sapphire-paratime@2.2.0':
+    resolution: {integrity: sha512-P8feNe2ecUgyL118b35BlkCmvfx4b3/7vKupdQw2YBotbqeOV82LunwHkgChuTf5BFjosDB+ad2wSqcuG4pHDA==}
 
   '@openzeppelin/contracts@5.3.0':
     resolution: {integrity: sha512-zj/KGoW7zxWUE8qOI++rUM18v+VeLTTzKs/DJFkSzHpQFPD/jKKF0TrMxBfGLl3kpdELCNccvB3zmofSzm4nlA==}
@@ -2662,8 +2766,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.56.1':
-    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2917,9 +3021,6 @@ packages:
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
-
-  '@scure/base@1.2.4':
-    resolution: {integrity: sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==}
 
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
@@ -3651,8 +3752,8 @@ packages:
     resolution: {integrity: sha512-ZQnyDDpqDPAk5lyLV19BRccQ3wwK3LmAwibuIv3X+44aT/dOs2kQGu9pla3iW2LgZ5qRMYvgvvfr5g3WlDGceQ==}
     engines: {node: '>=18.20.8'}
 
-  '@walletconnect/core@2.23.0':
-    resolution: {integrity: sha512-W++xuXf+AsMPrBWn1It8GheIbCTp1ynTQP+aoFB86eUwyCtSiK7UQsn/+vJZdwElrn+Ptp2A0RqQx2onTMVHjQ==}
+  '@walletconnect/core@2.23.1':
+    resolution: {integrity: sha512-fW48PIw41Q/LJW+q0msFogD/OcelkrrDONQMcpGw4C4Y6w+IvFKGEg+7dxGLKWx1g8QuHk/p6C9VEIV/tDsm5A==}
     engines: {node: '>=18.20.8'}
 
   '@walletconnect/crypto@1.1.0':
@@ -3672,8 +3773,8 @@ packages:
     resolution: {integrity: sha512-NzPzNcjMLqow6ha2nssB1ciMD0cdHZesYcHSQKjCi9waIDMov9Fr2yEJccbiVFE3cxek7f9dCPsoZez2q8ihvg==}
     deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
-  '@walletconnect/ethereum-provider@2.23.0':
-    resolution: {integrity: sha512-jDuFarWWTbET2UhwUBBDfr1ZcPnrKBmqQtIc5EG6+ftzD+GcCz+cEJH7YJ5O77IdT8Uds9ETuIngvRokyWRSUw==}
+  '@walletconnect/ethereum-provider@2.23.1':
+    resolution: {integrity: sha512-G6KBsq92DsLlbCTDLhQu7783hOiZcS71TON+mPBSQkBqIpeDVQm+f3/DXUg7uiW4Ilz7WwehGNNlHa7rsZS0GA==}
 
   '@walletconnect/events@1.0.1':
     resolution: {integrity: sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==}
@@ -3737,6 +3838,9 @@ packages:
   '@walletconnect/logger@3.0.0':
     resolution: {integrity: sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==}
 
+  '@walletconnect/logger@3.0.1':
+    resolution: {integrity: sha512-O8lXGMZO1+e5NtHhBSjsAih/I9KC+1BxNhGNGD+SIWTqWd0zsbT5wJtNnJ+LnSXTRE7XZRxFUlvZgkER3vlhFA==}
+
   '@walletconnect/modal-core@2.6.2':
     resolution: {integrity: sha512-cv8ibvdOJQv2B+nyxP9IIFdxvQznMz8OOr/oR/AaUZym4hjXNL/l1a2UlSQBXrVjo3xxbouMxLb3kBsHoYP2CA==}
 
@@ -3778,8 +3882,8 @@ packages:
   '@walletconnect/sign-client@2.22.4':
     resolution: {integrity: sha512-la+sol0KL33Fyx5DRlupHREIv8wA6W33bRfuLAfLm8pINRTT06j9rz0IHIqJihiALebFxVZNYzJnF65PhV0q3g==}
 
-  '@walletconnect/sign-client@2.23.0':
-    resolution: {integrity: sha512-Nzf5x/LnQgC0Yjk0NmkT8kdrIMcScpALiFm9gP0n3CulL+dkf3HumqWzdoTmQSqGPxwHu/TNhGOaRKZLGQXSqw==}
+  '@walletconnect/sign-client@2.23.1':
+    resolution: {integrity: sha512-x0sG8ZuuaOi3G/gYWLppf7nmNItWlV8Yga9Bltb46/Ve6G20nCBis6gcTVVeJOpnmqQ85FISwExqOYPmJ0FQlw==}
 
   '@walletconnect/time@1.0.2':
     resolution: {integrity: sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==}
@@ -3793,8 +3897,8 @@ packages:
   '@walletconnect/types@2.22.4':
     resolution: {integrity: sha512-KJdiS9ezXzx1uASanldYaaenDwb42VOQ6Rj86H7FRwfYddhNnYnyEaDjDKOdToGRGcpt5Uzom6qYUOnrWEbp5g==}
 
-  '@walletconnect/types@2.23.0':
-    resolution: {integrity: sha512-9ZEOJyx/kNVCRncDHh3Qr9eH7Ih1dXBFB4k1J8iEudkv3t4GhYpXhqIt2kNdQWluPb1BBB4wEuckAT96yKuA8g==}
+  '@walletconnect/types@2.23.1':
+    resolution: {integrity: sha512-sbWOM9oCuzSbz/187rKWnSB3sy7FCFcbTQYeIJMc9+HTMTG2TUPftPCn8NnkfvmXbIeyLw00Y0KNvXoCV/eIeQ==}
 
   '@walletconnect/universal-provider@2.11.0':
     resolution: {integrity: sha512-zgJv8jDvIMP4Qse/D9oIRXGdfoNqonsrjPZanQ/CHNe7oXGOBiQND2IIeX+tS0H7uNA0TPvctljCLiIN9nw4eA==}
@@ -3807,8 +3911,8 @@ packages:
   '@walletconnect/universal-provider@2.22.4':
     resolution: {integrity: sha512-TF2RNX13qxa0rrBAhVDs5+C2G8CHX7L0PH5hF2uyQHdGyxZ3pFbXf8rxmeW1yKlB76FSbW80XXNrUes6eK/xHg==}
 
-  '@walletconnect/universal-provider@2.23.0':
-    resolution: {integrity: sha512-3ZEqAsbtCbk+CV0ZLpy7Qzc04KXEnrW4zCboZ+gkkC0ey4H62x9h23kBOIrU9qew6orjA7D5gg0ikRC2Up1lbw==}
+  '@walletconnect/universal-provider@2.23.1':
+    resolution: {integrity: sha512-XlvG1clsL7Ds+g28Oz5dXsPA+5ERtQGYvd+L8cskMaTvtphGhipVGgX8WNAhp7p1gfNcDg4tCiTHlj131jctwA==}
 
   '@walletconnect/utils@2.11.0':
     resolution: {integrity: sha512-hxkHPlTlDQILHfIKXlmzgNJau/YcSBC3XHUSuZuKZbNEw3duFT6h6pm3HT/1+j1a22IG05WDsNBuTCRkwss+BQ==}
@@ -3819,8 +3923,8 @@ packages:
   '@walletconnect/utils@2.22.4':
     resolution: {integrity: sha512-coAPrNiTiD+snpiXQyXakMVeYcddqVqII7aLU39TeILdPoXeNPc2MAja+MF7cKNM/PA3tespljvvxck/oTm4+Q==}
 
-  '@walletconnect/utils@2.23.0':
-    resolution: {integrity: sha512-bVyv4Hl+/wVGueZ6rEO0eYgDy5deSBA4JjpJHAMOdaNoYs05NTE1HymV2lfPQQHuqc7suYexo9jwuW7i3JLuAA==}
+  '@walletconnect/utils@2.23.1':
+    resolution: {integrity: sha512-J12DadZHIL0KvsUoQuK0rag9jDUy8qu1zwz47xEHl03LrMcgrotQiXvdTQ3uHwAVA4yKLTQB/LEI2JiTIt7X8Q==}
 
   '@walletconnect/window-getters@1.0.1':
     resolution: {integrity: sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==}
@@ -3966,17 +4070,6 @@ packages:
 
   abitype@1.1.0:
     resolution: {integrity: sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3.22.0 || ^4.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-
-  abitype@1.2.1:
-    resolution: {integrity: sha512-AhkAWBE5QqzSuaPi6B9w5scl5739iBknQdFFAbY/CybASOBVWtVmPavUYW1OrDRX/iZWB/Je80xhJMZz2G4G1Q==}
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3.22.0 || ^4.0.0
@@ -4621,6 +4714,10 @@ packages:
 
   cborg@1.10.2:
     resolution: {integrity: sha512-b3tFPA9pUr2zCUiCfRd2+wok2/LBSNUMKOuRRok+WlvvAgEt/PlbgPTsZUcwCOs53IJvLgTp0eotwtosE6njug==}
+    hasBin: true
+
+  cborg@2.0.5:
+    resolution: {integrity: sha512-xVW1rSIw1ZXbkwl2XhJ7o/jAv0vnVoQv/QlfQxV8a7V5PlA4UU/AcIiXqmpyybwNWy/GPQU1m/aBVNIWr7/T0w==}
     hasBin: true
 
   chai-as-promised@7.1.2:
@@ -5399,6 +5496,10 @@ packages:
   dotenv@10.0.0:
     resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
     engines: {node: '>=10'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -6340,6 +6441,18 @@ packages:
 
   hardhat@2.22.19:
     resolution: {integrity: sha512-jptJR5o6MCgNbhd7eKa3mrteR+Ggq1exmE5RUL5ydQEVKcZm0sss5laa86yZ0ixIavIvF4zzS7TdGDuyopj0sQ==}
+    hasBin: true
+    peerDependencies:
+      ts-node: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+      typescript:
+        optional: true
+
+  hardhat@2.26.3:
+    resolution: {integrity: sha512-gBfjbxCCEaRgMCRgTpjo1CEoJwqNPhyGMMVHYZJxoQ3LLftp2erSVf8ZF6hTQC0r2wst4NcqNmLWqMnHg1quTw==}
     hasBin: true
     peerDependencies:
       ts-node: '*'
@@ -7552,8 +7665,14 @@ packages:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
 
+  micro-eth-signer@0.14.0:
+    resolution: {integrity: sha512-5PLLzHiVYPWClEvZIXXFu5yutzpadb73rnQCpUqIHu3No3coFuWQNfE5tkBQJ7djuLYl6aRLaS0MgWJYGoqiBw==}
+
   micro-ftch@0.3.1:
     resolution: {integrity: sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==}
+
+  micro-packed@0.7.3:
+    resolution: {integrity: sha512-2Milxs+WNC00TRlem41oRswvw31146GiSaoCT7s3Xi2gMUglW5QBeqlQaZeHr5tJx9nm3i57LNXPqxOOaWtTYg==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -8216,13 +8335,13 @@ packages:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
 
-  playwright-core@1.56.1:
-    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.56.1:
-    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8757,6 +8876,10 @@ packages:
 
   protobufjs@7.1.2:
     resolution: {integrity: sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@7.4.0:
+    resolution: {integrity: sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -10463,6 +10586,14 @@ packages:
 
   viem@2.23.2:
     resolution: {integrity: sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  viem@2.37.5:
+    resolution: {integrity: sha512-bLKvKgLcge6KWBMLk8iP9weu5tHNr0hkxPNwQd+YQrHEgek7ogTBBeE10T0V6blwBMYmeZFZHLnMhDmPjp63/A==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -12493,6 +12624,8 @@ snapshots:
 
   '@ethereumjs/rlp@4.0.1': {}
 
+  '@ethereumjs/rlp@5.0.2': {}
+
   '@ethereumjs/tx@3.3.2':
     dependencies:
       '@ethereumjs/common': 2.5.0
@@ -12515,6 +12648,11 @@ snapshots:
       '@ethereumjs/rlp': 4.0.1
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
+
+  '@ethereumjs/util@9.1.0':
+    dependencies:
+      '@ethereumjs/rlp': 5.0.2
+      ethereum-cryptography: 2.2.1
 
   '@ethersproject/abi@5.8.0':
     dependencies:
@@ -13338,7 +13476,7 @@ snapshots:
       '@ethereumjs/tx': 4.2.0
       '@metamask/superstruct': 3.2.1
       '@noble/hashes': 1.3.2
-      '@scure/base': 1.2.4
+      '@scure/base': 1.2.6
       '@types/debug': 4.1.12
       debug: 4.4.0(supports-color@8.1.1)
       pony-cause: 2.1.11
@@ -13352,7 +13490,7 @@ snapshots:
       '@ethereumjs/tx': 4.2.0
       '@metamask/superstruct': 3.2.1
       '@noble/hashes': 1.3.2
-      '@scure/base': 1.2.4
+      '@scure/base': 1.2.6
       '@types/debug': 4.1.12
       debug: 4.4.0(supports-color@8.1.1)
       pony-cause: 2.1.11
@@ -13472,19 +13610,43 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@nomicfoundation/edr-darwin-arm64@0.11.3': {}
+
   '@nomicfoundation/edr-darwin-arm64@0.8.0': {}
+
+  '@nomicfoundation/edr-darwin-x64@0.11.3': {}
 
   '@nomicfoundation/edr-darwin-x64@0.8.0': {}
 
+  '@nomicfoundation/edr-linux-arm64-gnu@0.11.3': {}
+
   '@nomicfoundation/edr-linux-arm64-gnu@0.8.0': {}
+
+  '@nomicfoundation/edr-linux-arm64-musl@0.11.3': {}
 
   '@nomicfoundation/edr-linux-arm64-musl@0.8.0': {}
 
+  '@nomicfoundation/edr-linux-x64-gnu@0.11.3': {}
+
   '@nomicfoundation/edr-linux-x64-gnu@0.8.0': {}
+
+  '@nomicfoundation/edr-linux-x64-musl@0.11.3': {}
 
   '@nomicfoundation/edr-linux-x64-musl@0.8.0': {}
 
+  '@nomicfoundation/edr-win32-x64-msvc@0.11.3': {}
+
   '@nomicfoundation/edr-win32-x64-msvc@0.8.0': {}
+
+  '@nomicfoundation/edr@0.11.3':
+    dependencies:
+      '@nomicfoundation/edr-darwin-arm64': 0.11.3
+      '@nomicfoundation/edr-darwin-x64': 0.11.3
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.11.3
+      '@nomicfoundation/edr-linux-arm64-musl': 0.11.3
+      '@nomicfoundation/edr-linux-x64-gnu': 0.11.3
+      '@nomicfoundation/edr-linux-x64-musl': 0.11.3
+      '@nomicfoundation/edr-win32-x64-msvc': 0.11.3
 
   '@nomicfoundation/edr@0.8.0':
     dependencies:
@@ -13572,6 +13734,17 @@ snapshots:
       hardhat: 2.22.19(bufferutil@4.0.9)(ts-node@8.10.2(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
       ordinal: 1.0.3
 
+  '@nomicfoundation/hardhat-chai-matchers@2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)))(chai@4.5.0)(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@types/chai-as-promised': 7.1.8
+      chai: 4.5.0
+      chai-as-promised: 7.1.2(chai@4.5.0)
+      deep-eql: 4.1.4
+      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      hardhat: 2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
+      ordinal: 1.0.3
+
   '@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@18.19.86)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10))':
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
@@ -13608,6 +13781,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      debug: 4.4.0(supports-color@8.1.1)
+      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      hardhat: 2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
+      lodash.isequal: 4.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@nomicfoundation/hardhat-ignition-ethers@0.15.11(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10)))(@nomicfoundation/hardhat-ignition@0.15.11(@nomicfoundation/hardhat-verify@2.0.13(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10))(@nomicfoundation/ignition-core@0.15.11(bufferutil@4.0.9)(utf-8-validate@5.0.10))(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10))':
     dependencies:
       '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10))
@@ -13631,6 +13813,14 @@ snapshots:
       '@nomicfoundation/ignition-core': 0.15.11(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       hardhat: 2.22.19(bufferutil@4.0.9)(ts-node@8.10.2(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
+
+  '@nomicfoundation/hardhat-ignition-ethers@0.15.11(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)))(@nomicfoundation/hardhat-ignition@0.15.11(@nomicfoundation/hardhat-verify@2.0.13(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10))(@nomicfoundation/ignition-core@0.15.11(bufferutil@4.0.9)(utf-8-validate@5.0.10))(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@nomicfoundation/hardhat-ignition': 0.15.11(@nomicfoundation/hardhat-verify@2.0.13(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
+      '@nomicfoundation/ignition-core': 0.15.11(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      hardhat: 2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
 
   '@nomicfoundation/hardhat-ignition-viem@0.15.11(@nomicfoundation/hardhat-ignition@0.15.11(@nomicfoundation/hardhat-verify@2.0.13(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10))(@nomicfoundation/hardhat-viem@2.0.6(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(typescript@5.8.3)(viem@2.9.19(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4))(@nomicfoundation/ignition-core@0.15.11(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(viem@2.9.19(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4))':
     dependencies:
@@ -13688,6 +13878,22 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@nomicfoundation/hardhat-ignition@0.15.11(@nomicfoundation/hardhat-verify@2.0.13(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)':
+    dependencies:
+      '@nomicfoundation/hardhat-verify': 2.0.13(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@nomicfoundation/ignition-core': 0.15.11(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@nomicfoundation/ignition-ui': 0.15.11
+      chalk: 4.1.2
+      debug: 4.4.0(supports-color@8.1.1)
+      fs-extra: 10.1.0
+      hardhat: 2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
+      json5: 2.2.3
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@nomicfoundation/hardhat-network-helpers@1.0.12(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10))':
     dependencies:
       ethereumjs-util: 7.1.5
@@ -13702,6 +13908,11 @@ snapshots:
     dependencies:
       ethereumjs-util: 7.1.5
       hardhat: 2.22.19(bufferutil@4.0.9)(ts-node@8.10.2(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
+
+  '@nomicfoundation/hardhat-network-helpers@1.0.12(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      ethereumjs-util: 7.1.5
+      hardhat: 2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
 
   '@nomicfoundation/hardhat-toolbox-viem@3.0.0(88bcfad2a8ca3da6985fd5b479b16ac4)':
     dependencies:
@@ -13806,6 +14017,27 @@ snapshots:
       typechain: 8.3.2(typescript@5.8.3)
       typescript: 5.8.3
 
+  '@nomicfoundation/hardhat-toolbox@5.0.0(c57650d770c281e6674bfc522685ca50)':
+    dependencies:
+      '@nomicfoundation/hardhat-chai-matchers': 2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)))(chai@4.5.0)(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@nomicfoundation/hardhat-ignition-ethers': 0.15.11(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)))(@nomicfoundation/hardhat-ignition@0.15.11(@nomicfoundation/hardhat-verify@2.0.13(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10))(@nomicfoundation/ignition-core@0.15.11(bufferutil@4.0.9)(utf-8-validate@5.0.10))(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@nomicfoundation/hardhat-network-helpers': 1.0.12(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@nomicfoundation/hardhat-verify': 2.0.13(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@typechain/ethers-v6': 0.5.1(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)
+      '@typechain/hardhat': 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3))(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))
+      '@types/chai': 4.3.20
+      '@types/mocha': 9.1.1
+      '@types/node': 22.7.5
+      chai: 4.5.0
+      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      hardhat: 2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
+      hardhat-gas-reporter: 1.0.10(bufferutil@4.0.9)(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
+      solidity-coverage: 0.8.15(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))
+      ts-node: 10.9.2(@types/node@22.7.5)(typescript@5.8.3)
+      typechain: 8.3.2(typescript@5.8.3)
+      typescript: 5.8.3
+
   '@nomicfoundation/hardhat-verify@2.0.13(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10))':
     dependencies:
       '@ethersproject/abi': 5.8.0
@@ -13843,6 +14075,21 @@ snapshots:
       cbor: 8.1.0
       debug: 4.4.0(supports-color@8.1.1)
       hardhat: 2.22.19(bufferutil@4.0.9)(ts-node@8.10.2(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
+      lodash.clonedeep: 4.5.0
+      picocolors: 1.1.1
+      semver: 6.3.1
+      table: 6.9.0
+      undici: 5.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@nomicfoundation/hardhat-verify@2.0.13(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@ethersproject/abi': 5.8.0
+      '@ethersproject/address': 5.8.0
+      cbor: 8.1.0
+      debug: 4.4.0(supports-color@8.1.1)
+      hardhat: 2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
       lodash.clonedeep: 4.5.0
       picocolors: 1.1.1
       semver: 6.3.1
@@ -13931,6 +14178,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@oasisprotocol/client-rt@1.3.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+    dependencies:
+      '@noble/curves': 1.9.0
+      '@noble/hashes': 1.8.0
+      '@oasisprotocol/client': 1.3.0
+      '@oasisprotocol/deoxysii': 0.0.6
+      tweetnacl: 1.0.3
+      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
   '@oasisprotocol/client@0.1.1-alpha.2':
     dependencies:
       bech32: 2.0.0
@@ -13941,7 +14202,32 @@ snapshots:
       protobufjs: 7.1.2
       tweetnacl: 1.0.3
 
+  '@oasisprotocol/client@1.3.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      bech32: 2.0.0
+      bip39: 3.1.0
+      cborg: 2.0.5
+      grpc-web: 1.5.0
+      protobufjs: 7.4.0
+      tweetnacl: 1.0.3
+
   '@oasisprotocol/deoxysii@0.0.6': {}
+
+  '@oasisprotocol/sapphire-contracts@0.2.14':
+    dependencies:
+      '@openzeppelin/contracts': 5.3.0
+
+  '@oasisprotocol/sapphire-hardhat@2.22.2(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@oasisprotocol/sapphire-paratime': 2.2.0
+      hardhat: 2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
+
+  '@oasisprotocol/sapphire-paratime@2.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+      '@oasisprotocol/deoxysii': 0.0.6
+      cborg: 1.10.2
 
   '@openzeppelin/contracts@5.3.0': {}
 
@@ -13954,9 +14240,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.56.1':
+  '@playwright/test@1.57.0':
     dependencies:
-      playwright: 1.56.1
+      playwright: 1.57.0
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.16(react-refresh@0.11.0)(type-fest@4.40.0)(webpack-dev-server@4.15.2)(webpack@5.99.6)':
     dependencies:
@@ -14179,7 +14465,7 @@ snapshots:
       '@reown/appkit-polyfills': 1.8.11
       '@reown/appkit-wallet': 1.8.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@wallet-standard/wallet': 1.1.0
-      '@walletconnect/logger': 3.0.0
+      '@walletconnect/logger': 3.0.1
       '@walletconnect/universal-provider': 2.22.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
       valtio: 2.1.7(@types/react@18.3.20)(react@18.3.1)
       viem: 2.41.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -14214,7 +14500,7 @@ snapshots:
     dependencies:
       '@reown/appkit-common': 1.8.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@reown/appkit-polyfills': 1.8.11
-      '@walletconnect/logger': 3.0.0
+      '@walletconnect/logger': 3.0.1
       zod: 3.22.4
     transitivePeerDependencies:
       - bufferutil
@@ -14407,8 +14693,6 @@ snapshots:
 
   '@scure/base@1.1.9': {}
 
-  '@scure/base@1.2.4': {}
-
   '@scure/base@1.2.6': {}
 
   '@scure/bip32@1.1.5':
@@ -14433,11 +14717,11 @@ snapshots:
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
-      '@scure/base': 1.2.4
+      '@scure/base': 1.2.6
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.7
+      '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -14459,7 +14743,7 @@ snapshots:
   '@scure/bip39@1.5.4':
     dependencies:
       '@noble/hashes': 1.7.1
-      '@scure/base': 1.2.4
+      '@scure/base': 1.2.6
 
   '@scure/bip39@1.6.0':
     dependencies:
@@ -14763,10 +15047,10 @@ snapshots:
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
-  '@tenkeylabs/dappwright@2.12.0(playwright-core@1.56.1)':
+  '@tenkeylabs/dappwright@2.12.0(playwright-core@1.57.0)':
     dependencies:
       node-stream-zip: 1.15.0
-      playwright-core: 1.56.1
+      playwright-core: 1.57.0
 
   '@tootallnate/once@1.1.2': {}
 
@@ -14871,6 +15155,14 @@ snapshots:
       ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       fs-extra: 9.1.0
       hardhat: 2.22.19(bufferutil@4.0.9)(ts-node@8.10.2(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
+      typechain: 8.3.2(typescript@5.8.3)
+
+  '@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3))(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))':
+    dependencies:
+      '@typechain/ethers-v6': 0.5.1(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)
+      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      fs-extra: 9.1.0
+      hardhat: 2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
       typechain: 8.3.2(typescript@5.8.3)
 
   '@types/babel__core@7.20.5':
@@ -15701,7 +15993,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.23.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@walletconnect/core@2.23.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -15709,13 +16001,13 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/logger': 3.0.0
+      '@walletconnect/logger': 3.0.1
       '@walletconnect/relay-api': 1.0.11
       '@walletconnect/relay-auth': 1.1.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.0
-      '@walletconnect/utils': 2.23.0(typescript@5.8.3)(zod@3.22.4)
+      '@walletconnect/types': 2.23.1
+      '@walletconnect/utils': 2.23.1(typescript@5.8.3)(zod@3.22.4)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.39.3
       events: 3.3.0
@@ -15840,7 +16132,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/ethereum-provider@2.23.0(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@walletconnect/ethereum-provider@2.23.1(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
       '@reown/appkit': 1.8.11(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -15848,11 +16140,11 @@ snapshots:
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/logger': 3.0.0
-      '@walletconnect/sign-client': 2.23.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@walletconnect/types': 2.23.0
-      '@walletconnect/universal-provider': 2.23.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@walletconnect/utils': 2.23.0(typescript@5.8.3)(zod@3.22.4)
+      '@walletconnect/logger': 3.0.1
+      '@walletconnect/sign-client': 2.23.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/types': 2.23.1
+      '@walletconnect/universal-provider': 2.23.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/utils': 2.23.1(typescript@5.8.3)(zod@3.22.4)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -16036,6 +16328,11 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       pino: 10.0.0
 
+  '@walletconnect/logger@3.0.1':
+    dependencies:
+      '@walletconnect/safe-json': 1.0.2
+      pino: 10.0.0
+
   '@walletconnect/modal-core@2.6.2(@types/react@18.3.20)(react@18.3.1)':
     dependencies:
       valtio: 1.11.2(@types/react@18.3.20)(react@18.3.1)
@@ -16213,16 +16510,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.23.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@walletconnect/sign-client@2.23.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
-      '@walletconnect/core': 2.23.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/core': 2.23.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/logger': 3.0.0
+      '@walletconnect/logger': 3.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.0
-      '@walletconnect/utils': 2.23.0(typescript@5.8.3)(zod@3.22.4)
+      '@walletconnect/types': 2.23.1
+      '@walletconnect/utils': 2.23.1(typescript@5.8.3)(zod@3.22.4)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -16336,13 +16633,13 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/types@2.23.0':
+  '@walletconnect/types@2.23.1':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/logger': 3.0.0
+      '@walletconnect/logger': 3.0.1
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -16476,7 +16773,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.23.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@walletconnect/universal-provider@2.23.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -16484,10 +16781,10 @@ snapshots:
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/logger': 3.0.0
-      '@walletconnect/sign-client': 2.23.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@walletconnect/types': 2.23.0
-      '@walletconnect/utils': 2.23.0(typescript@5.8.3)(zod@3.22.4)
+      '@walletconnect/logger': 3.0.1
+      '@walletconnect/sign-client': 2.23.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/types': 2.23.1
+      '@walletconnect/utils': 2.23.1(typescript@5.8.3)(zod@3.22.4)
       es-toolkit: 1.39.3
       events: 3.3.0
     transitivePeerDependencies:
@@ -16638,7 +16935,7 @@ snapshots:
       - uploadthing
       - zod
 
-  '@walletconnect/utils@2.23.0(typescript@5.8.3)(zod@3.22.4)':
+  '@walletconnect/utils@2.23.1(typescript@5.8.3)(zod@3.22.4)':
     dependencies:
       '@msgpack/msgpack': 3.1.2
       '@noble/ciphers': 1.3.0
@@ -16647,12 +16944,12 @@ snapshots:
       '@scure/base': 1.2.6
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/logger': 3.0.0
+      '@walletconnect/logger': 3.0.1
       '@walletconnect/relay-api': 1.0.11
       '@walletconnect/relay-auth': 1.1.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.0
+      '@walletconnect/types': 2.23.1
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       blakejs: 1.2.1
@@ -16819,11 +17116,6 @@ snapshots:
       zod: 3.22.4
 
   abitype@1.1.0(typescript@5.8.3)(zod@3.22.4):
-    optionalDependencies:
-      typescript: 5.8.3
-      zod: 3.22.4
-
-  abitype@1.2.1(typescript@5.8.3)(zod@3.22.4):
     optionalDependencies:
       typescript: 5.8.3
       zod: 3.22.4
@@ -17571,6 +17863,8 @@ snapshots:
       nofilter: 3.1.0
 
   cborg@1.10.2: {}
+
+  cborg@2.0.5: {}
 
   chai-as-promised@7.1.2(chai@4.3.10):
     dependencies:
@@ -18369,6 +18663,8 @@ snapshots:
   dotenv-expand@5.1.0: {}
 
   dotenv@10.0.0: {}
+
+  dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -19797,6 +20093,18 @@ snapshots:
       - debug
       - utf-8-validate
 
+  hardhat-gas-reporter@1.0.10(bufferutil@4.0.9)(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10):
+    dependencies:
+      array-uniq: 1.0.3
+      eth-gas-reporter: 0.2.27(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      hardhat: 2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
+      sha1: 1.1.1
+    transitivePeerDependencies:
+      - '@codechecks/client'
+      - bufferutil
+      - debug
+      - utf-8-validate
+
   hardhat-watcher@2.5.0(hardhat@2.22.19(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@18.19.86)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10)):
     dependencies:
       chokidar: 3.6.0
@@ -20019,6 +20327,55 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - c-kzg
+      - supports-color
+      - utf-8-validate
+
+  hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10):
+    dependencies:
+      '@ethereumjs/util': 9.1.0
+      '@ethersproject/abi': 5.8.0
+      '@nomicfoundation/edr': 0.11.3
+      '@nomicfoundation/solidity-analyzer': 0.1.2
+      '@sentry/node': 5.30.0
+      adm-zip: 0.4.16
+      aggregate-error: 3.1.0
+      ansi-escapes: 4.3.2
+      boxen: 5.1.2
+      chokidar: 4.0.3
+      ci-info: 2.0.0
+      debug: 4.4.0(supports-color@8.1.1)
+      enquirer: 2.4.1
+      env-paths: 2.2.1
+      ethereum-cryptography: 1.2.0
+      find-up: 5.0.0
+      fp-ts: 1.19.3
+      fs-extra: 7.0.1
+      immutable: 4.3.7
+      io-ts: 1.10.4
+      json-stream-stringify: 3.1.6
+      keccak: 3.0.4
+      lodash: 4.17.21
+      micro-eth-signer: 0.14.0
+      mnemonist: 0.38.5
+      mocha: 10.8.2
+      p-map: 4.0.0
+      picocolors: 1.1.1
+      raw-body: 2.5.2
+      resolve: 1.17.0
+      semver: 6.3.1
+      solc: 0.8.26(debug@4.4.0)
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.11
+      tinyglobby: 0.2.13
+      tsort: 0.0.1
+      undici: 5.29.0
+      uuid: 8.3.2
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      ts-node: 10.9.2(@types/node@22.7.5)(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - bufferutil
       - supports-color
       - utf-8-validate
 
@@ -21645,7 +22002,17 @@ snapshots:
 
   methods@1.1.2: {}
 
+  micro-eth-signer@0.14.0:
+    dependencies:
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      micro-packed: 0.7.3
+
   micro-ftch@0.3.1: {}
+
+  micro-packed@0.7.3:
+    dependencies:
+      '@scure/base': 1.2.6
 
   micromatch@4.0.8:
     dependencies:
@@ -22075,11 +22442,11 @@ snapshots:
   ox@0.6.7(typescript@5.8.3)(zod@3.22.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.9.0
+      '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.8.3)(zod@3.22.4)
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.1.0(typescript@5.8.3)(zod@3.22.4)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.8.3
@@ -22094,7 +22461,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.1(typescript@5.8.3)(zod@3.22.4)
+      abitype: 1.1.0(typescript@5.8.3)(zod@3.22.4)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.8.3
@@ -22327,11 +22694,11 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
-  playwright-core@1.56.1: {}
+  playwright-core@1.57.0: {}
 
-  playwright@1.56.1:
+  playwright@1.57.0:
     dependencies:
-      playwright-core: 1.56.1
+      playwright-core: 1.57.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -22853,6 +23220,21 @@ snapshots:
       react-is: 16.13.1
 
   protobufjs@7.1.2:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 18.19.86
+      long: 5.3.2
+
+  protobufjs@7.4.0:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -23945,6 +24327,29 @@ snapshots:
       shelljs: 0.8.5
       web3-utils: 1.10.4
 
+  solidity-coverage@0.8.15(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)):
+    dependencies:
+      '@ethersproject/abi': 5.8.0
+      '@solidity-parser/parser': 0.19.0
+      chalk: 2.4.2
+      death: 1.1.0
+      difflib: 0.2.4
+      fs-extra: 8.1.0
+      ghost-testrpc: 0.0.2
+      global-modules: 2.0.0
+      globby: 10.0.2
+      hardhat: 2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
+      jsonschema: 1.5.0
+      lodash: 4.17.21
+      mocha: 10.8.2
+      node-emoji: 1.11.0
+      pify: 4.0.1
+      recursive-readdir: 2.2.3
+      sc-istanbul: 0.4.6
+      semver: 7.7.1
+      shelljs: 0.8.5
+      web3-utils: 1.10.4
+
   sonic-boom@2.8.0:
     dependencies:
       atomic-sleep: 1.0.0
@@ -25013,6 +25418,23 @@ snapshots:
       isows: 1.0.6(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.6.7(typescript@5.8.3)(zod@3.22.4)
       ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.1.0(typescript@5.8.3)(zod@3.22.4)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ox: 0.9.3(typescript@5.8.3)(zod@3.22.4)
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,4 @@ packages:
   - examples/onchain-signer
   - examples/wagmi-v2
   - examples/wagmi-v1
+  - examples/encrypted-events


### PR DESCRIPTION
Closes #275.

[PREVIEW](https://deploy-preview-1398--oasisprotocol-docs.netlify.app/build/sapphire/develop/encrypted-events)

Introduces documentation and a new example project for implementing encrypted events on Oasis Sapphire. This allows developers to emit confidential event data that can only be decrypted by authorized parties.

### Key Changes:

* **Core Documentation (`docs/develop/encrypted-events.mdx`):** Added a new page detailing three patterns for emitting confidential event data:
      1. Passing a symmetric key directly.
      2. Deriving a shared secret via ECDH.
      3. On-chain key generation for ROFL.

* **Example Project (`examples/encrypted-events`):** Created a new project that includes:
      * Solidity contracts for the key-passing and ECDH patterns.
      * Hardhat tasks (`emit`, `listen`, `decrypt`, `deploy`, `deploy-ecdh`) for the full workflow.
      * A test suite covering core functionality and AAD binding.

Example under: https://github.com/oasisprotocol/sapphire-paratime/tree/docs/275-add-encrypted-events-tutorial/examples/encrypted-events

Sidebar update in docs PR: https://github.com/oasisprotocol/docs/pull/1398