### PR TITLE
contracts: Prepare 0.2.15 release

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is inspired by [Keep a Changelog].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 
+## 0.2.15 (2025-09)
+
+### Added
+
+* `Subcall.getRoflAppId()` which returns the app identifier for the current
+  origin transaction.
+
 ## 0.2.14 (2025-03)
 
 ### Added

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisprotocol/sapphire-contracts",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "license": "Apache-2.0",
   "description": "Solidity smart contract library for confidential contract development",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/contracts",


### PR DESCRIPTION
The new `getRoflAppId()` helper was merged [a while ago](https://github.com/oasisprotocol/sapphire-paratime/pull/606), but it took a while to test it in production.