### PR TITLE
fix: Publish foundry soldeer package on correct tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,7 @@ on:
       - clients/py/v[0-9]+.[0-9]+.[0-9]+*
       - contracts/v[0-9]+.[0-9]+.[0-9]+*
       - integrations/ethers-v6/v[0-9]+.[0-9]+.[0-9]+*
+      - integrations/foundry/v[0-9]+.[0-9]+.[0-9]+*
       - integrations/hardhat/v[0-9]+.[0-9]+.[0-9]+*
       - integrations/viem-v2/v[0-9]+.[0-9]+.[0-9]+*
       - integrations/wagmi-v2/v[0-9]+.[0-9]+.[0-9]+*


### PR DESCRIPTION
Followup to https://github.com/oasisprotocol/sapphire-paratime/pull/629