### PR TITLE
Ziga mr/feat/sapphirepy wrapper fix

### DIFF
--- a/clients/py/README.md
+++ b/clients/py/README.md
@@ -42,12 +42,18 @@ w3.middleware_onion.add(SignAndSendRawMiddlewareBuilder.build(account))
 # Note: Account parameter in the wrap() function is used for signing view
 # calls and can be different from the account used for singing transactions.
 w3 = sapphire.wrap(w3, account) # Can provide custom "account" parameter
+w3.eth.default_account = account.address # Alternatively you can set "from" tx param each time for signed view calls
 # Wrapper middleware also works with AsyncWeb3
 async_w3 = sapphire.wrap(async_w3, account)
 
+# Account parameter is optional, to encrypt view calls without signing 
+# we can omit the account parameter
+w3 = sapphire.wrap(w3)
+async_w3 = sapphire.wrap(async_w3)
+
 # Optionally, query Oasis Web3 Gateway for the gas price.
-# from web3.gas_strategies.rpc import rpc_gas_price_strategy
-# w3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
+from web3.gas_strategies.rpc import rpc_gas_price_strategy
+w3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
 ```
 
 The Sapphire middleware for Web3.py ensures all transactions, gas estimates and

--- a/clients/py/sapphirepy/sapphire.py
+++ b/clients/py/sapphirepy/sapphire.py
@@ -301,8 +301,8 @@ class ConstructSapphireMiddlewareBuilder(Web3MiddlewareBuilder):
                     if not pk:
                         raise RuntimeError("Could not retrieve callDataPublicKey!")
                     do_fetch = False
-
-                    if method == "eth_call" and params[0]["from"] and self.sapphire_account:
+                    if method == "eth_call" and self.sapphire_account and "from" in params[0]:
+                        from_address = params[0]["from"]
                         # Get block number - use inline if to handle async vs sync
                         block_number = (
                             await self._w3.eth.block_number
@@ -318,11 +318,11 @@ class ConstructSapphireMiddlewareBuilder(Web3MiddlewareBuilder):
                         # Get transaction count - inline if
                         nonce = (
                             await self._w3.eth.get_transaction_count(
-                                self._w3.to_checksum_address(params[0]["from"])
+                                self._w3.to_checksum_address(from_address)
                             )
                             if isinstance(self._w3, AsyncWeb3)
                             else self._w3.eth.get_transaction_count(
-                                self._w3.to_checksum_address(params[0]["from"])
+                                self._w3.to_checksum_address(from_address)
                             )
                         )
                         # Get block and extract hash - inline if

--- a/clients/py/sapphirepy/tests/test_e2e.py
+++ b/clients/py/sapphirepy/tests/test_e2e.py
@@ -59,6 +59,7 @@ class TestEndToEnd(unittest.TestCase):
             SignAndSendRawMiddlewareBuilder.build(account)  # pylint: disable=no-value-for-parameter
         )
         self.w3_no_signer = Web3(Web3.HTTPProvider("http://localhost:8545"))
+        self.w3_no_signer_wrapped = sapphire.wrap(Web3(Web3.HTTPProvider("http://localhost:8545")))
         self.w3 = sapphire.wrap(w3, account)
 
         self.w3.eth.default_account = account.address
@@ -73,6 +74,9 @@ class TestEndToEnd(unittest.TestCase):
             address=tx_receipt["contractAddress"], abi=iface["abi"]
         )
         self.greeter_no_signer = self.w3_no_signer.eth.contract(
+            address=tx_receipt["contractAddress"], abi=iface["abi"]
+        )
+        self.greeter_no_signer_wrapped = self.w3_no_signer_wrapped.eth.contract(
             address=tx_receipt["contractAddress"], abi=iface["abi"]
         )
 
@@ -114,6 +118,11 @@ class TestEndToEnd(unittest.TestCase):
         y = w3.eth.wait_for_transaction_receipt(x)
         z = greeter.events.Greeting().process_receipt(y)
         self.assertEqual(z[0].args["g"], "Hello")
+
+    def test_transaction_no_signer_wrapped(self):
+        greeter = self.greeter_no_signer_wrapped
+
+        self.assertEqual(greeter.functions.greet().call(), "Hello")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When sending encrypted (but not signed) view calls the "from" parameter is not set. This PR updates the conditional from params[0]["from"] to params[0].get("from", None) and adds tests.
Bug report: #637 