### PR TITLE
runtime: Allow future nonces

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -193,6 +193,10 @@ impl sdk::Runtime for Runtime {
         max_tx_count: 1_000,      // Consistent with runtime descriptor.
     };
 
+    /// Maximum delta that the transaction nonce can be in the future from the current nonce
+    /// to still be accepted during transaction checks.
+    const MAX_CHECK_NONCE_FUTURE_DELTA: u64 = 9;
+
     type Core = modules::core::Module<Config>;
     type Accounts = modules::accounts::Module;
     type FeeProxy = modules::rofl::Module<Config>;


### PR DESCRIPTION
Allowing up to 10 transactions per block from the same sender.