### PR TITLE
Fix `forge doc` in CI for contracts

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -111,7 +111,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Install forge doc deps
-        run: cargo install mdbook-pagetoc
+        run: cargo install mdbook-pagetoc@0.2.2 # TODO: 0.3 fails with "Unable to parse the input" error
 
       - name: Build docs
         run: pnpm doc

--- a/.github/workflows/contracts-test.yaml
+++ b/.github/workflows/contracts-test.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Install forge doc deps
-        run: cargo install mdbook-pagetoc
+        run: cargo install mdbook-pagetoc@0.2.2 # TODO: 0.3 fails with "Unable to parse the input" error
       - name: Build docs
         working-directory: contracts
         run: make clean && pnpm doc


### PR DESCRIPTION
Fixes two issues:
- too new version of solc shipped with `forge`. Run `make clean` to clear incompatible cache from the old solc version.
- workaround for `mdbook-pagetoc@0.3.0` `Unable to parse input` on mdbook 0.5.x error (similar bug: https://github.com/lzanini/mdbook-katex/issues/130)