### PR TITLE
wagmi-v2-example: Use latest v12 MetaMask version

### DIFF
--- a/examples/wagmi-v2/test/e2e.spec.ts
+++ b/examples/wagmi-v2/test/e2e.spec.ts
@@ -1,5 +1,5 @@
 import { BrowserContext, expect, test as baseTest } from "@playwright/test";
-import dappwright, { Dappwright, MetaMaskWallet } from "@tenkeylabs/dappwright";
+import dappwright, { Dappwright } from "@tenkeylabs/dappwright";
 
 baseTest.describe.configure({ mode: "serial" });
 
@@ -11,7 +11,7 @@ export const test = baseTest.extend<{
 		// Launch context with extension
 		const [wallet, _, context] = await dappwright.bootstrap("", {
 			wallet: "metamask",
-			version: MetaMaskWallet.recommendedVersion,
+			version: "12.23.1",
 			seed: "test test test test test test test test test test test junk", // Hardhat's default https://hardhat.org/hardhat-network/docs/reference#accounts
 			headless: false,
 		});


### PR DESCRIPTION
MetaMask version 12.23.0 is no longer available, while the dappwright recommendedVersion pointed to 12.23.0 the CI will be erroring out.

Until the recommended version is updated, that is the version that works for now.

Tracked here: https://github.com/TenKeyLabs/dappwright/issues/506