### PR TITLE
 wagmi-v3: enable playwright commented tests

### DIFF
--- a/examples/wagmi-v3/test/e2e.spec.ts
+++ b/examples/wagmi-v3/test/e2e.spec.ts
@@ -56,7 +56,6 @@ export const test = base.extend<
         network: "23293",
         encrypted: true,
     },
-    /* // TODO: Uncomment when https://github.com/TenKeyLabs/dappwright/issues/550 is fixed upstream
     {
         url: "/#/wagmi-injected",
         rdns: "injected-sapphire",
@@ -75,7 +74,6 @@ export const test = base.extend<
         network: "31337",
         encrypted: false,
     },
-    */
     // RainbowKit route removed - @rainbow-me/rainbowkit is not yet compatible with wagmi 3.x
 ].forEach(({ url, rdns, network, encrypted }) => {
     test.describe(() => {


### PR DESCRIPTION
Since updating to latest `dappwright` did not resolve the issue https://github.com/oasisprotocol/sapphire-paratime/pull/690, since dappwright#550 issue was not addressed in the latest release. Seems like, keeping the current version auto-magically works 🤷 Not sure why, the only explanation would be if the lock file was not respected - which it is. Or either the MetaMask backend changed somehow - or it was pulling the wrong MetaMask extension version.