### PR TITLE
clients/py: Fix package name API docs generation

### DIFF
--- a/clients/py/Makefile
+++ b/clients/py/Makefile
@@ -33,7 +33,7 @@ docs:
 	@echo "source_suffix = {'.rst': 'restructuredtext', '.md': 'markdown'}" >> docs/source/conf.py
 	@sed -i '/Add your content/,/details/c\\n.. automodule:: sapphirepy\n   :members:\n   :undoc-members:\n   :show-inheritance:\n\n.. include:: ../../README.md\n   :parser: markdown' docs/source/index.rst
 	@echo "\n   modules" >> docs/source/index.rst
-	@sphinx-apidoc -o docs/source/ $$(pip show sapphire-py | grep Location | cut -d' ' -f2)/sapphirepy
+	@sphinx-apidoc -o docs/source/ $$(pip show oasis-sapphire-py | grep Location | cut -d' ' -f2)/sapphirepy
 	@$(MAKE) html -C docs
 
 .PHONY: all mypy ruff test clean lint build wheel docs


### PR DESCRIPTION
This PR fixes regression introduced in https://github.com/oasisprotocol/sapphire-paratime/commit/13874a9b27dbb03891caeba970e18da69f370a65

It caused CI to fail, for example: https://github.com/oasisprotocol/sapphire-paratime/actions/runs/23201869064/job/67426196755