### PR TITLE
integrations/hardhat: Reduce poll interval for Localnet to 100ms

### DIFF
--- a/contracts/test/subcall.ts
+++ b/contracts/test/subcall.ts
@@ -20,25 +20,39 @@ import { getRandomValues, randomInt } from 'crypto';
 
 import { execSync } from 'child_process';
 
+function getDockerCmd(): string {
+  try {
+    execSync('which docker', { stdio: 'pipe' });
+    return 'docker';
+  } catch {}
+  try {
+    execSync('which podman', { stdio: 'pipe' });
+    return 'podman';
+  } catch {}
+  throw new Error('Please install docker or podman to run this test');
+}
+
 async function getDockerName() {
-  const cmd =
-    "docker ps --format '{{.Names}}' --filter status=running --filter expose=8545";
+  const dockerCmd = getDockerCmd();
+  const cmd = `${dockerCmd} ps --format '{{.Names}}' --filter status=running --filter ${
+    dockerCmd == 'docker' ? 'expose=8545' : 'ancestor=sapphire-localnet'
+  }`;
   const name = new TextDecoder().decode(execSync(cmd));
   return name.replace(/\n|\r/g, '');
 }
 
 async function getDockerEpoch(dockerName: string) {
-  const cmd = `docker exec ${dockerName} /oasis-node control status -a unix:/serverdir/node/net-runner/network/client-0/internal.sock  | jq '.consensus.latest_epoch'`;
+  const cmd = `${getDockerCmd()} exec ${dockerName} /oasis-node control status -a unix:/serverdir/node/net-runner/network/client-0/internal.sock  | jq '.consensus.latest_epoch'`;
   return Number.parseInt(new TextDecoder().decode(execSync(cmd)));
 }
 
 async function getDockerDebondingInterval(dockerName: string) {
-  const cmd = `docker exec ${dockerName} cat /serverdir/node/fixture.json | jq .network.staking_genesis.params.debonding_interval`;
+  const cmd = `${getDockerCmd()} exec ${dockerName} cat /serverdir/node/fixture.json | jq .network.staking_genesis.params.debonding_interval`;
   return Number.parseInt(new TextDecoder().decode(execSync(cmd)));
 }
 
 async function setDockerEpoch(dockerName: string, epoch: number) {
-  const cmd = `docker exec ${dockerName} /oasis-node debug control set-epoch --epoch ${epoch} -a unix:/serverdir/node/net-runner/network/client-0/internal.sock`;
+  const cmd = `${getDockerCmd()} exec ${dockerName} /oasis-node debug control set-epoch --epoch ${epoch} -a unix:/serverdir/node/net-runner/network/client-0/internal.sock`;
   execSync(cmd);
 }
 

--- a/integrations/hardhat/src/index.ts
+++ b/integrations/hardhat/src/index.ts
@@ -7,6 +7,8 @@ import {
 import { extendEnvironment } from 'hardhat/config';
 import { HttpNetworkUserConfig } from 'hardhat/types';
 
+const LOCALNET_POLL_INTERVAL = 100; // in milliseconds
+
 export const sapphireLocalnet = {
   url: NETWORKS.localnet.defaultGateway,
   chainId: NETWORKS.localnet.chainId,
@@ -38,5 +40,22 @@ extendEnvironment((hre) => {
       'You can prevent this from happening by setting a non-Sapphire `chainId`.',
     );
   }
+  // A hack to reduce polling interval on Sapphire Localnet.
+  // Must be applied before wrapEthereumProvider so Sapphire captures the patched upstream.
+  if (chainId == NETWORKS.localnet.chainId) {
+    const origRequest = hre.network.provider.request.bind(hre.network.provider);
+    hre.network.provider.request = async ({ method, params }) => {
+      if (method !== 'eth_getTransactionByHash') {
+        return origRequest({ method, params });
+      }
+      for (let i = 0; i < 30; i++) {
+        const result = await origRequest({ method, params });
+        if (result !== null) return result;
+        await new Promise((r) => setTimeout(r, LOCALNET_POLL_INTERVAL));
+      }
+      return origRequest({ method, params });
+    };
+  }
+
   hre.network.provider = wrapEthereumProvider(hre.network.provider);
 });


### PR DESCRIPTION
Fixes #687 

Sapphire Localnet block time is 1 second. Hardhat polling interval for HTTP JSON RPCs is hardcoded to 4 seconds. This fix reduces expected time of Sapphire Localnet tests by a factor of 4. Affects Sapphire Localnet only.