### PR TITLE
integrations: Publish sapphire-hardhat 2.22.3

### DIFF
--- a/integrations/hardhat/CHANGELOG.md
+++ b/integrations/hardhat/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is inspired by [Keep a Changelog].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 
+## 2.22.3 (2026-04)
+
+### Fixed
+
+- Reduce poll interval to 100 ms when running on Sapphire Localnet. This speeds up tests roughly 4-fold.
+
 ## 2.22.2 (2025-02)
 
 Publish stable V2 integration.

--- a/integrations/hardhat/package.json
+++ b/integrations/hardhat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oasisprotocol/sapphire-hardhat",
   "license": "Apache-2.0",
-  "version": "2.22.2",
+  "version": "2.22.3",
   "description": "A Hardhat plugin for developing on the Sapphire ParaTime.",
   "homepage": "https://github.com/oasisprotocol/sapphire-paratime/tree/main/integrations/hardhat",
   "repository": {


### PR DESCRIPTION
New `@oasisprotocol/sapphire-hardhat` 2.22.3 release.