### PR TITLE
deps: protobufjs upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "overrides": {
       "elliptic": "^6.6.1",
       "sha.js": "^2.4.12",
-      "axios": "^1.15.0"
+      "axios": "^1.15.0",
+      "protobufjs": "^7.5.5"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   elliptic: ^6.6.1
   sha.js: ^2.4.12
   axios: ^1.15.0
+  protobufjs: ^7.5.5
 
 importers:
 
@@ -9060,12 +9061,8 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  protobufjs@7.1.2:
-    resolution: {integrity: sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==}
-    engines: {node: '>=12.0.0'}
-
-  protobufjs@7.4.0:
-    resolution: {integrity: sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -14398,7 +14395,7 @@ snapshots:
       cborg: 1.10.2
       grpc-web: 1.5.0
       js-sha512: 0.8.0
-      protobufjs: 7.1.2
+      protobufjs: 7.5.5
       tweetnacl: 1.0.3
 
   '@oasisprotocol/client@1.3.0':
@@ -14408,7 +14405,7 @@ snapshots:
       bip39: 3.1.0
       cborg: 2.0.5
       grpc-web: 1.5.0
-      protobufjs: 7.4.0
+      protobufjs: 7.5.5
       tweetnacl: 1.0.3
 
   '@oasisprotocol/deoxysii@0.0.6': {}
@@ -23535,22 +23532,7 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  protobufjs@7.1.2:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/node': 18.19.86
-      long: 5.3.2
-
-  protobufjs@7.4.0:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
Should resolve the following 2 security concerns:
https://github.com/oasisprotocol/sapphire-paratime/security/dependabot?q=is%3Aopen+package%3Aprotobufjs