### PR TITLE
clients/py: Prepare for v0.4.2

### DIFF
--- a/clients/py/CHANGELOG.md
+++ b/clients/py/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.2 (2026-05-07)
+
+### Fixed
+
+- Fixed compatibility with cbor2 version 6.x
+
 ## 0.4.1 (2025-10-28)
 
 ### Fixed

--- a/clients/py/setup.py
+++ b/clients/py/setup.py
@@ -28,6 +28,6 @@ setup(
     packages=find_packages(include=["sapphirepy"]),
     install_requires=REQUIREMENTS,
     url="https://github.com/oasisprotocol/sapphire-paratime",
-    version="0.4.1",
+    version="0.4.2",
     zip_safe=True,
 )


### PR DESCRIPTION
Prepare for the release of oasis-sapphire-py v0.4.2.