### PR TITLE
Add Envio to Sapphire indexers

### DIFF
--- a/docs/network.mdx
+++ b/docs/network.mdx
@@ -87,6 +87,7 @@ dedicated RPC endpoints, consider the following providers (in alphabetic order):
 
 | Name (Provider)              | Mainnet URL                                            | Testnet URL                                            | Documentation                                                                                             |
 |------------------------------|--------------------------------------------------------|--------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| [Envio HyperIndex][Envio]    | *N/A*                                                  | *N/A*                                                  | [Documentation site][Envio-docs]                                                                          |
 | [Covalent]                   | `https://api.covalenthq.com/v1/oasis-sapphire-mainnet` | `https://api.covalenthq.com/v1/oasis-sapphire-testnet` | [Unified API docs][Covalent-docs]                                                                         |
 | [Goldsky Subgraph][Goldsky]  | *N/A*                                                  | *N/A*                                                  | [Documentation site][Goldsky-docs]                                                                        |
 | Oasis Nexus ([Oasis])        | `https://nexus.oasis.io/v1/`                           | `https://testnet.nexus.oasis.io/v1/`                   | [API][Nexus-docs]                                                                                         |
@@ -95,6 +96,8 @@ dedicated RPC endpoints, consider the following providers (in alphabetic order):
 
 [Covalent]: https://www.covalenthq.com/
 [Covalent-docs]: https://www.covalenthq.com/docs/unified-api/
+[Envio]: https://envio.dev/?utm_source=sapphire&utm_medium=partner-docs
+[Envio-docs]: https://docs.envio.dev/docs/HyperIndex/overview?utm_source=sapphire&utm_medium=partner-docs
 [Nexus-docs]: https://nexus.oasis.io/v1/spec/v1.html
 [Goldsky]: https://goldsky.com
 [Goldsky-docs]: https://docs.goldsky.com/subgraphs/deploying-subgraphs

--- a/docs/network.mdx
+++ b/docs/network.mdx
@@ -87,7 +87,7 @@ dedicated RPC endpoints, consider the following providers (in alphabetic order):
 
 | Name (Provider)              | Mainnet URL                                            | Testnet URL                                            | Documentation                                                                                             |
 |------------------------------|--------------------------------------------------------|--------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
-| [Envio HyperIndex][Envio]    | *N/A*                                                  | *N/A*                                                  | [Documentation site][Envio-docs]                                                                          |
+| [Envio HyperIndex][Envio]    | *N/A*                                                  | *N/A*                                                  | [Documentation site][Envio-docs], [Benchmarks][Envio-benchmarks]                                          |
 | [Covalent]                   | `https://api.covalenthq.com/v1/oasis-sapphire-mainnet` | `https://api.covalenthq.com/v1/oasis-sapphire-testnet` | [Unified API docs][Covalent-docs]                                                                         |
 | [Goldsky Subgraph][Goldsky]  | *N/A*                                                  | *N/A*                                                  | [Documentation site][Goldsky-docs]                                                                        |
 | Oasis Nexus ([Oasis])        | `https://nexus.oasis.io/v1/`                           | `https://testnet.nexus.oasis.io/v1/`                   | [API][Nexus-docs]                                                                                         |
@@ -98,6 +98,7 @@ dedicated RPC endpoints, consider the following providers (in alphabetic order):
 [Covalent-docs]: https://www.covalenthq.com/docs/unified-api/
 [Envio]: https://envio.dev/?utm_source=sapphire&utm_medium=partner-docs
 [Envio-docs]: https://docs.envio.dev/docs/HyperIndex/overview?utm_source=sapphire&utm_medium=partner-docs
+[Envio-benchmarks]: https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=sapphire&utm_medium=partner-docs
 [Nexus-docs]: https://nexus.oasis.io/v1/spec/v1.html
 [Goldsky]: https://goldsky.com
 [Goldsky-docs]: https://docs.goldsky.com/subgraphs/deploying-subgraphs


### PR DESCRIPTION
This adds Envio to the Indexers table on the Sapphire network information page.

Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API. Its HyperIndex supports indexing any EVM chain out of the box, so developers can index Oasis Sapphire (chain ID 23294) using their own RPC as the data source. Indexers can be self-hosted or run on the managed Envio Cloud service.

Website: https://envio.dev/
Docs: https://docs.envio.dev/