### PR TITLE
sapphire-contracts: Add ROFLable and ROFLableUpgradeable

### DIFF
--- a/contracts/contracts/ROFLable.sol
+++ b/contracts/contracts/ROFLable.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {Subcall} from "./Subcall.sol";
+
+/**
+ * @title Base contract for ROFL-authenticated access control
+ * @notice Provides the `onlyROFL` modifier, restricting calls to
+ * transactions signed by an authorized instance of a specific ROFL app.
+ *
+ * See [`ROFLableUpgradeable`](../ROFLableUpgradeable.sol/abstract.ROFLableUpgradeable.md)
+ * for an upgradeable counterpart of this contract.
+ *
+ * #### Example
+ *
+ * ```solidity
+ * contract MyContract is ROFLable {
+ *   constructor(bytes21 inRoflAppId) ROFLable(inRoflAppId) {}
+ *
+ *   function setPrice(uint128 price) external onlyROFL {
+ *     ...
+ *   }
+ * }
+ * ```
+ */
+abstract contract ROFLable {
+    bytes21 private _roflAppId;
+
+    event RoflAppIdUpdated(
+        bytes21 indexed previousRoflAppId,
+        bytes21 indexed newRoflAppId
+    );
+
+    /**
+     * @notice Initializes the contract, authorizing the given ROFL app.
+     * @param initialRoflAppId ROFL app ID.
+     */
+    constructor(bytes21 initialRoflAppId) {
+        _setRoflAppId(initialRoflAppId);
+    }
+
+    /**
+     * @notice Reverts unless the transaction is signed by an authorized
+     * instance of the configured ROFL app.
+     */
+    modifier onlyROFL() {
+        _checkRoflAppId();
+        _;
+    }
+
+    /**
+     * @notice Returns the currently authorized ROFL app ID.
+     */
+    function roflAppId() public view virtual returns (bytes21) {
+        return _roflAppId;
+    }
+
+    /**
+     * @notice Updates the authorized ROFL app ID. Callable only by the
+     * currently authorized ROFL app.
+     */
+    function setRoflAppId(bytes21 newRoflAppId) public virtual onlyROFL {
+        _setRoflAppId(newRoflAppId);
+    }
+
+    /**
+     * @notice Reverts unless the transaction is signed by an authorized
+     * instance of the configured ROFL app.
+     */
+    function _checkRoflAppId() internal view virtual {
+        Subcall.roflEnsureAuthorizedOrigin(_roflAppId);
+    }
+
+    /**
+     * @notice Updates the authorized ROFL app ID. Internal, without access
+     * restriction - gate calls to this with your own access control (e.g.
+     * `onlyOwner`) when exposing it externally.
+     */
+    function _setRoflAppId(bytes21 newRoflAppId) internal virtual {
+        bytes21 previousRoflAppId = _roflAppId;
+        _roflAppId = newRoflAppId;
+        emit RoflAppIdUpdated(previousRoflAppId, newRoflAppId);
+    }
+}

--- a/contracts/contracts/ROFLableUpgradeable.sol
+++ b/contracts/contracts/ROFLableUpgradeable.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import {Subcall} from "./Subcall.sol";
+
+/**
+ * @title Upgradeable base contract for ROFL-authenticated access control
+ * @notice Upgradeable counterpart of [`ROFLable`](../ROFLable.sol/abstract.ROFLable.md).
+ * Provides the `onlyROFL` modifier, restricting calls to transactions signed by
+ * an authorized instance of a specific ROFL app.
+ *
+ * #### Example
+ *
+ * ```solidity
+ * contract MyContract is ROFLableUpgradeable {
+ *   function initialize(bytes21 inRoflAppId) public initializer {
+ *     __ROFLable_init(inRoflAppId);
+ *   }
+ *
+ *   function setPrice(uint128 price) external onlyROFL {
+ *     ...
+ *   }
+ * }
+ * ```
+ */
+abstract contract ROFLableUpgradeable is Initializable {
+    /// @custom:storage-location erc7201:oasisprotocol.storage.ROFLable
+    struct ROFLableStorage {
+        bytes21 _roflAppId;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("oasisprotocol.storage.ROFLable")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant ROFLableStorageLocation =
+        0x8940e4963ccaa2197d6e961909d33623c50bf1e108e975034323ec0eeeb65700;
+
+    function _getROFLableStorage()
+        private
+        pure
+        returns (ROFLableStorage storage $)
+    {
+        assembly {
+            $.slot := ROFLableStorageLocation
+        }
+    }
+
+    event RoflAppIdUpdated(
+        bytes21 indexed previousRoflAppId,
+        bytes21 indexed newRoflAppId
+    );
+
+    /**
+     * @notice Initializes the contract, authorizing the given ROFL app.
+     * @param initialRoflAppId ROFL app ID.
+     */
+    function __ROFLable_init(bytes21 initialRoflAppId)
+        internal
+        onlyInitializing
+    {
+        __ROFLable_init_unchained(initialRoflAppId);
+    }
+
+    function __ROFLable_init_unchained(bytes21 initialRoflAppId)
+        internal
+        onlyInitializing
+    {
+        _setRoflAppId(initialRoflAppId);
+    }
+
+    /**
+     * @notice Reverts unless the transaction is signed by an authorized
+     * instance of the configured ROFL app.
+     */
+    modifier onlyROFL() {
+        _checkRoflAppId();
+        _;
+    }
+
+    /**
+     * @notice Returns the currently authorized ROFL app ID.
+     */
+    function roflAppId() public view virtual returns (bytes21) {
+        ROFLableStorage storage $ = _getROFLableStorage();
+        return $._roflAppId;
+    }
+
+    /**
+     * @notice Updates the authorized ROFL app ID. Callable only by the
+     * currently authorized ROFL app.
+     */
+    function setRoflAppId(bytes21 newRoflAppId) public virtual onlyROFL {
+        _setRoflAppId(newRoflAppId);
+    }
+
+    /**
+     * @notice Reverts unless the transaction is signed by an authorized
+     * instance of the configured ROFL app.
+     */
+    function _checkRoflAppId() internal view virtual {
+        Subcall.roflEnsureAuthorizedOrigin(roflAppId());
+    }
+
+    /**
+     * @notice Updates the authorized ROFL app ID. Internal, without access
+     * restriction - gate calls to this with your own access control (e.g.
+     * `onlyOwner`) when exposing it externally.
+     */
+    function _setRoflAppId(bytes21 newRoflAppId) internal virtual {
+        ROFLableStorage storage $ = _getROFLableStorage();
+        bytes21 previousRoflAppId = $._roflAppId;
+        $._roflAppId = newRoflAppId;
+        emit RoflAppIdUpdated(previousRoflAppId, newRoflAppId);
+    }
+}

--- a/contracts/contracts/tests/ROFLableTests.sol
+++ b/contracts/contracts/tests/ROFLableTests.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {ROFLable} from "../ROFLable.sol";
+
+contract ROFLableTests is ROFLable {
+    uint256 private _counter;
+
+    constructor(bytes21 inRoflAppId) ROFLable(inRoflAppId) {}
+
+    function testOnlyROFL() external onlyROFL returns (uint256) {
+        _counter++;
+        return _counter;
+    }
+
+    // For testing, pass all onlyROFL calls if configured ROFL app id is zero.
+    function _checkRoflAppId() internal view override {
+        if (roflAppId() != bytes21(0)) {
+            super._checkRoflAppId();
+        }
+    }
+}

--- a/contracts/contracts/tests/ROFLableUpgradeableTests.sol
+++ b/contracts/contracts/tests/ROFLableUpgradeableTests.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {ROFLableUpgradeable} from "../ROFLableUpgradeable.sol";
+
+contract ROFLableUpgradeableTests is ROFLableUpgradeable {
+    uint256 private _counter;
+
+    function initialize(bytes21 inRoflAppId) external initializer {
+        __ROFLable_init(inRoflAppId);
+    }
+
+    function testOnlyROFL() external onlyROFL returns (uint256) {
+        _counter++;
+        return _counter;
+    }
+
+    // For testing, pass all onlyROFL calls if configured ROFL app id is zero.
+    function _checkRoflAppId() internal view override {
+        if (roflAppId() != bytes21(0)) {
+            super._checkRoflAppId();
+        }
+    }
+}

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -45,7 +45,7 @@ task('send-wrose', 'Transfer some wROSE')
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: '0.8.20',
+    version: '0.8.24',
     settings: {
       evmVersion: 'paris',
       optimizer: {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -57,6 +57,7 @@
     "@noble/hashes": "1.3.2"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^5.0.2"
+    "@openzeppelin/contracts": "5.3.0",
+    "@openzeppelin/contracts-upgradeable": "5.3.0"
   }
 }

--- a/contracts/test/roflable.ts
+++ b/contracts/test/roflable.ts
@@ -1,0 +1,83 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { zeroPadValue } from 'ethers';
+import { ROFLableTests } from '../typechain-types/contracts/tests/ROFLableTests';
+import { ROFLableUpgradeableTests } from '../typechain-types/contracts/tests/ROFLableUpgradeableTests';
+
+const ZERO_APP_ID = zeroPadValue('0x', 21);
+const SOME_APP_ID = zeroPadValue(
+  '0x1234567890123456789012345678901234567890',
+  21,
+);
+
+describe('ROFLable', function () {
+  async function deploy(appId: string) {
+    const factory = await ethers.getContractFactory('ROFLableTests');
+    const contract = await factory.deploy(appId);
+    await contract.waitForDeployment();
+    return contract as unknown as ROFLableTests;
+  }
+
+  it('Should report the configured app ID', async () => {
+    const contract = await deploy(SOME_APP_ID);
+    expect(await contract.roflAppId()).eq(SOME_APP_ID);
+  });
+
+  it('onlyROFL should pass when the app ID is 0x0', async () => {
+    const contract = await deploy(ZERO_APP_ID);
+    await expect(contract.testOnlyROFL()).to.not.be.reverted;
+  });
+
+  it('onlyROFL should revert when a non-zero app ID is set (no ROFL instance in tests)', async () => {
+    const contract = await deploy(SOME_APP_ID);
+    await expect(contract.testOnlyROFL()).to.be.reverted;
+  });
+
+  it('Setting a new app ID should update roflAppId() and emit an event', async () => {
+    const contract = await deploy(ZERO_APP_ID);
+    await expect(contract.setRoflAppId(SOME_APP_ID))
+      .to.emit(contract, 'RoflAppIdUpdated')
+      .withArgs(ZERO_APP_ID, SOME_APP_ID);
+    expect(await contract.roflAppId()).eq(SOME_APP_ID);
+  });
+
+  it('setRoflAppId should revert once a non-zero app ID is set (no ROFL instance in tests)', async () => {
+    const contract = await deploy(SOME_APP_ID);
+    await expect(contract.setRoflAppId(ZERO_APP_ID)).to.be.reverted;
+  });
+});
+
+describe('ROFLableUpgradeable', function () {
+  async function deploy(appId: string) {
+    const factory = await ethers.getContractFactory('ROFLableUpgradeableTests');
+    const contract = await factory.deploy();
+    await contract.waitForDeployment();
+    await contract.initialize(appId);
+    return contract as unknown as ROFLableUpgradeableTests;
+  }
+
+  it('Should report the configured app ID', async () => {
+    const contract = await deploy(SOME_APP_ID);
+    expect(await contract.roflAppId()).eq(SOME_APP_ID);
+  });
+
+  it('onlyROFL should pass when the app ID is 0x0', async () => {
+    const contract = await deploy(ZERO_APP_ID);
+    await expect(contract.testOnlyROFL()).to.not.be.reverted;
+  });
+
+  it('onlyROFL should revert when a non-zero app ID is set (no ROFL instance in tests)', async () => {
+    const contract = await deploy(SOME_APP_ID);
+    await expect(contract.testOnlyROFL()).to.be.reverted;
+  });
+
+  it('Cannot be initialized twice', async () => {
+    const contract = await deploy(ZERO_APP_ID);
+    await expect(contract.initialize(SOME_APP_ID)).to.be.reverted;
+  });
+
+  it('setRoflAppId should revert once a non-zero app ID is set (no ROFL instance in tests)', async () => {
+    const contract = await deploy(SOME_APP_ID);
+    await expect(contract.setRoflAppId(ZERO_APP_ID)).to.be.reverted;
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,11 @@ importers:
   contracts:
     dependencies:
       '@openzeppelin/contracts':
-        specifier: ^5.0.2
+        specifier: 5.3.0
         version: 5.3.0
+      '@openzeppelin/contracts-upgradeable':
+        specifier: 5.3.0
+        version: 5.3.0(@openzeppelin/contracts@5.3.0)
     devDependencies:
       '@noble/hashes':
         specifier: 1.3.2
@@ -2415,6 +2418,7 @@ packages:
 
   '@metamask/sdk-communication-layer@0.32.0':
     resolution: {integrity: sha512-dmj/KFjMi1fsdZGIOtbhxdg3amxhKL/A5BqSU4uh/SyDKPub/OT+x5pX8bGjpTL1WPWY/Q0OIlvFyX3VWnT06Q==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       cross-fetch: ^4.0.0
       eciesjs: '*'
@@ -2424,9 +2428,11 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.32.0':
     resolution: {integrity: sha512-TFoktj0JgfWnQaL3yFkApqNwcaqJ+dw4xcnrJueMP3aXkSNev2Ido+WVNOg4IIMxnmOrfAC9t0UJ0u/dC9MjOQ==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk@0.32.0':
     resolution: {integrity: sha512-WmGAlP1oBuD9hk4CsdlG1WJFuPtYJY+dnTHJMeCyohTWD2GgkcLMUUuvu9lO1/NVzuOoSi1OrnjbuY1O/1NZ1g==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/superstruct@3.2.1':
     resolution: {integrity: sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g==}
@@ -2870,12 +2876,17 @@ packages:
   '@oasisprotocol/sapphire-paratime@2.3.0':
     resolution: {integrity: sha512-TooQ+eGxz8kQJ4PavqkXxvjbRJw8V4TB/Nu5ptaMyclFFr+tCWXEpx01gpoRsUEEc9IRcEm4IfnBUqFnBcbt7w==}
 
+  '@openzeppelin/contracts-upgradeable@5.3.0':
+    resolution: {integrity: sha512-yVzSSyTMWO6rapGI5tuqkcLpcGGXA0UA1vScyV5EhE5yw8By3Ewex9rDUw8lfVw0iTkvR/egjfcW5vpk03lqZg==}
+    peerDependencies:
+      '@openzeppelin/contracts': 5.3.0
+
   '@openzeppelin/contracts@5.3.0':
     resolution: {integrity: sha512-zj/KGoW7zxWUE8qOI++rUM18v+VeLTTzKs/DJFkSzHpQFPD/jKKF0TrMxBfGLl3kpdELCNccvB3zmofSzm4nlA==}
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'The package is now available as "qr": npm install qr'
+    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
 
   '@phosphor-icons/webcomponents@2.1.5':
     resolution: {integrity: sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==}
@@ -3136,6 +3147,7 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
@@ -3781,6 +3793,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vanilla-extract/css@1.17.3':
     resolution: {integrity: sha512-jHivr1UPoJTX5Uel4AZSOwrCf4mO42LcdmnhJtUxZaRWhW4FviFbIfs0moAWWld7GOT+2XnuVZjjA/K32uUnMQ==}
@@ -6537,29 +6550,31 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.2:
     resolution: {integrity: sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@5.0.15:
     resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-modules@2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
@@ -11232,6 +11247,7 @@ packages:
 
   whatwg-encoding@1.0.5:
     resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
@@ -13666,7 +13682,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@types/debug': 4.1.12
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.3
       semver: 7.7.2
       superstruct: 1.0.4
     transitivePeerDependencies:
@@ -14435,6 +14451,10 @@ snapshots:
       '@noble/hashes': 1.3.2
       '@oasisprotocol/deoxysii': 0.0.6
       cborg: 1.10.2
+
+  '@openzeppelin/contracts-upgradeable@5.3.0(@openzeppelin/contracts@5.3.0)':
+    dependencies:
+      '@openzeppelin/contracts': 5.3.0
 
   '@openzeppelin/contracts@5.3.0': {}
 


### PR DESCRIPTION
Implements #723 

- `ROFLable` and `ROFLableUpgradeable` similar to OpenZeppelin's `Ownable` and `OwnableUpgradeable`
- `setRoflAppId` is enabled by default and gated by `onlyROFL` (in other words `roflAppId` is mutable).
- If stored `roflAppId` is zero, then `onlyROFL` gate is ignored. Useful for the tests on non-Sapphire chains.