### PR TITLE
examples/hardhat/test: Wait for block time to pass 30s

### DIFF
--- a/examples/hardhat/tasks/index.ts
+++ b/examples/hardhat/tasks/index.ts
@@ -38,7 +38,14 @@ task("check-secret")
     }
     console.log("Waiting...");
 
-    await new Promise((resolve) => setTimeout(resolve, 30_000));
+    // Wait until a block timestamp passes 30 seconds.
+    const startBlock = await hre.ethers.provider.getBlock("latest");
+    let currentBlock = startBlock;
+    while (currentBlock!.timestamp <= startBlock!.timestamp + 30) {
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+      currentBlock = await hre.ethers.provider.getBlock("latest");
+    }
+
     console.log("Checking the secret again");
     const secret = await vigil.revealSecret.staticCallResult(0); // Get the value.
     console.log(


### PR DESCRIPTION
Fixes flaky test when the localnet chain is too slow and in 30 wall clock seconds the required block time hasn't passed yet. Instead, wait for blocks until the one with timestamp greater than 30 seconds is mined.